### PR TITLE
feat: AWS bedrock converse tools support

### DIFF
--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -3,3 +3,4 @@ export * from "./json.js";
 export * from "./stream.js";
 export * from "./types.js";
 export * from "./options.js";
+export * from "./tools.js"

--- a/core/src/tools.ts
+++ b/core/src/tools.ts
@@ -1,4 +1,4 @@
-import { supportsToolUseBedrock } from "./tools/bedrock";
+import { supportsToolUseBedrock } from "./tools/bedrock.js";
 
 //Returns true if the model supports tool use, false if it doesn't, and undefined if unknown
 export function supportsToolUse(provider: string, model?: string, streaming?: boolean): boolean | undefined {

--- a/core/src/tools.ts
+++ b/core/src/tools.ts
@@ -1,0 +1,12 @@
+import { supportsToolUseBedrock } from "./tools/bedrock";
+
+//Returns true if the model supports tool use, false if it doesn't, and undefined if unknown
+export function supportsToolUse(provider: string, model?: string, streaming?: boolean): boolean | undefined {
+    switch (provider) {
+        case "bedrock":
+            return supportsToolUseBedrock(model ?? "", streaming);
+        default:
+            //TODO: Implement a loop through all providers 
+            return undefined;
+    }
+}

--- a/core/src/tools/bedrock.ts
+++ b/core/src/tools/bedrock.ts
@@ -1,0 +1,118 @@
+/**
+ * Models that explicitly do NOT support tool use in Amazon Bedrock
+ */
+const MODELS_WITHOUT_TOOL_USE = [
+    // AI21 models except Jamba 1.5
+    "jamba-instruct",
+    "jurassic-2",
+    // Amazon Titan models
+    "titan-text",
+    "titan-text-express",
+    "titan-text-lite",
+    "titan-text-premier",
+    // Anthropic Claude 2.x and earlier
+    "claude-2",
+    "claude-instant",
+    "claude-1",
+    // Cohere models except Command R
+    "command",
+    "command-light",
+    // DeepSeek models
+    "deepseek-r1",
+    // Meta Llama 2
+    "llama-2",
+    // Meta Llama 3 models not supporting tool use
+    "llama-3.2-1b",
+    "llama-3.2-3b",
+    // Mistral AI Instruct
+    "mistral-instruct"
+];
+
+/**
+ * Models that explicitly do NOT support streaming tool use in Amazon Bedrock
+ * This includes all models without tool use plus models that only support non-streaming tools
+ */
+const MODELS_WITHOUT_STREAMING_TOOL_USE = [
+    // Include all models that don't support tool use at all
+    ...MODELS_WITHOUT_TOOL_USE,
+
+    // Add models that support tool use but NOT streaming tool use
+    // These are models in MODELS_WITH_TOOL_USE but not in MODELS_WITH_STREAMING_TOOL_USE
+    "llama-3.1",
+    "llama-3.2-11b",
+    "llama-3.2-90b",
+    "mistral-large",
+    "mistral-small",
+    "pixtral",
+    "palmyra"
+];
+
+/**
+ * Models that are known to support tool use in Amazon Bedrock
+ */
+const MODELS_WITH_TOOL_USE = [
+    // AI21 Jamba models
+    "jamba-1.5",
+    // Amazon Nova models
+    "nova",
+    // Anthropic Claude 3 models
+    "claude-3",
+    // Cohere Command R models
+    "command-r",
+    // Meta Llama 3.1 and some 3.2 variants
+    "llama-3.1",
+    "llama-3.2-11b",
+    "llama-3.2-90b",
+    // Mistral models
+    "mistral-large",
+    "mistral-small",
+    // Pixtral models
+    "pixtral",
+    // Writer Palmyra models
+    "palmyra"
+];
+
+/**
+ * Models that are known to support streaming tool use in Amazon Bedrock
+ */
+const MODELS_WITH_STREAMING_TOOL_USE = [
+    // AI21 Jamba models
+    "jamba-1.5",
+    // Amazon Nova models
+    "nova",
+    // Anthropic Claude 3 models
+    "claude-3",
+    // Cohere Command R models
+    "command-r"
+];
+
+/**
+ * Determines if a Bedrock model supports tool use based on the model name/ID.
+ * 
+ * @param model The model name or ARN to check for tool use support
+ * @param streaming Optional parameter to check if the model supports streaming tool use
+ * @returns true if the model supports tool use, false if it doesn't, undefined if unknown
+ */
+export function supportsToolUseBedrock(model: string, streaming: boolean = false): boolean | undefined {
+    // Normalize the model string for easier matching
+    const modelLower = model.toLowerCase();
+
+    // Determine which lists to check against based on the streaming parameter
+    const supportList = streaming ? MODELS_WITH_STREAMING_TOOL_USE : MODELS_WITH_TOOL_USE;
+    const noSupportList = streaming ?
+        MODELS_WITHOUT_STREAMING_TOOL_USE :
+        MODELS_WITHOUT_TOOL_USE;
+
+    // First check if the model is explicitly known not to support tool use
+    if (noSupportList.some(unsupportedModel => modelLower.includes(unsupportedModel))) {
+        return false;
+    }
+
+    // Then check if the model is explicitly known to support tool use
+    if (supportList.some(supportedModel => modelLower.includes(supportedModel))) {
+        return true;
+    }
+
+    // If neither match, return undefined (unknown status)
+    return undefined;
+}

--- a/core/src/tools/bedrock.ts
+++ b/core/src/tools/bedrock.ts
@@ -56,7 +56,8 @@ const MODELS_WITH_TOOL_USE = [
     // Amazon Nova models
     "nova",
     // Anthropic Claude 3 models
-    "claude-3",
+    "claude-3-5",
+    "claude-3-7",
     // Cohere Command R models
     "command-r",
     // Meta Llama 3.1 and some 3.2 variants
@@ -81,7 +82,8 @@ const MODELS_WITH_STREAMING_TOOL_USE = [
     // Amazon Nova models
     "nova",
     // Anthropic Claude 3 models
-    "claude-3",
+    "claude-3-5",
+    "claude-3-7",
     // Cohere Command R models
     "command-r"
 ];
@@ -94,6 +96,7 @@ const MODELS_WITH_STREAMING_TOOL_USE = [
  * @returns true if the model supports tool use, false if it doesn't, undefined if unknown
  */
 export function supportsToolUseBedrock(model: string, streaming: boolean = false): boolean | undefined {
+    return undefined;
     // Normalize the model string for easier matching
     const modelLower = model.toLowerCase();
 

--- a/drivers/src/bedrock/converse.ts
+++ b/drivers/src/bedrock/converse.ts
@@ -92,8 +92,23 @@ export async function fortmatConversePrompt(segments: PromptSegment[], schema?: 
     for (const segment of segments) {
         const parts: Message[] = [];
 
+        //Tool response
+        if (segment.role === PromptRole.tool) {
+            parts.push({
+                content: [{
+                    toolResult: {
+                        toolUseId: segment.tool_use_id,
+                        content: [{ text: segment.content }],
+                    }
+                }],
+                role: ConversationRole.USER,
+            });
+            messages = messages.concat(parts);
+            continue;
+        }
+
         //File segments
-        if (segment.files)
+        if (segment.files) {
             for (const f of segment.files) {
                 const source = await f.getStream();
                 let content: ContentBlock[];
@@ -168,6 +183,7 @@ export async function fortmatConversePrompt(segments: PromptSegment[], schema?: 
                     role: roleConversion(segment.role),
                 });
             }
+        }
 
         //Text segments
         if (segment.content) {

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -1,8 +1,15 @@
-import { Bedrock, CreateModelCustomizationJobCommand, FoundationModelSummary, GetModelCustomizationJobCommand, GetModelCustomizationJobCommandOutput, ModelCustomizationJobStatus, StopModelCustomizationJobCommand } from "@aws-sdk/client-bedrock";
+import {
+    Bedrock, CreateModelCustomizationJobCommand, FoundationModelSummary, GetModelCustomizationJobCommand,
+    GetModelCustomizationJobCommandOutput, ModelCustomizationJobStatus, StopModelCustomizationJobCommand
+} from "@aws-sdk/client-bedrock";
 import { BedrockRuntime, ConverseRequest, ConverseResponse, ConverseStreamOutput, InferenceConfiguration, Tool } from "@aws-sdk/client-bedrock-runtime";
 import { S3Client } from "@aws-sdk/client-s3";
 import { AwsCredentialIdentity, Provider } from "@aws-sdk/types";
-import { AbstractDriver, AIModel, Completion, CompletionChunkObject, DataSource, DriverOptions, EmbeddingsOptions, EmbeddingsResult, ExecutionOptions, ExecutionTokenUsage, ImageGeneration, Modalities, PromptOptions, PromptSegment, TextFallbackOptions, ToolDefinition, ToolUse, TrainingJob, TrainingJobStatus, TrainingOptions } from "@llumiverse/core";
+import {
+    AbstractDriver, AIModel, Completion, CompletionChunkObject, DataSource, DriverOptions, EmbeddingsOptions, EmbeddingsResult,
+    ExecutionOptions, ExecutionTokenUsage, ImageGeneration, Modalities, PromptOptions, PromptSegment, supportsToolUse,
+    TextFallbackOptions, ToolDefinition, ToolUse, TrainingJob, TrainingJobStatus, TrainingOptions
+} from "@llumiverse/core";
 import { transformAsyncIterator } from "@llumiverse/core/async";
 import { formatNovaPrompt, NovaMessagesPrompt } from "@llumiverse/core/formatters";
 import { LRUCache } from "mnemonist";
@@ -10,7 +17,6 @@ import { BedrockClaudeOptions, BedrockPalmyraOptions, NovaCanvasOptions } from "
 import { converseConcatMessages, converseRemoveJSONprefill, converseSystemToMessages, fortmatConversePrompt } from "./converse.js";
 import { formatNovaImageGenerationPayload, NovaImageGenerationTaskType } from "./nova-image-payload.js";
 import { forceUploadFile } from "./s3.js";
-import { supportsToolUseBedrock } from "../../../core/src/tools/bedrock.js";
 
 const supportStreamingCache = new LRUCache<string, boolean>(4096);
 
@@ -144,7 +150,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
     };
 
     async requestTextCompletion(prompt: ConverseRequest, options: ExecutionOptions): Promise<Completion> {
-        if (options.tools && options.tools.length > 0 && !supportsToolUseBedrock(options.model, false) === false) {
+        if (options.tools && options.tools.length > 0 && supportsToolUse("bedrock", options.model, false) === false) {
             throw new Error(`Tool use is not supported for this model: ${options.model}`);
         }
 
@@ -265,7 +271,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
     }
 
     async requestTextCompletionStream(prompt: ConverseRequest, options: ExecutionOptions): Promise<AsyncIterable<CompletionChunkObject>> {
-        if (options.tools && options.tools.length > 0 && supportsToolUseBedrock(options.model, true) === false) {
+        if (options.tools && options.tools.length > 0 && supportsToolUse("bedrock", options.model, true) === false) {
             throw new Error(`Tool use with streaming is not supported for this model: ${options.model}`);
         }
 

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -166,14 +166,18 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
             //conversation: conversation,
         };
 
+        //Get tool requests
         if (res.stopReason === "tool_use") {
-            tool_use = res.output?.message?.content?.map(c => {
-                return {
-                    tool_name: c.toolUse?.name ?? "",
-                    tool_input: c.toolUse?.input as any,
-                    id: c.toolUse?.toolUseId ?? "",
-                } satisfies ToolUse;
-            });
+            tool_use = res.output?.message?.content?.reduce((tools: ToolUse[], c) => {
+                if (c.toolUse) {
+                    tools.push({
+                        tool_name: c.toolUse.name ?? "",
+                        tool_input: c.toolUse.input as any,
+                        id: c.toolUse.toolUseId ?? "",
+                    } satisfies ToolUse);
+                }
+                return tools;
+            }, []);
             completion.tool_use = tool_use;
         }
 

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -146,7 +146,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
 
         let conversation = updateConversation(options.conversation as ConverseRequest, prompt);
 
-        const payload = this.preparePayload(prompt, options);
+        const payload = this.preparePayload(conversation, options);
         const executor = this.getExecutor();
 
         const res = await executor.converse({
@@ -163,7 +163,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
         const completion: Completion = {
             ...BedrockDriver.getExtractedExecuton(res, prompt),
             original_response: options.include_original_response ? res : undefined,
-            //conversation: conversation,
+            conversation: conversation,
         };
 
         //Get tool requests

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -420,7 +420,9 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
             }
         }
 
-        return {
+        const tool_defs = getToolDefinitions(options.tools);
+
+        const request: ConverseRequest = {
             messages: prompt.messages,
             system: prompt.system,
             modelId: options.model,
@@ -432,11 +434,17 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
             } satisfies InferenceConfiguration,
             additionalModelRequestFields: {
                 ...additionalField,
-            },
-            toolConfig: {
-                tools: getToolDefinitions(options.tools),
             }
-        } satisfies ConverseRequest;
+        };
+
+        //Only add tools if they are defined
+        if (tool_defs) {
+            request.toolConfig = {
+                tools: tool_defs,
+            }
+        }
+
+        return request;
     }
 
 

--- a/drivers/test/tools.test.ts
+++ b/drivers/test/tools.test.ts
@@ -113,7 +113,7 @@ if (process.env.BEDROCK_REGION) {
         //Use foundation models and inference profiles to test the driver
         models: [
             "anthropic.claude-3-5-sonnet-20240620-v1:0",
-            "us.writer.palmyra-x5-v1:0"
+            //"us.writer.palmyra-x5-v1:0" // Only in us-west-2
         ],
     });
 } else {

--- a/drivers/test/tools.test.ts
+++ b/drivers/test/tools.test.ts
@@ -113,6 +113,7 @@ if (process.env.BEDROCK_REGION) {
         //Use foundation models and inference profiles to test the driver
         models: [
             "anthropic.claude-3-5-sonnet-20240620-v1:0",
+            "us.writer.palmyra-x5-v1:0"
         ],
     });
 } else {

--- a/drivers/test/tools.test.ts
+++ b/drivers/test/tools.test.ts
@@ -104,23 +104,20 @@ if (process.env.OPENAI_API_KEY) {
 // }
 
 
-// if (process.env.BEDROCK_REGION) {
-//     drivers.push({
-//         name: "bedrock",
-//         driver: new BedrockDriver({
-//             region: process.env.BEDROCK_REGION as string,
-//         }),
-//         //Use foundation models and inference profiles to test the driver
-//         models: [
-//             "anthropic.claude-3-5-sonnet-20240620-v1:0",
-//             "us.meta.llama3-3-70b-instruct-v1:0",
-//             "us.amazon.nova-micro-v1:0",
-//             "ai21.jamba-1-5-mini-v1:0",
-//         ],
-//     });
-// } else {
-//     console.warn("Bedrock tests are skipped: BEDROCK_REGION environment variable is not set");
-// }
+if (process.env.BEDROCK_REGION) {
+    drivers.push({
+        name: "bedrock",
+        driver: new BedrockDriver({
+            region: process.env.BEDROCK_REGION as string,
+        }),
+        //Use foundation models and inference profiles to test the driver
+        models: [
+            "anthropic.claude-3-5-sonnet-20240620-v1:0",
+        ],
+    });
+} else {
+    console.warn("Bedrock tests are skipped: BEDROCK_REGION environment variable is not set");
+}
 
 // if (process.env.GROQ_API_KEY) {
 


### PR DESCRIPTION
Implements tools support for AWS bedrock converse text execution.

Does not implement tool support for streaming.

Also implements a supportsToolUse function to query llumiverse if a model supports tools according to:
https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html
We may modify the list, if problems arise with particular models. See Palmyra note.

Returns true, when supported.
Returns false, when known to be unsupported.
Returns undefined otherwise.

Noting, Palmyra does not work with tools at the moment, even though it lists it as supported. This is a Amazon-side issue, Palmyra is mistakenly returning the tool request in the text field.

Llama is noted to possibly require some changes in the AWS docs. These are worded as recommendations, no changes made for now.
