### PR TITLE
feat: AWS deepseek support, reverse prefill logic

### DIFF
--- a/drivers/src/bedrock/converse.ts
+++ b/drivers/src/bedrock/converse.ts
@@ -83,6 +83,19 @@ export function converseRemoveJSONprefill(messages: Message[] | undefined): Mess
     return messages ?? [];
 }
 
+export function converseJSONprefill(messages: Message[] | undefined): Message[] {
+    if (!messages) {
+        messages = [];
+    }
+
+    //prefill the json
+    messages.push({
+        content: [{ text: "```json" }],
+        role: ConversationRole.ASSISTANT,
+    });
+    return messages;
+}
+
 export async function fortmatConversePrompt(segments: PromptSegment[], schema?: JSONSchema): Promise<ConverseRequest> {
     //Non-const for concat
     let system: SystemContentBlock[] = [];
@@ -218,12 +231,6 @@ export async function fortmatConversePrompt(segments: PromptSegment[], schema?: 
     if (schema) {
         safety.push({ text: "IMPORTANT: " + getJSONSafetyNotice(schema) });
         system = system.concat(safety);
-
-        //prefill the json
-        messages.push({
-            content: [{ text: "```json" }],
-            role: ConversationRole.ASSISTANT,
-        });
     }
 
     messages = converseConcatMessages(messages);


### PR DESCRIPTION
The only thing stopping "incidental" support of Deepseek and previously Writer Palmyra models was the usage of '''json prefill. 

I am reversing the prefill logic, to not prefill by default, instead only for supported models.

This leaves some models in the if else stack with empty sections. Leaving in the empty sections for better clarity and self-documenting code.