### PR TITLE
feat: OpenAI tools support and structured output for JSON support

### DIFF
--- a/drivers/test/tools.test.ts
+++ b/drivers/test/tools.test.ts
@@ -68,22 +68,20 @@ if (process.env.GOOGLE_PROJECT_ID && process.env.GOOGLE_REGION) {
 //     console.warn("TogetherAI tests are skipped: TOGETHER_API_KEY environment variable is not set");
 // }
 
-// if (process.env.OPENAI_API_KEY) {
-//     drivers.push({
-//         name: "openai",
-//         driver: new OpenAIDriver({
-//             apiKey: process.env.OPENAI_API_KEY as string
-//         }),
-//         models: [
-//             "gpt-4o",
-//             "gpt-3.5-turbo",
-//             "o1-mini",
-//         ]
-//     }
-//     )
-// } else {
-//     console.warn("OpenAI tests are skipped: OPENAI_API_KEY environment variable is not set");
-// }
+if (process.env.OPENAI_API_KEY) {
+    drivers.push({
+        name: "openai",
+        driver: new OpenAIDriver({
+            apiKey: process.env.OPENAI_API_KEY as string
+        }),
+        models: [
+            "gpt-4o",
+        ]
+    }
+    )
+} else {
+    console.warn("OpenAI tests are skipped: OPENAI_API_KEY environment variable is not set");
+}
 
 // const AZURE_OPENAI_MODELS = [
 //     "gpt-4o",


### PR DESCRIPTION
Adds tool support for OpenAI models and moves the JSON formatting over to structured output.
Also adds conversation support.

Structured output is used implicitly when strict:true this include for the tools.
One of it's restrictions is that additionalProperties is not supported and must explicitly be set to false.
This can cause problems for "wildcard" objects that have no properties and just additionalProperties:true, in this instance the schema parser throws an error and we fallback on using strict:false.

In either case, defaults are not supported and are removed.