### PR TITLE
fix: remove duplicated event on pull_request

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,7 +2,6 @@ name: Build+Test
 
 on:
   push:
-  pull_request:
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Right now all the tests are being executed twice (once for the push event and the other for the pull_request event). Let's just keep one of them.

![image](https://github.com/user-attachments/assets/212fc1b4-421d-4e2f-bc80-3cd12e92e9a4)
