### PR TITLE
fix: separate package manager into own group

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -26,5 +26,16 @@
       ],
       "rangeStrategy": "bump"
     },
+    {
+      "groupName": "package manager dependencies",
+      "matchManagers": [
+        "npm"
+      ],
+      "matchPackageNames": [
+        "npm",
+        "pnpm"
+      ],
+      "rangeStrategy": "bump"
+    }
   ],
 }


### PR DESCRIPTION
Differing package manager versions across repos can cause subtle build issues in CI.

Separating them allows other dependency updates to go along unhindered and allows synchronising the update of package managers easier.