### PR TITLE
Fix: Set default max_tokens value to 4096 for Claude 3.5 Sonnet

### DIFF
--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -272,6 +272,12 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
             if (!options.max_tokens) {
                 if (options.model.includes("claude-3-5") || options.model.includes("claude-4")) {
                     options.max_tokens = 8192;
+
+                    //Bug with AWS Converse Sonnet 3.5, does not effect Haiku.
+                    //See https://github.com/boto/boto3/issues/4279
+                    if (options.model.includes("claude-3-5-sonnet")) {
+                        options.max_tokens = 4096;
+                    }
                 } else {
                     options.max_tokens = 4096;
                 }


### PR DESCRIPTION
* https://github.com/vertesia/llumiverse/issues/61

A bug with AWS Converse, is causing the max_tokens to be lowered from 8192, to 4096. See attached issue.

Changing the default value to accommodate.