### PR TITLE
feat: Amazon Nova Canvas mask and negative support

### DIFF
--- a/core/src/formatters/nova.ts
+++ b/core/src/formatters/nova.ts
@@ -135,7 +135,7 @@ export async function formatNovaPrompt(segments: PromptSegment[], schema?: JSONS
     return {
         system: systemMessage ? [{ text: systemMessage }] : [{ text: "" }],
         messages: messages,
-        negative: negative,
-        mask: mask,
+        negative: negative || undefined,
+        mask: mask || undefined,
     }
 }

--- a/core/src/options/bedrock.ts
+++ b/core/src/options/bedrock.ts
@@ -119,8 +119,8 @@ export function getBedrockOptions(model: string, option?: ModelOptions): ModelOp
                 "Text-To-Image-with-Image-Conditioning": "TEXT_IMAGE_WITH_IMAGE_CONDITIONING",
                 "Color-Guided-Generation": "COLOR_GUIDED_GENERATION",
                 "Image-Variation": "IMAGE_VARIATION",
-                //    "Inpainting": "INPAINTING",    Not implemented yet
-                //    "Outpainting": "OUTPAINTING",
+                "Inpainting": "INPAINTING",
+                "Outpainting": "OUTPAINTING",
                 "Background-Removal": "BACKGROUND_REMOVAL",
             },
             default: "TEXT_IMAGE",

--- a/drivers/src/bedrock/nova-image-payload.ts
+++ b/drivers/src/bedrock/nova-image-payload.ts
@@ -144,9 +144,7 @@ async function backgroundRemovalPayload(prompt: NovaMessagesPrompt): Promise<Nov
 }
 
 async function inpaintingPayload(prompt: NovaMessagesPrompt, options: ExecutionOptions): Promise<NovaInpaintingPayload> {
-    if (options.model_options?._option_id !== "bedrock-nova-canvas") {
-        throw new Error("Invalid model options");
-    }
+    const modelOptions = options.model_options as NovaCanvasOptions;
 
     const images = getAllImagesFromPrompt(prompt.messages);
     if (!images?.length || images.length < 2) {
@@ -158,12 +156,12 @@ async function inpaintingPayload(prompt: NovaMessagesPrompt, options: ExecutionO
     const payload: NovaInpaintingPayload = {
         taskType: NovaImageGenerationTaskType.INPAINTING,
         imageGenerationConfig: {
-            quality: options.model_options?.quality,
-            width: options.model_options?.width,
-            height: options.model_options?.height,
-            numberOfImages: options.model_options?.numberOfImages,
-            seed: options.model_options?.seed,
-            cfgScale: options.model_options?.cfgScale,
+            quality: modelOptions?.quality,
+            width: modelOptions?.width,
+            height: modelOptions?.height,
+            numberOfImages: modelOptions?.numberOfImages,
+            seed: modelOptions?.seed,
+            cfgScale: modelOptions?.cfgScale,
         },
         inPaintingParams: {
             image: sourceImage,
@@ -177,9 +175,7 @@ async function inpaintingPayload(prompt: NovaMessagesPrompt, options: ExecutionO
 }
 
 async function outpaintingPayload(prompt: NovaMessagesPrompt, options: ExecutionOptions): Promise<NovaOutpaintingPayload> {
-    if (options.model_options?._option_id !== "bedrock-nova-canvas") {
-        throw new Error("Invalid model options");
-    }
+    const modelOptions = options.model_options as NovaCanvasOptions;
 
     const images = getAllImagesFromPrompt(prompt.messages);
     if (!images?.length || images.length < 2) {
@@ -191,19 +187,19 @@ async function outpaintingPayload(prompt: NovaMessagesPrompt, options: Execution
     const payload: NovaOutpaintingPayload = {
         taskType: NovaImageGenerationTaskType.OUTPAINTING,
         imageGenerationConfig: {
-            quality: options.model_options?.quality,
-            width: options.model_options?.width,
-            height: options.model_options?.height,
-            numberOfImages: options.model_options?.numberOfImages,
-            seed: options.model_options?.seed,
-            cfgScale: options.model_options?.cfgScale,
+            quality: modelOptions?.quality,
+            width: modelOptions?.width,
+            height: modelOptions?.height,
+            numberOfImages: modelOptions?.numberOfImages,
+            seed: modelOptions?.seed,
+            cfgScale: modelOptions?.cfgScale,
         },
         outPaintingParams: {
             image: sourceImage,
             maskImage: maskImage,
             text: prompt.messages.map(m => m.content.map(c => c.text)).flat().join("\n\n"),
             negativeText: prompt.negative,
-            outPaintingMode: options.model_options?.outPaintingMode ?? "DEFAULT"
+            outPaintingMode: modelOptions?.outPaintingMode ?? "DEFAULT"
         }
     }
 

--- a/drivers/src/bedrock/nova-image-payload.ts
+++ b/drivers/src/bedrock/nova-image-payload.ts
@@ -148,12 +148,12 @@ async function inpaintingPayload(prompt: NovaMessagesPrompt, options: ExecutionO
         throw new Error("Invalid model options");
     }
 
-    const image = getFirstImageFromPrompt(prompt.messages);
-    const maskImage = getFirstImageFromPrompt(prompt.messages);
-
-    if (!image?.source.bytes) {
-        throw new Error("No image found in prompt");
+    const images = getAllImagesFromPrompt(prompt.messages);
+    if (!images?.length || images.length < 2) {
+        throw new Error("2 images are required for inpainting");
     }
+    const sourceImage = images[0];
+    const maskImage = images[1];
 
     const payload: NovaInpaintingPayload = {
         taskType: NovaImageGenerationTaskType.INPAINTING,
@@ -166,8 +166,8 @@ async function inpaintingPayload(prompt: NovaMessagesPrompt, options: ExecutionO
             cfgScale: options.model_options?.cfgScale,
         },
         inPaintingParams: {
-            image: image.source.bytes,
-            maskImage: maskImage?.source.bytes,
+            image: sourceImage,
+            maskImage: maskImage,
             text: prompt.messages.map(m => m.content.map(c => c.text)).flat().join("\n\n"),
             negativeText: prompt.negative
         }
@@ -181,12 +181,12 @@ async function outpaintingPayload(prompt: NovaMessagesPrompt, options: Execution
         throw new Error("Invalid model options");
     }
 
-    const image = getFirstImageFromPrompt(prompt.messages);
-    const maskImage = getFirstImageFromPrompt(prompt.messages);
-
-    if (!image?.source.bytes) {
-        throw new Error("No image found in prompt");
+    const images = getAllImagesFromPrompt(prompt.messages);
+    if (!images?.length || images.length < 2) {
+        throw new Error("2 images are required for outpainting");
     }
+    const sourceImage = images[0];
+    const maskImage = images[1];
 
     const payload: NovaOutpaintingPayload = {
         taskType: NovaImageGenerationTaskType.OUTPAINTING,
@@ -199,8 +199,8 @@ async function outpaintingPayload(prompt: NovaMessagesPrompt, options: Execution
             cfgScale: options.model_options?.cfgScale,
         },
         outPaintingParams: {
-            image: image.source.bytes,
-            maskImage: maskImage?.source.bytes,
+            image: sourceImage,
+            maskImage: maskImage,
             text: prompt.messages.map(m => m.content.map(c => c.text)).flat().join("\n\n"),
             negativeText: prompt.negative,
             outPaintingMode: options.model_options?.outPaintingMode ?? "DEFAULT"


### PR DESCRIPTION
Adds basic inpainting and outpainting support to Amazon Nova Canvas 
and negative prompt support.