### PR TITLE
Feat imagen3 support

### DIFF
--- a/core/src/Driver.ts
+++ b/core/src/Driver.ts
@@ -64,7 +64,7 @@ export interface Driver<PromptT = unknown> {
      */
     createTrainingPrompt(options: TrainingPromptOptions): Promise<string>;
 
-    createPrompt(segments: PromptSegment[], opts: PromptOptions): Promise<PromptT>;
+    createPrompt(segments: PromptSegment[], opts: ExecutionOptions): Promise<PromptT>;
 
     execute(segments: PromptSegment[], options: ExecutionOptions): Promise<ExecutionResponse<PromptT>>;
 
@@ -224,8 +224,9 @@ export abstract class AbstractDriver<OptionsT extends DriverOptions = DriverOpti
 
     abstract requestTextCompletionStream(prompt: PromptT, options: ExecutionOptions): Promise<AsyncIterable<CompletionChunk>>;
 
-    async requestImageGeneration(_prompt: PromptT, _options: ExecutionOptions): Promise<Completion<ImageGeneration>> { //make abstract?
+    async requestImageGeneration(_prompt: PromptT, _options: ExecutionOptions): Promise<Completion<ImageGeneration>> {
         throw new Error("Image generation not implemented.");
+        //Cannot be made abstract, as abstract methods are required in the derived class
     }
 
     //list models available for this environement

--- a/core/src/formatters/nova.ts
+++ b/core/src/formatters/nova.ts
@@ -36,7 +36,9 @@ interface NovaMessagePart {
 
 export interface NovaMessagesPrompt {
     system?: NovaSystemMessage[];
-    messages: NovaMessage[]
+    messages: NovaMessage[];
+    negative?: string;
+    mask?: string;
 }
 
 /**
@@ -47,6 +49,8 @@ export async function formatNovaPrompt(segments: PromptSegment[], schema?: JSONS
     const system: string[] = [];
     const safety: string[] = [];
     const messages: NovaMessage[] = [];
+    let negative: string = "";
+    let mask: string = "";
 
     for (const segment of segments) {
 
@@ -85,6 +89,10 @@ export async function formatNovaPrompt(segments: PromptSegment[], schema?: JSONS
             //Maybe can remove for nova?
             //concatenate messages of the same role (Claude requires alternative user and assistant roles)
             messages[messages.length - 1].content.push(...parts);
+        } else if (segment.role === PromptRole.negative) {
+            negative = negative.concat(segment.content, ', ');
+        } else if (segment.role === PromptRole.mask) {
+            mask = mask.concat(segment.content, ' ');
         } else {
             messages.push({
                 role: segment.role,
@@ -126,6 +134,8 @@ export async function formatNovaPrompt(segments: PromptSegment[], schema?: JSONS
     // put system mesages first and safety last
     return {
         system: systemMessage ? [{ text: systemMessage }] : [{ text: "" }],
-        messages
+        messages: messages,
+        negative: negative,
+        mask: mask,
     }
 }

--- a/core/src/formatters/openai.ts
+++ b/core/src/formatters/openai.ts
@@ -42,7 +42,7 @@ export function formatOpenAILikeTextPrompt(segments: PromptSegment[]): OpenAITex
             system.push({ content: msg.content, role: "system" });
         } else if (msg.role === PromptRole.safety) {
             safety.push({ content: "IMPORTANT: " + msg.content, role: "system" });
-        } else {
+        } else if (msg.role !== PromptRole.negative && msg.role !== PromptRole.mask) {
             user.push({
                 content: msg.content,
                 role: msg.role || 'user',
@@ -114,7 +114,7 @@ export async function formatOpenAILikeMultimodalPrompt(segments: PromptSegment[]
 
             system.push(safetyMsg)
 
-        } else {
+        } else if (msg.role !== PromptRole.negative && msg.role !== PromptRole.mask) {
             others.push({
                 role: msg.role ?? 'user',
                 content: parts

--- a/core/src/options/vertexai.ts
+++ b/core/src/options/vertexai.ts
@@ -61,7 +61,7 @@ export function getVertexAiOptions(model: string, option?: ModelOptions): ModelO
                 integer: true, description: "The seed of the generated image"
             },
             {
-                name: "person_generation", type: OptionType.enum, enum: { "Disallow the inclusion of people or faces in images": "dont_allow", "Allow generation of adults only": "allow_adults", "Allow generation of people of all ages": "allow_all" },
+                name: "person_generation", type: OptionType.enum, enum: { "Disallow the inclusion of people or faces in images": "dont_allow", "Allow generation of adults only": "allow_adult", "Allow generation of people of all ages": "allow_all" },
                 default: "allow_adult", description: "The safety setting for allowing the generation of people in the image"
             },
             {

--- a/core/src/options/vertexai.ts
+++ b/core/src/options/vertexai.ts
@@ -120,7 +120,7 @@ export function getVertexAiOptions(model: string, option?: ModelOptions): ModelO
         if (model.includes("capability")) {
             //Edit models
             let guidanceScaleDefault = 75;
-            if ((option as ImagenOptions).edit_mode === "EDIT_MODE_INPAINT_INSERTION") {
+            if ((option as ImagenOptions)?.edit_mode === "EDIT_MODE_INPAINT_INSERTION") {
                 guidanceScaleDefault = 60;
             }
         
@@ -159,14 +159,14 @@ export function getVertexAiOptions(model: string, option?: ModelOptions): ModelO
                 }
             ];
 
-            const maskClassOptions: ModelOptionInfoItem[] = ((option as ImagenOptions).mask_mode === "MASK_MODE_SEMANTIC") ? [
+            const maskClassOptions: ModelOptionInfoItem[] = ((option as ImagenOptions)?.mask_mode === "MASK_MODE_SEMANTIC") ? [
                 {
                     name: "mask_class", type: OptionType.string_list, default: [],
                     description: "Input Class IDs. Create a mask based on image class, based on https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/imagen-api-customization#segment-ids"
                 }
             ] : [];
 
-            const customizationOptions: ModelOptionInfoItem[] = (option as ImagenOptions).edit_mode === "CUSTOMIZATION_GENERATE" ? [
+            const customizationOptions: ModelOptionInfoItem[] = (option as ImagenOptions)?.edit_mode === "CUSTOMIZATION_GENERATE" ? [
                 {
                     name: "controlType", type: OptionType.enum, enum: { "Face Mesh": "CONTROL_TYPE_FACE_MESH", "Canny": "CONTROL_TYPE_CANNY", "Scribble": "CONTROL_TYPE_SCRIBBLE" },
                     default: "CONTROL_TYPE_CANNY", description: "Method used to generate the control image"

--- a/core/src/options/vertexai.ts
+++ b/core/src/options/vertexai.ts
@@ -6,6 +6,8 @@ export type VertexAIOptions = ImagenOptions;
 
 export interface ImagenOptions {
     _option_id: "vertexai-imagen"
+
+    //General and generate options
     number_of_images?: number;
     seed?: number;
     person_generation?: "dont_allow" | "allow_adults" | "allow_all";
@@ -14,9 +16,13 @@ export interface ImagenOptions {
     jpeg_compression_quality?: number;
     aspect_ratio?: "1:1" | "4:3" | "3:4" | "16:9" | "9:16" ;
     add_watermark?: boolean;
+    enhance_prompt?: boolean;
+
+    //Capability options
     edit_mode?: "EDIT_MODE_INPAINT_REMOVAL" | "EDIT_MODE_INPAINT_INSERTION" | "EDIT_MODE_BGSWAP" | "EDIT_MODE_OUTPAINT";
     guidance_scale?: number;
-    enhance_prompt?: boolean;
+    base_steps?: number;
+    mask_dilation?: number;
 }
 
 export function getVertexAiOptions(model: string, option?: ModelOptions): ModelOptionsInfo {
@@ -58,7 +64,9 @@ export function getVertexAiOptions(model: string, option?: ModelOptions): ModelO
             outputOptions.push(jpegQuality);
         }
         if (model.includes("generate")) {
-            const modeOptions: ModelOptionInfoItem[] = [
+            //Generate models
+            const modeOptions: ModelOptionInfoItem[]
+                = [
                 {
                     name: "aspect_ratio", type: OptionType.enum, enum: { "1:1": "1:1", "4:3": "4:3", "3:4": "3:4", "16:9": "16:9" ,"9:16": "9:16" },
                     default: "1:1", description: "The aspect ratio of the generated image"
@@ -86,6 +94,7 @@ export function getVertexAiOptions(model: string, option?: ModelOptions): ModelO
             };
         }
         if (model.includes("capability")) {
+            //Edit models
             let guidanceScaleDefault = 75;
             if ((option as ImagenOptions).edit_mode === "EDIT_MODE_INPAINT_INSERTION") {
                 guidanceScaleDefault = 60;
@@ -100,6 +109,8 @@ export function getVertexAiOptions(model: string, option?: ModelOptions): ModelO
                         "Background Swap": "EDIT_MODE_BGSWAP",
                         "Outpaint": "EDIT_MODE_OUTPAINT",
                     },
+                    default: "EDIT_MODE_INPAINT_REMOVAL",
+                    description: "The editing mode"
                 },
                 {
                     name: "guidance_scale", type: OptionType.numeric, min: 0, max: 500, default: guidanceScaleDefault,

--- a/core/src/options/vertexai.ts
+++ b/core/src/options/vertexai.ts
@@ -22,7 +22,10 @@ export interface ImagenOptions {
     edit_mode?: "EDIT_MODE_INPAINT_REMOVAL" | "EDIT_MODE_INPAINT_INSERTION" | "EDIT_MODE_BGSWAP" | "EDIT_MODE_OUTPAINT";
     guidance_scale?: number;
     base_steps?: number;
+    mask_mode?: "MASK_MODE_USER_PROVIDED" | "MASK_MODE_BACKGROUND" | "MASK_MODE_FOREGROUND" | "MASK_MODE_SEMANTIC";
     mask_dilation?: number;
+    mask_class?: number[];
+
 }
 
 export function getVertexAiOptions(model: string, option?: ModelOptions): ModelOptionsInfo {
@@ -113,17 +116,40 @@ export function getVertexAiOptions(model: string, option?: ModelOptions): ModelO
                     description: "The editing mode"
                 },
                 {
+                    name: "mask_mode", type: OptionType.enum,
+                    enum: {
+                        "MASK_MODE_USER_PROVIDED": "MASK_MODE_USER_PROVIDED",
+                        "MASK_MODE_BACKGROUND": "MASK_MODE_BACKGROUND",
+                        "MASK_MODE_FOREGROUND": "MASK_MODE_FOREGROUND",
+                        "MASK_MODE_SEMANTIC": "MASK_MODE_SEMANTIC",
+                    },
+                    default: "MASK_MODE_USER_PROVIDED",
+                    description: "How should the mask for the generation be provided"
+                },
+                {
+                    name: "mask_dilation", type: OptionType.numeric, min: 0, max: 1, default: 0.01,
+                    integer: true, description: "The mask dilation, grows the mask by a percetage of image width to compensate for imprecise masks."
+                },
+                {
                     name: "guidance_scale", type: OptionType.numeric, min: 0, max: 500, default: guidanceScaleDefault,
                     integer: true, description: "The scale of the guidance image"
                 }
             ];
 
+            const maskClassOptions: ModelOptionInfoItem[] = ((option as ImagenOptions).mask_mode === "MASK_MODE_SEMANTIC") ? [
+                {
+                    name: "mask_class", type: OptionType.string_list, default: [],
+                    description: "Input Class IDs. Create a mask based on image class, based on https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/imagen-api-customization#segment-ids"
+                }
+            ] : [];
+
             return {
                 _option_id: "vertexai-imagen",
                 options: [
-                    ...commonOptions,
                     ...modeOptions,
+                    ...commonOptions,
                     ...outputOptions,
+                    ...maskClassOptions,
                 ]
             };
         }

--- a/core/src/options/vertexai.ts
+++ b/core/src/options/vertexai.ts
@@ -8,14 +8,15 @@ export interface ImagenOptions {
     _option_id: "vertexai-imagen"
     number_of_images?: number;
     seed?: number;
-    person_generation?: "dont_allow" | "random" | "allow_all";
-    safety_setting?: "block_none" | "block_only_high" | "block_medium_and_above" | "block_low_and_above";
+    person_generation?: "dont_allow" | "allow_adults" | "allow_all";
+    safety_setting?: "block_none" | "block_only_high" | "block_medium_and_above" | "block_low_and_above"; //The "off" option does not seem to work for Imagen 3, might be only for text models
     image_file_type?: "image/jpeg" | "image/png";
     jpeg_compression_quality?: number;
-    aspect_ratio?: "1:1" | "4:3" | "16:9";
+    aspect_ratio?: "1:1" | "4:3" | "3:4" | "16:9" | "9:16" ;
     add_watermark?: boolean;
     edit_mode?: "EDIT_MODE_INPAINT_REMOVAL" | "EDIT_MODE_INPAINT_INSERTION" | "EDIT_MODE_BGSWAP" | "EDIT_MODE_OUTPAINT";
     guidance_scale?: number;
+    enhance_prompt?: boolean;
 }
 
 export function getVertexAiOptions(model: string, option?: ModelOptions): ModelOptionsInfo {
@@ -30,12 +31,12 @@ export function getVertexAiOptions(model: string, option?: ModelOptions): ModelO
                 integer: true, description: "The seed of the generated image"
             },
             {
-                name: "person_generation", type: OptionType.enum, enum: { "Disallow the inclusion of people or faces in images": "dont_allow", "Allow generation of adults only": "random", "Allow generation of people of all ages": "allow_all" },
-                default: "allow_adult", description: "The type of person to generate"
+                name: "person_generation", type: OptionType.enum, enum: { "Disallow the inclusion of people or faces in images": "dont_allow", "Allow generation of adults only": "allow_adults", "Allow generation of people of all ages": "allow_all" },
+                default: "allow_adult", description: "The safety setting for allowing the generation of people in the image"
             },
             {
                 name: "safety_setting", type: OptionType.enum, enum: { "Block very few problematic prompts and responses": "block_none", "Block only few problematic prompts and responses": "block_only_high", "Block some problematic prompts and responses": "block_medium_and_above", "Strictest filtering": "block_low_and_above" },
-                default: "block_medium_and_above", description: "The safety setting for the generated image"
+                default: "block_medium_and_above", description: "The overall safety setting"
             },
         ];
 
@@ -59,14 +60,20 @@ export function getVertexAiOptions(model: string, option?: ModelOptions): ModelO
         if (model.includes("generate")) {
             const modeOptions: ModelOptionInfoItem[] = [
                 {
-                    name: "aspect_ratio", type: OptionType.enum, enum: { "1:1": "1:1", "4:3": "4:3", "16:9": "16:9" },
+                    name: "aspect_ratio", type: OptionType.enum, enum: { "1:1": "1:1", "4:3": "4:3", "3:4": "3:4", "16:9": "16:9" ,"9:16": "9:16" },
                     default: "1:1", description: "The aspect ratio of the generated image"
                 },
                 {
-                    name: "add_watermark", type: OptionType.boolean, default: true, description: "Add an invisible watermark to the generated image, useful for detection of AI images"
+                    name: "add_watermark", type: OptionType.boolean, default: false, description: "Add an invisible watermark to the generated image, useful for detection of AI images"
                 },
                 
             ];
+
+            const enhanceOptions: ModelOptionInfoItem[] = !model.includes("generate-001") ? [
+                {
+                    name: "enhance_prompt", type: OptionType.boolean, default: true, description: "VertexAI automatically rewrites the prompt to better reflect the prompt's intent."
+                },
+            ] : [];
 
             return {
                 _option_id: "vertexai-imagen",
@@ -74,6 +81,7 @@ export function getVertexAiOptions(model: string, option?: ModelOptions): ModelO
                     ...commonOptions,
                     ...modeOptions,
                     ...outputOptions,
+                    ...enhanceOptions,
                 ]
             };
         }

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -218,6 +218,8 @@ export enum PromptRole {
     system = "system",
     user = "user",
     assistant = "assistant",
+    negative = "negative",
+    mask = "mask",
 }
 
 export interface PromptSegment {

--- a/drivers/src/bedrock/converse.ts
+++ b/drivers/src/bedrock/converse.ts
@@ -155,7 +155,7 @@ export async function fortmatConversePrompt(segments: PromptSegment[], schema?: 
             system.push({ text: segment.content });
         } else if (segment.role === PromptRole.safety) {
             safety.push({ text: segment.content });
-        } else {
+        } else if (segment.role !== PromptRole.negative && segment.role !== PromptRole.mask) {
             //User or Assistant
             messages = messages.concat(parts);
         }

--- a/drivers/src/bedrock/nova-image-payload.ts
+++ b/drivers/src/bedrock/nova-image-payload.ts
@@ -83,6 +83,7 @@ async function imageVariationPayload(prompt: NovaMessagesPrompt, options: Execut
         imageVariationParams: {
             images: images ?? [],
             text: text,
+            negativeText: prompt.negative,
             similarityStrength: options.model_options?.similarityStrength,
         }
     }

--- a/drivers/src/test/index.ts
+++ b/drivers/src/test/index.ts
@@ -1,4 +1,4 @@
-import { AIModel, AIModelStatus, CompletionStream, Driver, EmbeddingsResult, ExecutionOptions, ExecutionResponse, ModelType, PromptOptions, PromptSegment, TrainingJob } from "@llumiverse/core";
+import { AIModel, AIModelStatus, CompletionStream, Driver, EmbeddingsResult, ExecutionOptions, ExecutionResponse, ModelType, PromptSegment, TrainingJob } from "@llumiverse/core";
 import { TestErrorCompletionStream } from "./TestErrorCompletionStream.js";
 import { TestValidationErrorCompletionStream } from "./TestValidationErrorCompletionStream.js";
 import { createValidationErrorCompletion, sleep, throwError } from "./utils.js";
@@ -30,9 +30,10 @@ export class TestDriver implements Driver<PromptSegment[]> {
         throw new Error("Method not implemented.");
     }
 
-    async createPrompt(segments: PromptSegment[], _opts: PromptOptions): Promise<PromptSegment[]> {
+    async createPrompt(segments: PromptSegment[], _opts: ExecutionOptions): Promise<PromptSegment[]> {
         return segments;
     }
+    
     execute(segments: PromptSegment[], options: ExecutionOptions): Promise<ExecutionResponse<PromptSegment[]>> {
         switch (options.model) {
             case TestDriverModels.executionError:

--- a/drivers/src/vertexai/index.ts
+++ b/drivers/src/vertexai/index.ts
@@ -1,5 +1,5 @@
 import { GenerateContentRequest, VertexAI } from "@google-cloud/vertexai";
-import { AIModel, AbstractDriver, Completion, CompletionChunkObject, DriverOptions, EmbeddingsResult, ExecutionOptions, ImageGeneration, Modalities, ModelSearchPayload, PromptOptions, PromptSegment } from "@llumiverse/core";
+import { AIModel, AbstractDriver, Completion, CompletionChunkObject, DriverOptions, EmbeddingsResult, ExecutionOptions, ImageGeneration, Modalities, ModelSearchPayload, PromptSegment } from "@llumiverse/core";
 import { FetchClient } from "api-fetch-client";
 import { GoogleAuth, GoogleAuthOptions } from "google-auth-library";
 import { JSONClient } from "google-auth-library/build/src/auth/googleauth.js";
@@ -9,7 +9,7 @@ import { EmbeddingsOptions } from "@llumiverse/core";
 import { getEmbeddingsForImages } from "./embeddings/embeddings-image.js";
 import { v1beta1 } from '@google-cloud/aiplatform';
 import { AnthropicVertex } from '@anthropic-ai/vertex-sdk';
-import { ImagenModelDefinition } from "./models/imagen.js";
+import { ImagenModelDefinition, ImagenPrompt } from "./models/imagen.js";
 
 
 export interface VertexAIDriverOptions extends DriverOptions {
@@ -19,7 +19,7 @@ export interface VertexAIDriverOptions extends DriverOptions {
 }
 
 //General Prompt type for VertexAI
-export type VertexAIPrompt = GenerateContentRequest;
+export type VertexAIPrompt = GenerateContentRequest | ImagenPrompt;
 
 export function trimModelName(model: string) {
     const i = model.lastIndexOf('@');
@@ -77,7 +77,7 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
         return Promise.resolve(getModelDefinition(options.model).model.can_stream === true);
     }
 
-    public createPrompt(segments: PromptSegment[], options: PromptOptions): Promise<VertexAIPrompt> {
+    public createPrompt(segments: PromptSegment[], options: ExecutionOptions): Promise<VertexAIPrompt> {
         if (options.model.includes("imagen")) {
             return new ImagenModelDefinition(options.model).createPrompt(this, segments, options);
         }
@@ -91,7 +91,7 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
         return getModelDefinition(options.model).requestTextCompletionStream(this, prompt, options);
     }
 
-    async requestImageGeneration(_prompt: GenerateContentRequest, _options: ExecutionOptions): Promise <Completion<ImageGeneration>> {
+    async requestImageGeneration(_prompt: ImagenPrompt, _options: ExecutionOptions): Promise <Completion<ImageGeneration>> {
         const splits = _options.model.split("/");
         const modelName = trimModelName(splits[splits.length - 1]);
         return new ImagenModelDefinition(modelName).requestImageGeneration(this, _prompt, _options);

--- a/drivers/src/vertexai/models/imagen.ts
+++ b/drivers/src/vertexai/models/imagen.ts
@@ -148,10 +148,6 @@ export class ImagenModelDefinition  {
             throw new Error(`Image generation requires image output_modality`);
         }
 
-        if (!options.model.includes('imagen-3.0') || !options.model.includes('generate')) {
-            throw new Error(`Model ${options.model} not supported, use imagen-3.0 generate models`);
-        }
-
         const taskType = ImagenImageGenerationTaskType.TEXT_IMAGE;
          /*   
             () => {
@@ -180,15 +176,17 @@ export class ImagenModelDefinition  {
         const instances = [instanceValue];
 
         const parameter = {
-            sampleCount: options.model_options?.number_of_images ?? 1,
+            sampleCount: options.model_options?.number_of_images,
             // You can't use a seed value and watermark at the same time.
-            seed: options.model_options?.seed ?? 1,
+            seed: options.model_options?.seed,
             addWatermark: options.model_options?.add_watermark,
-            aspectRatio: options.model_options?.aspect_ratio ?? '1:1',
+            aspectRatio: options.model_options?.aspect_ratio,
             //negativePrompt: options.model_options.negative_prompt ?? '',
             safetySetting: options.model_options?.safety_setting,
             personGeneration: options.model_options?.person_generation,
-            //enhancePrompt: options.model_options?.enhance_prompt,
+            enhancePrompt: options.model_options?.enhance_prompt,
+            includeSafetyAttributes: true,
+            includeRaiReason: true,
         };
         const parameters = helpers.toValue(parameter);
 
@@ -202,13 +200,15 @@ export class ImagenModelDefinition  {
         const [response] = await predictionServiceClient.predict(request);
         const predictions = response.predictions;
 
+        console.log("Response: ", JSON.stringify(response));
+
         if (!predictions) {
             throw new Error('No predictions found');
         }
 
         // Extract base64 encoded images from predictions
         const images : string[] = predictions.map(prediction =>
-            prediction.structValue?.fields?.bytesBase64Encoded.stringValue ?? ''
+            prediction.structValue?.fields?.bytesBase64Encoded?.stringValue ?? ''
         );
 
         return {


### PR DESCRIPTION
* https://github.com/vertesia/llumiverse/issues/58

To be merged after: 
* https://github.com/vertesia/llumiverse/pull/76
as it includes that PR, but should be separated for clarity of purpose in the commit history.

Improves and adds to Imagen 3 support.
Fixes usage of imagen 3 model, to not be hardcoded to generate-001.
Adds support for Imagen capability, this includes "edit mode" the typical one shot generation and customization which is the "few shot" generation.
Fixes option display for Imagen models.