### PR TITLE
Fix Imagen Prompt formatting

### DIFF
--- a/drivers/src/vertexai/index.ts
+++ b/drivers/src/vertexai/index.ts
@@ -78,6 +78,9 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
     }
 
     public createPrompt(segments: PromptSegment[], options: PromptOptions): Promise<VertexAIPrompt> {
+        if (options.model.includes("imagen")) {
+            return new ImagenModelDefinition(options.model).createPrompt(this, segments, options);
+        }
         return getModelDefinition(options.model).createPrompt(this, segments, options);
     }
 

--- a/drivers/src/vertexai/models/imagen.ts
+++ b/drivers/src/vertexai/models/imagen.ts
@@ -1,4 +1,4 @@
-import { AIModel, Completion, ImageGeneration, ImageGenExecutionOptions, Modalities, ModelType } from "@llumiverse/core";
+import { AIModel, Completion, ImageGeneration, ImageGenExecutionOptions, Modalities, ModelType, PromptOptions, PromptRole, PromptSegment, readStreamAsBase64 } from "@llumiverse/core";
 import { VertexAIDriver } from "../index.js";
 
 const projectId = process.env.GOOGLE_PROJECT_ID;
@@ -11,7 +11,7 @@ const { PredictionServiceClient } = aiplatform.v1;
 
 // Import the helper module for converting arbitrary protobuf.Value objects
 import { helpers } from '@google-cloud/aiplatform';
-import { GenerateContentRequest } from "@google-cloud/vertexai";
+import { Content, GenerateContentRequest, InlineDataPart, TextPart } from "@google-cloud/vertexai";
 
 interface IPredictRequest {
     endpoint: string;
@@ -33,8 +33,8 @@ export enum ImagenImageGenerationTaskType {
 }
 
 async function textToImagePayload(prompt: GenerateContentRequest): Promise<string> {
-    //At runtime, prompt is sometimes not an array.
-    const textMessages = prompt.contents.map((content) => {content.parts.map((part) => part.text)});
+    // Extract text from prompt
+    const textMessages: string[] = prompt.contents.map(content => content.parts.map(part => part.text).join(''));
     
     const text = textMessages.join("\n\n");
 
@@ -64,9 +64,81 @@ export class ImagenModelDefinition  {
             can_stream: false,
         } as AIModel;
     }
+
+    async createPrompt(_driver: VertexAIDriver, segments: PromptSegment[], options: PromptOptions): Promise<GenerateContentRequest> {
+        const splits = options.model.split("/");
+        const modelName = splits[splits.length - 1];
+        options = { ...options, model: modelName };
+        
+        const schema = options.result_schema;
+        const contents: Content[] = [];
+        const safety: string[] = [];
+
+        let lastUserContent: Content | undefined = undefined;
+
+        for (const msg of segments) {
+
+            if (msg.role === PromptRole.safety) {
+                safety.push(msg.content);
+            } else {
+                let fileParts: InlineDataPart[] | undefined;
+                if (msg.files) {
+                    fileParts = [];
+                    for (const f of msg.files) {
+                        const stream = await f.getStream();
+                        const data = await readStreamAsBase64(stream);
+                        fileParts.push({
+                            inlineData: {
+                                data,
+                                mimeType: f.mime_type!
+                            }
+                        });
+                    }
+                }
+
+                const role = msg.role === PromptRole.assistant ? "model" : "user";
+
+                if (lastUserContent && lastUserContent.role === role) {
+                    lastUserContent.parts.push({ text: msg.content } as TextPart);
+                    fileParts?.forEach(p => lastUserContent?.parts.push(p));
+                } else {
+                    const content: Content = {
+                        role,
+                        parts: [{ text: msg.content } as TextPart],
+                    }
+                    fileParts?.forEach(p => content.parts.push(p));
+
+                    if (role === 'user') {
+                        lastUserContent = content;
+                    }
+                    contents.push(content);
+                }
+            }
+        }
+
+        let tools: any = undefined;
+        if (schema) {
+            safety.push("The answer must be a JSON object using the following JSON Schema:\n" + JSON.stringify(schema));
+        }
+
+        if (safety.length > 0) {
+            const content = safety.join('\n');
+            if (lastUserContent) {
+                lastUserContent.parts.push({ text: content } as TextPart);
+            } else {
+                contents.push({
+                    role: 'user',
+                    parts: [{ text: content } as TextPart],
+                })
+            }
+        }
+
+        // put system mesages first and safety last
+        return { contents, tools } as GenerateContentRequest;
+    }
     
     async requestImageGeneration(driver: VertexAIDriver, prompt: GenerateContentRequest, options: ImageGenExecutionOptions): Promise<Completion<ImageGeneration>> {
-    
+        
         if (options.output_modality !== Modalities.image) {
             throw new Error(`Image generation requires image output_modality`);
         }
@@ -89,16 +161,12 @@ export class ImagenModelDefinition  {
             throw new Error("Bad prompt format");
         }
 
-        console.log('Prompt:', JSON.stringify(prompt));
-
         // Configure the parent resource
         const endpoint = `projects/${projectId}/locations/${location}/publishers/google/models/imagen-3.0-generate-001`;
 
         const promptText = {
             prompt: await formatImagenImageGenerationPayload(taskType(), prompt, options)
         };
-
-        console.log('Prompt Text:', JSON.stringify(promptText));
 
         const instanceValue = helpers.toValue(promptText);
         const instances = [instanceValue];
@@ -127,8 +195,6 @@ export class ImagenModelDefinition  {
         if (!predictions) {
             throw new Error('No predictions found');
         }
-
-        console.log('Response:', JSON.stringify(response));
 
         // Extract base64 encoded images from predictions
         const images : string[] = predictions.map(prediction =>


### PR DESCRIPTION
* https://github.com/vertesia/llumiverse/issues/58

The text from prompts was being extracted incorrectly for Imagen.
Also separated prompt formatting entirely from Gemini. There is no change in behaviour as Gemini prompt formatting has been copy pasted but this ensures easier changes and more reliable behaviour in future.

Before:
<img width="444" alt="Screenshot 2025-02-03 at 12 54 20" src="https://github.com/user-attachments/assets/dada8bbc-7530-4053-8373-e558a75a7016" />

After
<img width="528" alt="Screenshot 2025-02-03 at 12 54 31" src="https://github.com/user-attachments/assets/f7c77b04-80f1-430a-a3df-82e829c21a27" />
