### PR TITLE
feat: Vertex AI list all versions

### DIFF
--- a/drivers/package.json
+++ b/drivers/package.json
@@ -64,7 +64,7 @@
     "@aws-sdk/lib-storage": "^3.709.0",
     "@azure/identity": "^4.4.1",
     "@azure/openai": "2.0.0-beta.2",
-    "@google-cloud/aiplatform": "^3.34.0",
+    "@google-cloud/aiplatform": "^3.35.0",
     "@google-cloud/vertexai": "^1.7.0",
     "@huggingface/inference": "2.6.7",
     "@llumiverse/core": "workspace:*",

--- a/drivers/src/vertexai/index.ts
+++ b/drivers/src/vertexai/index.ts
@@ -123,8 +123,7 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
                 parent: `publishers/${publisher}`,
                 orderBy: 'name',
                 //filter: `name eq name`,
-                //list_all_versions: 'true',     
-                //As of 27/12/24 list_all_versions is not supported yet, see if https://github.com/googleapis/google-cloud-node/pull/5836 is merged
+                listAllVersions: true,
             });
 
             models = models.concat(response.map(model => ({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,7 +93,7 @@ importers:
         specifier: 2.0.0-beta.2
         version: 2.0.0-beta.2
       '@google-cloud/aiplatform':
-        specifier: ^3.34.0
+        specifier: ^3.35.0
         version: 3.35.0
       '@google-cloud/vertexai':
         specifier: ^1.7.0


### PR DESCRIPTION
google cloud ai platform 3.35.0 has brought "listAllVersions" support for the listing api.

This allows us to see older versions of models in the listing like Gemini 1.5 Pro 001.