### PR TITLE
fix: watsonx model options corrected and expanded

### DIFF
--- a/drivers/src/watsonx/index.ts
+++ b/drivers/src/watsonx/index.ts
@@ -39,8 +39,11 @@ export class WatsonxDriver extends AbstractDriver<WatsonxDriverOptions, string> 
             model_id: options.model,
             input: prompt + "\n",
             parameters: {
-                max_new_tokens: options.model_options.max_tokens
-                //time_limit: options.time_limit,
+                max_new_tokens: options.model_options.max_tokens,
+                temperature: options.model_options.temperature,
+                top_k: options.model_options.top_k,
+                top_p: options.model_options.top_p,
+                stop_sequences: options.model_options.stop_sequence,
             },
             project_id: this.projectId,
         }
@@ -70,8 +73,11 @@ export class WatsonxDriver extends AbstractDriver<WatsonxDriverOptions, string> 
             model_id: options.model,
             input: prompt + "\n",
             parameters: {
-                max_new_tokens: options.model_options.temperature,
-                //time_limit: options.time_limit,
+                max_new_tokens: options.model_options.max_tokens,
+                temperature: options.model_options.temperature,
+                top_k: options.model_options.top_k,
+                top_p: options.model_options.top_p,
+                stop_sequences: options.model_options.stop_sequence,
             },
             project_id: this.projectId,
         }

--- a/drivers/src/watsonx/interfaces.ts
+++ b/drivers/src/watsonx/interfaces.ts
@@ -6,6 +6,10 @@ export interface WatsonxTextGenerationPayload {
     parameters: {
         max_new_tokens?: number;
         time_limit?: number;
+        stop_sequences?: string[];
+        temperature?: number;
+        top_k?: number;
+        top_p?: number;
     },
     project_id: string;
 }


### PR DESCRIPTION
There was a typo in the watsonx driver, max_new_tokens was set to temperature.
This caused the execution to always fail when temperature was set to a decimal.

Typo has been fixed and extra model options have been added according to:
https://ibm.github.io/watsonx-ai-node-sdk/interfaces/0_1_x.WatsonXAI.TextGenRequestParameters-1.html