### PR TITLE
fix: get Google Authentication access token for fetch client depending on type

### DIFF
--- a/drivers/src/vertexai/index.ts
+++ b/drivers/src/vertexai/index.ts
@@ -52,8 +52,8 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
             region: this.options.region,
             project: this.options.project,
         }).withAuthCallback(async () => {
-            //@ts-ignore
-            const token = await this.authClient.getAccessToken();
+            const accessTokenResponse = await this.authClient.getAccessToken();
+            const token = typeof accessTokenResponse === 'string' ? accessTokenResponse : accessTokenResponse?.token;
             return `Bearer ${token}`;
         });
     }


### PR DESCRIPTION
This fix is for VertexAI embeddings which uses the fetch client within the VertexAI driver. 
No other functionality is affected.

The authClient is a union type of JSONClient and GoogleAuth, JSONClient itself being a union type.

This meant .getAccessToken could either return a string directly or return a object of form { token: string ,...}. 
Then depending on how llumiverse was used, it would work in some cases and not others.
For example the tests were passed but elsewhere VertexAI embeddings became inaccessible due to the differing authClient.