### PR TITLE
fix: sonnet 3.7 thinking mode did not enable properly

### DIFF
--- a/core/src/options/bedrock.ts
+++ b/core/src/options/bedrock.ts
@@ -43,7 +43,7 @@ export interface BedrockPalmyraOptions extends BaseConverseOptions {
     presence_penalty?: number;
 }
 
-function getMaxTokensLimit(model: string, option?: ModelOptions): number | undefined {
+export function getMaxTokensLimit(model: string, option?: ModelOptions): number | undefined {
     // Claude models
     if (model.includes("claude")) {
         if (model.includes("3-7")) {
@@ -54,6 +54,8 @@ function getMaxTokensLimit(model: string, option?: ModelOptions): number | undef
             }
         }
         else if (model.includes("3-5")) {
+            //Bug with AWS Converse Sonnet 3.5, does not effect Haiku.
+            //See https://github.com/boto/boto3/issues/4279
             if (model.includes("claude-3-5-sonnet")) {
                 return 4096;
             }

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -13,7 +13,7 @@ import {
 import { transformAsyncIterator } from "@llumiverse/core/async";
 import { formatNovaPrompt, NovaMessagesPrompt } from "@llumiverse/core/formatters";
 import { LRUCache } from "mnemonist";
-import { BedrockClaudeOptions, BedrockPalmyraOptions, NovaCanvasOptions } from "../../../core/src/options/bedrock.js";
+import { BedrockClaudeOptions, BedrockPalmyraOptions, getMaxTokensLimit, NovaCanvasOptions } from "../../../core/src/options/bedrock.js";
 import { converseConcatMessages, converseRemoveJSONprefill, converseSystemToMessages, fortmatConversePrompt } from "./converse.js";
 import { formatNovaImageGenerationPayload, NovaImageGenerationTaskType } from "./nova-image-payload.js";
 import { forceUploadFile } from "./s3.js";
@@ -311,7 +311,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
                     model_options.max_tokens = thinking ? 128000 : 8192;
                 }
                 additionalField = {
-                    top_k: model_options?.top_k,
+                    ...additionalField,
                     reasoning_config: {
                         type: thinking ? "enabled" : "disabled",
                         budget_tokens: thinking_options?.thinking_budget_tokens,
@@ -326,19 +326,9 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
             }
             //Needs max_tokens to be set
             if (!model_options?.max_tokens) {
-                if (options.model.includes("claude-3-5")) {
-                    model_options.max_tokens = 8192;
-
-                    //Bug with AWS Converse Sonnet 3.5, does not effect Haiku.
-                    //See https://github.com/boto/boto3/issues/4279
-                    if (options.model.includes("claude-3-5-sonnet")) {
-                        model_options.max_tokens = 4096;
-                    }
-                } else {
-                    model_options.max_tokens = 4096;
-                }
+                model_options.max_tokens = getMaxTokensLimit(options.model, model_options);
             }
-            additionalField = { top_k: model_options?.top_k };
+            additionalField = { ...additionalField, top_k: model_options?.top_k };
         } else if (options.model.includes("meta")) {
             //If last message is "```json", remove it. Model requires the final message to be a user message
             prompt.messages = converseRemoveJSONprefill(prompt.messages);


### PR DESCRIPTION
The Claude 3.7 specific options were overwritten by the general claude options, thus removing the thinking mode setting.
Adding a ... spread operator to propagate the options correctly.