### PR TITLE
Update llama-3.1-70b-versatile to llama-3.3-70b-versatile in groq test

### DIFF
--- a/drivers/test/all-models.test.ts
+++ b/drivers/test/all-models.test.ts
@@ -135,7 +135,7 @@ if (process.env.GROQ_API_KEY) {
         models: [
             "llama3-70b-8192",
             "mixtral-8x7b-32768",
-            "llama-3.1-70b-versatile"
+            "llama-3.3-70b-versatile"
         ]
     })
 } else {


### PR DESCRIPTION
llama-3.1-70b-versatile has been deprecated by groq.

Updating to  llama-3.3-70b-versatile in all-models.test.ts to pass the CI.

No functional change