### PR TITLE
chore(deps): eventsource upgrade to v3

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -68,7 +68,6 @@
         "url": "git+ssh://git@github.com/vertesia/llumiverse.git"
     },
     "devDependencies": {
-        "@types/eventsource": "^1.1.15",
         "api-fetch-client": "^0.13.0",
         "rimraf": "^6.0.0",
         "ts-dual-module": "^0.6.3",

--- a/drivers/package.json
+++ b/drivers/package.json
@@ -46,7 +46,6 @@
     "togetherai"
   ],
   "devDependencies": {
-    "@types/eventsource": "^1.1.15",
     "dotenv": "^16.4.5",
     "rimraf": "^6.0.0",
     "ts-dual-module": "^0.6.3",
@@ -69,7 +68,7 @@
     "@llumiverse/core": "workspace:*",
     "@smithy/types": "^3.4.2",
     "api-fetch-client": "^0.13.0",
-    "eventsource": "^2.0.2",
+    "eventsource": "^3.0.6",
     "google-auth-library": "^9.14.0",
     "groq-sdk": "^0.15.0",
     "mnemonist": "^0.39.8",

--- a/drivers/src/replicate.ts
+++ b/drivers/src/replicate.ts
@@ -14,7 +14,7 @@ import {
     TrainingOptions,
 } from "@llumiverse/core";
 import { EventStream } from "@llumiverse/core/async";
-import EventSource from "eventsource";
+import { EventSource } from "eventsource";
 import Replicate, { Prediction } from "replicate";
 
 let cachedTrainableModels: AIModel[] | undefined;

--- a/examples/package.json
+++ b/examples/package.json
@@ -19,7 +19,6 @@
     },
     "license": "MIT",
     "devDependencies": {
-        "@types/eventsource": "^1.1.15",
         "@types/json-schema": "^7.0.15",
         "rimraf": "^6.0.0",
         "typescript": "^5.4.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,8 +109,8 @@ importers:
         specifier: ^0.13.0
         version: 0.13.0
       eventsource:
-        specifier: ^2.0.2
-        version: 2.0.2
+        specifier: ^3.0.6
+        version: 3.0.6
       google-auth-library:
         specifier: ^9.14.0
         version: 9.15.1
@@ -1232,9 +1232,13 @@ packages:
     resolution: {integrity: sha512-v0eOBUbiaFojBu2s2NPBfYUoRR9GjcDNvCXVaqEf5vVfpIAh9f8RCo4vXTP8c63QRKCFwoLpMpTdPwwhEKVgzA==}
     engines: {node: '>=14.18'}
 
-  eventsource@2.0.2:
-    resolution: {integrity: sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==}
-    engines: {node: '>=12.0.0'}
+  eventsource-parser@3.0.1:
+    resolution: {integrity: sha512-VARTJ9CYeuQYb0pZEPbzi740OWFgpHe7AYJ2WFZVnUDUQp5Dk2yJUgF36YsZ81cOyxT0QxmXD2EQpapAouzWVA==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.6:
+    resolution: {integrity: sha512-l19WpE2m9hSuyP06+FbuUUf1G+R0SFLrtQfbRb9PRr+oimOfxQhgGCbVaXg5IvZyyTThJsxh6L/srkMiCeBPDA==}
+    engines: {node: '>=18.0.0'}
 
   expect-type@1.1.0:
     resolution: {integrity: sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==}
@@ -3464,7 +3468,11 @@ snapshots:
 
   eventsource-parser@1.1.2: {}
 
-  eventsource@2.0.2: {}
+  eventsource-parser@3.0.1: {}
+
+  eventsource@3.0.6:
+    dependencies:
+      eventsource-parser: 3.0.1
 
   expect-type@1.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,9 +42,6 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1(ajv@8.17.1)
     devDependencies:
-      '@types/eventsource':
-        specifier: ^1.1.15
-        version: 1.1.15
       api-fetch-client:
         specifier: ^0.13.0
         version: 0.13.0
@@ -130,9 +127,6 @@ importers:
         specifier: ^0.33.0
         version: 0.33.0
     devDependencies:
-      '@types/eventsource':
-        specifier: ^1.1.15
-        version: 1.1.15
       dotenv:
         specifier: ^16.4.5
         version: 16.4.7
@@ -161,9 +155,6 @@ importers:
         specifier: ^16.4.5
         version: 16.4.7
     devDependencies:
-      '@types/eventsource':
-        specifier: ^1.1.15
-        version: 1.1.15
       '@types/json-schema':
         specifier: ^7.0.15
         version: 7.0.15
@@ -946,9 +937,6 @@ packages:
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
-
-  '@types/eventsource@1.1.15':
-    resolution: {integrity: sha512-XQmGcbnxUNa06HR3VBVkc9+A2Vpi9ZyLJcdS5dwaQQ/4ZMWFO+5c90FnMUpbtMZwB/FChoYHwuVg8TvkECacTA==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -3170,8 +3158,6 @@ snapshots:
   '@types/caseless@0.12.5': {}
 
   '@types/estree@1.0.6': {}
-
-  '@types/eventsource@1.1.15': {}
 
   '@types/json-schema@7.0.15': {}
 


### PR DESCRIPTION
Upgrades eventsource to new major version. This package is only used in the replicate driver.