### PR TITLE
fix: Update renovaterc.json5 to have correct package names

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -16,11 +16,12 @@
       ],
       "matchPackageNames": [
         "@azure/openai",
+        "@azure/identity",
         "@google-cloud/**",
         "@huggingface/inference",
-        "@replicate",
-        "@openai",
-        "@groq-sdk",
+        "replicate",
+        "openai",
+        "groq-sdk",
         "@aws-sdk/**",
         "@anthropic-ai/**"
       ],


### PR DESCRIPTION
Some packages I added a @ when it was not needed.
Also adding @azure/identity to model client libraries.