### PR TITLE
Improve and fix OpenAI support for thinking models

### DIFF
--- a/core/src/formatters/openai.ts
+++ b/core/src/formatters/openai.ts
@@ -1,4 +1,4 @@
-import { PromptRole } from "../index.js";
+import { PromptRole, PromptOptions } from "../index.js";
 import { readStreamAsBase64 } from "../stream.js";
 import { PromptSegment } from "../types.js";
 
@@ -55,7 +55,7 @@ export function formatOpenAILikeTextPrompt(segments: PromptSegment[]): OpenAITex
 }
 
 
-export async function formatOpenAILikeMultimodalPrompt(segments: PromptSegment[], opts: OpenAIPromptFormatterOptions): Promise<OpenAIMessage[]> {
+export async function formatOpenAILikeMultimodalPrompt(segments: PromptSegment[], opts: PromptOptions & OpenAIPromptFormatterOptions): Promise<OpenAIMessage[]> {
     const system: OpenAIMessage[] = [];
     const safety: OpenAIMessage[] = [];
     const others: OpenAIMessage[] = [];
@@ -120,12 +120,12 @@ export async function formatOpenAILikeMultimodalPrompt(segments: PromptSegment[]
 
     }
 
-    if (opts.schema && !opts.useToolForFormatting) {
+    if (opts.result_schema && !opts.useToolForFormatting) {
         system.push({
             role: "system",
             content: [{
                 type: "text",
-                text: "IMPORTANT: only answer using JSON, and respecting the schema included below, between the <response_schema> tags. " + `<response_schema>${JSON.stringify(opts.schema)}</response_schema>`
+                text: "IMPORTANT: only answer using JSON, and respecting the schema included below, between the <response_schema> tags. " + `<response_schema>${JSON.stringify(opts.result_schema)}</response_schema>`
             }]
         })
     }

--- a/drivers/package.json
+++ b/drivers/package.json
@@ -76,7 +76,7 @@
     "json-schema": "^0.4.0",
     "mnemonist": "^0.39.8",
     "node-web-stream-adapters": "^0.1.0",
-    "openai": "^4.61.1",
+    "openai": "^4.85.1",
     "replicate": "^0.33.0"
   },
   "ts_dual_module": {

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -37,7 +37,7 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<
     OpenAI.Chat.Completions.ChatCompletionMessageParam[]
 > {
     abstract provider: "azure_openai" | "openai" | "xai";
-    abstract service: OpenAI | AzureOpenAI ;
+    abstract service: OpenAI | AzureOpenAI;
 
     constructor(opts: BaseOpenAIDriverOptions) {
         super(opts);
@@ -66,7 +66,8 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<
             }
         }
 
-        const useTools: boolean = !isNonStructureSupporting(options.model);
+        const useTools: boolean = !isNonStructureSupporting(options.model)
+            && !options.model.includes("chatgpt-4o");
         let data = undefined;
         if (useTools) {
             //we have a schema: get the content and return after validation
@@ -88,7 +89,8 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<
 
     async requestCompletionStream(prompt: OpenAI.Chat.Completions.ChatCompletionMessageParam[], options: ExecutionOptions): Promise<any> {
 
-        const useTools : boolean = !isNonStructureSupporting(options.model);
+        const useTools: boolean = !isNonStructureSupporting(options.model)
+            && !options.model.includes("chatgpt-4o");
 
         const mapFn = (chunk: OpenAI.Chat.Completions.ChatCompletionChunk) => {
             let result = undefined
@@ -114,7 +116,7 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<
         //TODO: OpenAI o1 support requires max_completions_tokens
         const stream = (await this.service.chat.completions.create({
             stream: true,
-            stream_options: {include_usage: true},
+            stream_options: { include_usage: true },
             model: options.model,
             messages: prompt,
             temperature: options.temperature,
@@ -161,7 +163,8 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<
         
         convertRoles(prompt, options.model);
 
-        const useTools: boolean = !isNonStructureSupporting(options.model);
+        const useTools: boolean = !isNonStructureSupporting(options.model)
+            && !options.model.includes("chatgpt-4o");
 
         //TODO: OpenAI o1 support requires max_completions_tokens
         const res = await this.service.chat.completions.create({

--- a/drivers/src/xai/index.ts
+++ b/drivers/src/xai/index.ts
@@ -44,7 +44,7 @@ export class xAIDriver extends BaseOpenAIDriver {
             useToolForFormatting: false,
         }
 
-        const p = await formatOpenAILikeMultimodalPrompt(segments, options) as OpenAI.Chat.Completions.ChatCompletionMessageParam[];
+        const p = await formatOpenAILikeMultimodalPrompt(segments, {...options, ...opts}) as OpenAI.Chat.Completions.ChatCompletionMessageParam[];
 
         return p;
 

--- a/drivers/test/all-models.test.ts
+++ b/drivers/test/all-models.test.ts
@@ -78,7 +78,8 @@ if (process.env.OPENAI_API_KEY) {
         }),
         models: [
             "gpt-4o",
-            "gpt-3.5-turbo"
+            "gpt-3.5-turbo",
+            "o1-mini",
         ]
     }
     )
@@ -176,12 +177,16 @@ if (process.env.XAI_API_KEY) {
     })
 }
 
-describe.concurrent.each(drivers)("Driver $name", ({ name, driver, models }) => {
+function getTestOptions(model: string): ExecutionOptions {
+    if (model == "o1-mini") {
+        return {
+            model: model,
+            output_modality: Modalities.text,
+        };
+    }
 
-    let fetchedModels: AIModel[];
-
-    let test_options: ExecutionOptions = {
-        model: "",
+    return {
+        model: model,
         max_tokens: 128,
         temperature: 0.3,
         top_k: 40,
@@ -192,6 +197,11 @@ describe.concurrent.each(drivers)("Driver $name", ({ name, driver, models }) => 
         stop_sequence: ["adsoiuygsa"],
         output_modality: Modalities.text,
     };
+}
+
+describe.concurrent.each(drivers)("Driver $name", ({ name, driver, models }) => {
+
+    let fetchedModels: AIModel[];
 
     test(`${name}: list models`, { timeout: TIMEOUT, retry: 1 }, async () => {
         const r = await driver.listModels();
@@ -199,8 +209,6 @@ describe.concurrent.each(drivers)("Driver $name", ({ name, driver, models }) => 
         console.log(r)
         expect(r.length).toBeGreaterThan(0);
     });
-
-
 
     test.each(models)(`${name}: prompt generation for %s`, {}, async (model) => {
         const p = await driver.createPrompt(testPrompt_color, { model })
@@ -217,26 +225,26 @@ describe.concurrent.each(drivers)("Driver $name", ({ name, driver, models }) => 
         expect(p).toBeDefined();
     });
 
-    test.each(models)(`${name}: execute prompt on %s`, { timeout: TIMEOUT, retry: 3 }, async (model) => {
-        const r = await driver.execute(testPrompt_color, { ...test_options, model: model } as ExecutionOptions);
+    test.each(models)(`${name}: execute prompt on %s`, { timeout: TIMEOUT, retry: 2 }, async (model) => {
+        const r = await driver.execute(testPrompt_color, getTestOptions(model));
         console.log("Result for execute " + model, JSON.stringify(r));
         assertCompletionOk(r, model, driver);
     });
 
-    test.each(models)(`${name}: execute prompt with streaming on %s`, { timeout: TIMEOUT, retry: 3 }, async (model) => {
-        const r = await driver.stream(testPrompt_color, { ...test_options, model: model } as ExecutionOptions);
+    test.each(models)(`${name}: execute prompt with streaming on %s`, { timeout: TIMEOUT, retry: 2 }, async (model) => {
+        const r = await driver.stream(testPrompt_color, getTestOptions(model));
         const out = await assertStreamingCompletionOk(r);
         console.log("Result for streaming " + model, JSON.stringify(out));
     });
 
-    test.each(models)(`${name}: execute prompt with schema on %s`, { timeout: TIMEOUT, retry: 3 }, async (model) => {
-        const r = await driver.execute(testPrompt_color, { ...test_options, model: model, result_schema: testSchema_color } as ExecutionOptions);
+    test.each(models)(`${name}: execute prompt with schema on %s`, { timeout: TIMEOUT, retry: 2 }, async (model) => {
+        const r = await driver.execute(testPrompt_color, { ...getTestOptions(model), result_schema: testSchema_color });
         console.log("Result for execute with schema " + model, JSON.stringify(r.result));
         assertCompletionOk(r, model, driver);
     });
 
-    test.each(models)(`${name}: execute prompt with streaming and schema on %s`, { timeout: TIMEOUT, retry: 3 }, async (model) => {
-        const r = await driver.stream(testPrompt_color, { ...test_options, model: model, result_schema: testSchema_color } as ExecutionOptions);
+    test.each(models)(`${name}: execute prompt with streaming and schema on %s`, { timeout: TIMEOUT, retry: 2 }, async (model) => {
+        const r = await driver.stream(testPrompt_color, { ...getTestOptions(model), result_schema: testSchema_color });
         const out = await assertStreamingCompletionOk(r, true);
         console.log("Result for streaming with schema " + model, JSON.stringify(out));
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,8 +129,8 @@ importers:
         specifier: ^0.1.0
         version: 0.1.0
       openai:
-        specifier: ^4.61.1
-        version: 4.77.0
+        specifier: ^4.85.1
+        version: 4.85.1
       replicate:
         specifier: ^0.33.0
         version: 0.33.0
@@ -1480,12 +1480,15 @@ packages:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
 
-  openai@4.77.0:
-    resolution: {integrity: sha512-WWacavtns/7pCUkOWvQIjyOfcdr9X+9n9Vvb0zFeKVDAqwCMDHB+iSr24SVaBAhplvSG6JrRXFpcNM9gWhOGIw==}
+  openai@4.85.1:
+    resolution: {integrity: sha512-jkX2fntHljUvSH3MkWh4jShl10oNkb+SsCj4auKlbu2oF4KWAnmHLNR5EpnUHK1ZNW05Rp0fjbJzYwQzMsH8ZA==}
     hasBin: true
     peerDependencies:
+      ws: ^8.18.0
       zod: ^3.23.8
     peerDependenciesMeta:
+      ws:
+        optional: true
       zod:
         optional: true
 
@@ -3745,7 +3748,7 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openai@4.77.0:
+  openai@4.85.1:
     dependencies:
       '@types/node': 18.19.68
       '@types/node-fetch': 2.6.12


### PR DESCRIPTION
## Improve OpenAI support for thinking models

OpenAI support for various API options is patchy and not clearly or correctly documented.

See user made support matrix from 2 weeks ago:
https://community.openai.com/t/developer-role-not-accepted-for-o1-o1-mini-o3-mini/1110750/7

Picture for posterity:
<img width="938" alt="Screenshot 2025-02-14 at 13 17 24" src="https://github.com/user-attachments/assets/9e033074-3d06-4bb0-8e01-722fc54282b2" />

Changes:

- Use `developer` role instead of `system` for **o1 (full)** and newer, i.e. **o3-mini**.
- Use `user` role instead of `system` for **o1-mini** and **o1-preview** which support neither `system` or `developer`.
- Align usage of tools for JSON support with model support
  - Disable tools for **o1-mini** and **o1-preview**
- Add model specific options for testing (o1 model do not support temperature)
- Use `max_completion_tokens` instead of `max_tokens` for all models. This is equivalent for non-thinking models and needed for thinking models where it also includes reasoning tokens with output tokens in the limit. NOTE: This means very high limits may be needed to not truncate output.
- Disables streaming for **o1 (full)** as it does not support it, to be updated when support added by OpenAI