### PR TITLE
Imagen model check is too restrictive

### DIFF
--- a/drivers/src/vertexai/models/imagen.ts
+++ b/drivers/src/vertexai/models/imagen.ts
@@ -71,8 +71,8 @@ export class ImagenModelDefinition  {
             throw new Error(`Image generation requires image output_modality`);
         }
 
-        if (!options.model.includes('imagen-3.0-generate-001')) {
-            throw new Error(`Model ${options.model} not supported, use imagen-3.0-generate-001`);
+        if (!options.model.includes('imagen-3.0') || !options.model.includes('generate')) {
+            throw new Error(`Model ${options.model} not supported, use imagen-3.0 generate models`);
         }
 
         const taskType = () => {


### PR DESCRIPTION
Imagen-3.0-generate-002 has released but we explicitly check for imagen-3.0-generate-001

The current Imagen support is not complete (will be done soon as a priority), and so filtered on the model generate model, to avoid the capability model. With the release of the 002 version, this check is too strict.
To compound, the 001 does not show in Model Listing in environments as the show all versions functionality is not yet supported by the google client library used, and only shows the latest model.