### PR TITLE
feat: filter foundation models on AWS bedrock based on provider.

### DIFF
--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -545,6 +545,13 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
             fmodels = fmodels.filter(foundationFilter);
         }
 
+        const supportedProviders = ["amazon", "anthropic", "cohere", "ai21", "mistral", "meta", "deepseek"];
+        fmodels = fmodels.filter((m) => {
+            supportedProviders.some((provider) => {
+                m.providerName?.includes(provider) ?? false;
+            });
+        });
+
         const aimodels: AIModel[] = fmodels.map((m) => {
 
             if (!m.modelId) {


### PR DESCRIPTION
Filtering to only supported providers. This is the start of a change of approach to listModels, where listModels becomes a "whitelist" only showing supported models.

There is potential to support a show everything function in the future for diagnostics and ease of use.