### PR TITLE
fix: Don't throw error for missing options_id for Nova canvas

### DIFF
--- a/drivers/src/bedrock/nova-image-payload.ts
+++ b/drivers/src/bedrock/nova-image-payload.ts
@@ -1,6 +1,6 @@
 import { ExecutionOptions } from "@llumiverse/core";
 import { NovaMessage, NovaMessagesPrompt } from "@llumiverse/core/formatters";
-import { NovaCanvasOptions } from "../../../core/src/options/bedrock";
+import { NovaCanvasOptions } from "../../../core/src/options/bedrock.js";
 
 function getFirstImageFromPrompt(prompt: NovaMessage[]) {
 


### PR DESCRIPTION
* https://github.com/vertesia/studio/issues/1323

Originally added as part of the type control of model_options and because the image options are sufficiently unique that if we don't have the correct model options, we are unlikely to have overlap with other model options.

Removing as it has proven a unnecessary stop, turning small bugs into a full stop if the options_id is not correct.
This is in line with all other model which only log a warning.
Nova Canvas does and still will log a warning, so the issue can still be traced.