### PR TITLE
feat: openai filter listing

### DIFF
--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -277,8 +277,14 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<
     }
 
     async _listModels(filter?: (m: OpenAI.Models.Model) => boolean): Promise<AIModel[]> {
-        let result = await this.service.models.list();
-        const models = filter ? result.data.filter(filter) : result.data;
+        let result = (await this.service.models.list()).data;
+        
+        //Azure OpenAI has additional information about the models
+        result = result.filter((m) => {
+            return (m as any)?.capabilities?.chat_completion ?? false
+        });
+
+        const models = filter ? result.filter(filter) : result;
         return models.map((m) => ({
             id: m.id,
             name: m.id,

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -284,9 +284,12 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<
             return (m as any)?.capabilities?.chat_completion ?? false
         });
 
+        //Some of these use the completions API instead of the chat completions API
+        //Others are for non-text input modalities. Update as required.
+        const wordBlacklist = ["embed", "whisper", "dall-e", "babbage", "davinci", "transcribe", "audio", "moderation", "tts"];
         //OpenAI has very little information, filtering based on name.
         result = result.filter((m) => {
-            return !m.id.includes("embed") && !m.id.includes("dall-e") && !m.id.includes("whisper");
+            return !wordBlacklist.some((word) => m.id.includes(word));
         });
 
         const models = filter ? result.filter(filter) : result;

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -279,25 +279,20 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<
     async _listModels(filter?: (m: OpenAI.Models.Model) => boolean): Promise<AIModel[]> {
         let result = (await this.service.models.list()).data;
 
-        //Some of these use the completions API instead of the chat completions API. They work on Azure regardless, so only filtering for openAI.
-        const nonAzureWordBlacklist = ["dall-e", "babbage", "davinci"];
+        //Some of these use the completions API instead of the chat completions API.
         //Others are for non-text input modalities. Therefore common to both.
-        const commonWordBlacklist = ["embed", "whisper", "transcribe", "audio", "moderation", "tts", "realtime"];
+        const wordBlacklist = ["embed", "whisper", "transcribe", "audio", "moderation", "tts", "realtime", "dall-e", "babbage", "davinci"];
         
         if (this.provider === "azure_openai") {
             //Azure OpenAI has additional information about the models
             result = result.filter((m) => {
                 return !(m as any)?.capabilities?.embeddings;
             });
-        } else {
-            result = result.filter((m) => {
-                return !nonAzureWordBlacklist.some((word) => m.id.includes(word));
-            });
         }
 
         //OpenAI has very little information, filtering based on name.
         result = result.filter((m) => {
-            return !commonWordBlacklist.some((word) => m.id.includes(word));
+            return !wordBlacklist.some((word) => m.id.includes(word));
         });
 
         const models = filter ? result.filter(filter) : result;

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -281,7 +281,7 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<
         
         //Azure OpenAI has additional information about the models
         result = result.filter((m) => {
-            return (m as any)?.capabilities?.chat_completion ?? false
+            return (m as any)?.capabilities?.chat_completion ?? true;
         });
 
         //Some of these use the completions API instead of the chat completions API

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -280,9 +280,11 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<
         let result = (await this.service.models.list()).data;
         
         //Azure OpenAI has additional information about the models
-        result = result.filter((m) => {
-            return (m as any)?.capabilities?.chat_completion ?? true;
-        });
+        if (this.provider === "azure_openai") {
+            result = result.filter((m) => {
+                return !(m as any)?.capabilities?.embeddings;
+            });
+        }
 
         //Some of these use the completions API instead of the chat completions API
         //Others are for non-text input modalities. Update as required.

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -288,7 +288,7 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<
 
         //Some of these use the completions API instead of the chat completions API
         //Others are for non-text input modalities. Update as required.
-        const wordBlacklist = ["embed", "whisper", "dall-e", "babbage", "davinci", "transcribe", "audio", "moderation", "tts"];
+        const wordBlacklist = ["embed", "whisper", "dall-e", "babbage", "davinci", "transcribe", "audio", "moderation", "tts", "realtime"];
         //OpenAI has very little information, filtering based on name.
         result = result.filter((m) => {
             return !wordBlacklist.some((word) => m.id.includes(word));

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -284,8 +284,8 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<
         //Others are for non-text input modalities. Therefore common to both.
         const commonWordBlacklist = ["embed", "whisper", "transcribe", "audio", "moderation", "tts", "realtime"];
         
-        //Azure OpenAI has additional information about the models
         if (this.provider === "azure_openai") {
+            //Azure OpenAI has additional information about the models
             result = result.filter((m) => {
                 return !(m as any)?.capabilities?.embeddings;
             });

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -284,6 +284,11 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<
             return (m as any)?.capabilities?.chat_completion ?? false
         });
 
+        //OpenAI has very little information, filtering based on name.
+        result = result.filter((m) => {
+            return !m.id.includes("embed") && !m.id.includes("dall-e") && !m.id.includes("whisper");
+        });
+
         const models = filter ? result.filter(filter) : result;
         return models.map((m) => ({
             id: m.id,

--- a/drivers/test/all-models.test.ts
+++ b/drivers/test/all-models.test.ts
@@ -90,8 +90,7 @@ if (process.env.OPENAI_API_KEY) {
 }
 
 const AZURE_OPENAI_MODELS = [
-    "gpt-4o",
-    "gpt-3.5-turbo"
+    "gpt-4",
 ]
 
 


### PR DESCRIPTION
Similar to : 
* https://github.com/vertesia/llumiverse/pull/118

However in this instance we are filtering using a word blacklist.
A whitelist is more ideal however there is no practical way to do this for openai.

On Azure, we can use the chat_completion filter to remove models more simply.
Azure docs: https://learn.microsoft.com/en-us/rest/api/azureopenai/models/list?view=rest-azureopenai-2024-10-21&tabs=HTTP#model

Azure has an issue where the specified models are not being used. The test was adjusted to account for this. Will revisit in a different PR.