### PR TITLE
Imagen 3 Customisation Options

### DIFF
--- a/core/src/options/vertexai.ts
+++ b/core/src/options/vertexai.ts
@@ -31,18 +31,18 @@ export interface ImagenOptions {
     safety_setting?: "block_none" | "block_only_high" | "block_medium_and_above" | "block_low_and_above"; //The "off" option does not seem to work for Imagen 3, might be only for text models
     image_file_type?: "image/jpeg" | "image/png";
     jpeg_compression_quality?: number;
-    aspect_ratio?: "1:1" | "4:3" | "3:4" | "16:9" | "9:16" ;
+    aspect_ratio?: "1:1" | "4:3" | "3:4" | "16:9" | "9:16";
     add_watermark?: boolean;
     enhance_prompt?: boolean;
 
     //Capability options
     edit_mode?: ImagenTaskType
     guidance_scale?: number;
-    base_steps?: number;
+    edit_steps?: number;
     mask_mode?: ImagenMaskMode;
     mask_dilation?: number;
     mask_class?: number[];
-    
+
     //Customization options
     controlType: "CONTROL_TYPE_FACE_MESH" | "CONTROL_TYPE_CANNY" | "CONTROL_TYPE_SCRIBBLE";
     controlImageComputation?: boolean;
@@ -102,15 +102,15 @@ export function getVertexAiOptions(model: string, option?: ModelOptions): ModelO
             //Generate models
             const modeOptions: ModelOptionInfoItem[]
                 = [
-                {
-                    name: "aspect_ratio", type: OptionType.enum, enum: { "1:1": "1:1", "4:3": "4:3", "3:4": "3:4", "16:9": "16:9" ,"9:16": "9:16" },
-                    default: "1:1", description: "The aspect ratio of the generated image"
-                },
-                {
-                    name: "add_watermark", type: OptionType.boolean, default: false, description: "Add an invisible watermark to the generated image, useful for detection of AI images"
-                },
-                
-            ];
+                    {
+                        name: "aspect_ratio", type: OptionType.enum, enum: { "1:1": "1:1", "4:3": "4:3", "3:4": "3:4", "16:9": "16:9", "9:16": "9:16" },
+                        default: "1:1", description: "The aspect ratio of the generated image"
+                    },
+                    {
+                        name: "add_watermark", type: OptionType.boolean, default: false, description: "Add an invisible watermark to the generated image, useful for detection of AI images"
+                    },
+
+                ];
 
             const enhanceOptions: ModelOptionInfoItem[] = !model.includes("generate-001") ? [
                 {
@@ -134,7 +134,7 @@ export function getVertexAiOptions(model: string, option?: ModelOptions): ModelO
             if ((option as ImagenOptions)?.edit_mode === "EDIT_MODE_INPAINT_INSERTION") {
                 guidanceScaleDefault = 60;
             }
-        
+
             const modeOptions: ModelOptionInfoItem[] = [
                 {
                     name: "edit_mode", type: OptionType.enum,
@@ -170,6 +170,13 @@ export function getVertexAiOptions(model: string, option?: ModelOptions): ModelO
                 }
             ];
 
+            const editOptions: ModelOptionInfoItem[] = (option as ImagenOptions)?.edit_mode?.includes("edit") ? [
+                {
+                    name: "edit_steps", type: OptionType.numeric, min: 1, max: 500, default: 35,
+                    integer: true, description: "The number of steps for the base image generation, more steps means more time and better quality"
+                },
+            ] : [];
+
             const maskClassOptions: ModelOptionInfoItem[] = ((option as ImagenOptions)?.mask_mode === "MASK_MODE_SEMANTIC") ? [
                 {
                     name: "mask_class", type: OptionType.string_list, default: [],
@@ -192,6 +199,7 @@ export function getVertexAiOptions(model: string, option?: ModelOptions): ModelO
                 options: [
                     ...modeOptions,
                     ...commonOptions,
+                    ...editOptions,
                     ...outputOptions,
                     ...maskClassOptions,
                     ...customizationOptions,

--- a/drivers/src/vertexai/models/imagen.ts
+++ b/drivers/src/vertexai/models/imagen.ts
@@ -15,7 +15,7 @@ import { ImagenOptions } from "../../../../core/src/options/vertexai.js";
 
 interface ImagenBaseReference {
     referenceType: "REFERENCE_TYPE_RAW" | "REFERENCE_TYPE_MASK" | "REFERENCE_TYPE_SUBJECT" |
-        "REFERENCE_TYPE_CONTROL" | "REFERENCE_TYPE_STYLE";
+    "REFERENCE_TYPE_CONTROL" | "REFERENCE_TYPE_STYLE";
     referenceId: number;
     referenceImage: {
         bytesBase64Encoded: string; //10MB max
@@ -49,7 +49,7 @@ interface ImagenReferenceMask extends Omit<ImagenBaseReference, "referenceImage"
         maskMode?: ImagenMaskMode;
         maskClasses?: number[]; //Used for MASK_MODE_SEMANTIC, based on https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/imagen-api-customization#segment-ids
         dilation?: number; //Recommendation depends on mode: Inpaint: 0.01, BGSwap: 0.0, Outpaint: 0.01-0.03
-    }   
+    }
     referenceImage?: {  //Only used for MASK_MODE_USER_PROVIDED
         bytesBase64Encoded: string; //10MB max
     }
@@ -89,7 +89,7 @@ export interface ImagenPrompt {
 
 // Specifies the location of the api endpoint
 const clientOptions = {
-  apiEndpoint: `${location}-aiplatform.googleapis.com`,
+    apiEndpoint: `${location}-aiplatform.googleapis.com`,
 };
 
 // Instantiates a client
@@ -113,11 +113,13 @@ function getImagenParameters(taskType: string, options: ImagenOptions) {
             return {
                 ...commonParameters,
                 editMode: "EDIT_MODE_INPAINT_REMOVAL",
+                editSteps: options?.edit_steps,
             }
         case ImagenTaskType.EDIT_MODE_INPAINT_INSERTION:
             return {
                 ...commonParameters,
                 editMode: "EDIT_MODE_INPAINT_INSERTION",
+                editSteps: options?.edit_steps,
             }
         case ImagenTaskType.EDIT_MODE_BGSWAP:
             return {
@@ -129,14 +131,14 @@ function getImagenParameters(taskType: string, options: ImagenOptions) {
                 ...commonParameters,
                 editMode: "EDIT_MODE_OUTPAINT",
                 editConfig: {
-                    baseSteps: options?.base_steps,
+                    baseSteps: options?.edit_steps,
                 },
             }
         case ImagenTaskType.TEXT_IMAGE:
             return {
                 ...commonParameters,
                 // You can't use a seed value and watermark at the same time.
-                addWatermark: options?.add_watermark, 
+                addWatermark: options?.add_watermark,
                 aspectRatio: options?.aspect_ratio,
                 enhancePrompt: options?.enhance_prompt,
             };
@@ -153,7 +155,7 @@ function getImagenParameters(taskType: string, options: ImagenOptions) {
     }
 }
 
-export class ImagenModelDefinition  {
+export class ImagenModelDefinition {
 
     model: AIModel
 
@@ -199,7 +201,7 @@ export class ImagenModelDefinition  {
             }
             if (msg.files) {
                 //Get images from messages
-                if (!prompt.referenceImages) { 
+                if (!prompt.referenceImages) {
                     prompt.referenceImages = [];
                 }
 
@@ -243,7 +245,7 @@ export class ImagenModelDefinition  {
                                         },
                                         controlImageConfig: {
                                             controlType: imagenOptions?.controlType === "CONTROL_TYPE_FACE_MESH" ? "CONTROL_TYPE_FACE_MESH" : "CONTROL_TYPE_CANNY",
-                                            enableControlImageComputation : imagenOptions?.controlImageComputation,
+                                            enableControlImageComputation: imagenOptions?.controlImageComputation,
                                         }
                                     });
                                 } else {
@@ -290,22 +292,22 @@ export class ImagenModelDefinition  {
         }
 
         console.log(prompt);
-            
+
         return prompt
     }
-    
+
     async requestImageGeneration(driver: VertexAIDriver, prompt: ImagenPrompt, options: ExecutionOptions): Promise<Completion<ImageGeneration>> {
         if (options.model_options?._option_id !== "vertexai-imagen") {
             driver.logger.warn("Invalid model options", options.model_options);
         }
         options.model_options = options.model_options as ImagenOptions;
-        
+
         if (options.output_modality !== Modalities.image) {
             throw new Error(`Image generation requires image output_modality`);
         }
 
-        const taskType : string = options.model_options.edit_mode ?? ImagenTaskType.TEXT_IMAGE;
-        
+        const taskType: string = options.model_options.edit_mode ?? ImagenTaskType.TEXT_IMAGE;
+
         driver.logger.info("Task type: " + taskType);
 
         const modelName = options.model.split("/").pop() ?? '';
@@ -338,7 +340,7 @@ export class ImagenModelDefinition  {
         };
 
         // Predict request
-        const [response] = await predictionServiceClient.predict(request, {timeout: 120000 * numberOfImages}); //Extended timeout for image generation
+        const [response] = await predictionServiceClient.predict(request, { timeout: 120000 * numberOfImages }); //Extended timeout for image generation
         const predictions = response.predictions;
 
         if (!predictions) {
@@ -346,7 +348,7 @@ export class ImagenModelDefinition  {
         }
 
         // Extract base64 encoded images from predictions
-        const images : string[] = predictions.map(prediction =>
+        const images: string[] = predictions.map(prediction =>
             prediction.structValue?.fields?.bytesBase64Encoded?.stringValue ?? ''
         );
 


### PR DESCRIPTION
Refines the implementation of the customisation options, splitting it into 4 categories as per:
https://cloud.google.com/vertex-ai/generative-ai/docs/image/subject-customization
(see sidebar)

Also adds edit steps for the edit modes and cleans up some of the model options.