### PR TITLE
Update the renovate config json

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -1,13 +1,30 @@
 {
-  $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  packageRules: [
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
     {
-      groupName: "gh-actions deps",
-      matchManagers: ["github-actions"],
+      "groupName": "gh-actions deps",
+      "matchManagers": ["github-actions"]
     },
     {
-      groupName: "node deps",
-      matchManagers: ["npm", "nvm", "nodenv"],
+      "groupName": "node deps",
+      "matchManagers": ["npm", "nvm", "nodenv"]
+    },
+    {
+      "groupName": "Model Provider Client libraries",
+      "matchManagers": [
+        "npm"
+      ],
+      "matchPackageNames": [
+        "@azure/openai",
+        "@google-cloud/**",
+        "@huggingface/inference",
+        "@replicate",
+        "@openai",
+        "@groq-sdk",
+        "@aws-sdk/**",
+        "@anthropic-ai/**"
+      ],
+      "rangeStrategy": "bump"
     },
   ],
 }


### PR DESCRIPTION
Adds a new group for model provider client libraries which we want to update frequently to make sure we are not developing to an old API.

Uses the bump strategy for said client libraries.