### PR TITLE
feat: AWS bedrock support for Writer Palmyra X5 and X4

### DIFF
--- a/core/src/options/bedrock.ts
+++ b/core/src/options/bedrock.ts
@@ -2,7 +2,7 @@ import { ModelOptionsInfo, ModelOptions, OptionType, ModelOptionInfoItem } from 
 import { textOptionsFallback } from "../options.js";
 
 // Union type of all Bedrock options
-export type BedrockOptions = NovaCanvasOptions | BaseConverseOptions | BedrockClaudeOptions;
+export type BedrockOptions = NovaCanvasOptions | BaseConverseOptions | BedrockClaudeOptions | BedrockPalmyraOptions;
 
 export interface NovaCanvasOptions {
     _option_id: "bedrock-nova-canvas"
@@ -404,6 +404,12 @@ export function getBedrockOptions(model: string, option?: ModelOptions): ModelOp
                     step: 100,
                 },
                 {
+                    name: "seed",
+                    type: OptionType.numeric,
+                    integer: true,
+                    description: "Random seed for generation"
+                },
+                {
                     name: "frequency_penalty",
                     type: OptionType.numeric,
                     min: -2,
@@ -421,12 +427,6 @@ export function getBedrockOptions(model: string, option?: ModelOptions): ModelOp
                     step: 0.1,
                     description: "A higher presence penalty encourages the model to talk about new topics"
                 },
-                {
-                    name: "seed",
-                    type: OptionType.numeric,
-                    integer: true,
-                    description: "Random seed for generation"
-                }
             ]
             return {
                 _option_id: "bedrock-palmyra",

--- a/core/src/options/bedrock.ts
+++ b/core/src/options/bedrock.ts
@@ -1,6 +1,5 @@
 import { ModelOptionsInfo, ModelOptions, OptionType, ModelOptionInfoItem } from "../types.js";
 import { textOptionsFallback } from "../options.js";
-import { get } from "http";
 
 // Union type of all Bedrock options
 export type BedrockOptions = NovaCanvasOptions | BaseConverseOptions | BedrockClaudeOptions;

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -6,7 +6,7 @@ import { AbstractDriver, AIModel, Completion, CompletionChunkObject, DataSource,
 import { transformAsyncIterator } from "@llumiverse/core/async";
 import { formatNovaPrompt, NovaMessagesPrompt } from "@llumiverse/core/formatters";
 import { LRUCache } from "mnemonist";
-import { BedrockClaudeOptions, NovaCanvasOptions } from "../../../core/src/options/bedrock.js";
+import { BedrockClaudeOptions, BedrockPalmyraOptions, NovaCanvasOptions } from "../../../core/src/options/bedrock.js";
 import { converseConcatMessages, converseRemoveJSONprefill, converseSystemToMessages, fortmatConversePrompt } from "./converse.js";
 import { formatNovaImageGenerationPayload, NovaImageGenerationTaskType } from "./nova-image-payload.js";
 import { forceUploadFile } from "./s3.js";
@@ -363,13 +363,14 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
                 }
             }
         } else if (options.model.includes("palmyra")) {
+            const palmyraOptions = options.model_options as BedrockPalmyraOptions;
             //If last message is "```json", remove it. Model requires the final message to be a user message
             prompt.messages = converseRemoveJSONprefill(prompt.messages);
             additionalField = {
-                //seed: model_options?.seed,
-                presence_penalty: model_options?.presence_penalty,
-                frequency_penalty: model_options?.frequency_penalty,
-                //min_tokens: model_options?.min_tokens,
+                seed: palmyraOptions?.seed,
+                presence_penalty: palmyraOptions?.presence_penalty,
+                frequency_penalty: palmyraOptions?.frequency_penalty,
+                min_tokens: palmyraOptions?.min_tokens,
             }
         }
 

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -545,7 +545,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
             fmodels = fmodels.filter(foundationFilter);
         }
 
-        const supportedProviders = ["amazon", "anthropic", "cohere", "ai21", "mistral", "meta", "deepseek"];
+        const supportedProviders = ["amazon", "anthropic", "cohere", "ai21", "mistral", "meta", "deepseek", "writer"];
         fmodels = fmodels.filter((m) =>
             supportedProviders.some((provider) =>
                 m.providerName?.toLowerCase().includes(provider) ?? false

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -362,6 +362,15 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
                     prompt.messages = converseConcatMessages(prompt.messages);
                 }
             }
+        } else if (options.model.includes("palmyra")) {
+            //If last message is "```json", remove it. Model requires the final message to be a user message
+            prompt.messages = converseRemoveJSONprefill(prompt.messages);
+            additionalField = {
+                //seed: model_options?.seed,
+                presence_penalty: model_options?.presence_penalty,
+                frequency_penalty: model_options?.frequency_penalty,
+                //min_tokens: model_options?.min_tokens,
+            }
         }
 
         //If last message is "```json", add corresponding ``` as a stop sequence.


### PR DESCRIPTION
Adds support for the Writer models Palmyra X5 and X5 on AWS bedrock.

https://aws.amazon.com/about-aws/whats-new/2025/04/writers-palmyra-x5-x4-models-amazon-bedrock/