### PR TITLE
fix: Mistral embed, use prompt and completion token as fallback

### DIFF
--- a/drivers/src/mistral/index.ts
+++ b/drivers/src/mistral/index.ts
@@ -158,7 +158,7 @@ export class MistralAIDriver extends AbstractDriver<MistralAIDriverOptions, Open
         return {
             values: r.data[0].embedding,
             model,
-            token_count: r.usage.total_tokens ?? r.usage.prompt_tokens + r.usage.completion_tokens,
+            token_count: r.usage.total_tokens || r.usage.prompt_tokens + r.usage.completion_tokens,
         }
     }
 

--- a/drivers/src/mistral/index.ts
+++ b/drivers/src/mistral/index.ts
@@ -158,7 +158,7 @@ export class MistralAIDriver extends AbstractDriver<MistralAIDriverOptions, Open
         return {
             values: r.data[0].embedding,
             model,
-            token_count: r.usage.total_tokens
+            token_count: r.usage.total_tokens ?? r.usage.prompt_tokens + r.usage.completion_tokens,
         }
     }
 


### PR DESCRIPTION
Mistral embed has been returning zero, total tokens in the tests lately. Causing the test to fail.

This adds prompt and completion tokens as a fallback.
Looking at the output manually, we get something like:
usage: {
    prompt_tokens: 3,
    total_tokens: 0,
    completion_tokens: 0,
    request_count: null
  }