### PR TITLE
fix: model specific type imports under llumiverse/core

### DIFF
--- a/core/src/options.ts
+++ b/core/src/options.ts
@@ -4,6 +4,12 @@ import { getVertexAiOptions } from "./options/vertexai.js";
 import { getOpenAiOptions } from "./options/openai.js";
 import { getGroqOptions } from "./options/groq.js";
 
+//Export types from providers
+export * from "./options/bedrock.js";
+export * from "./options/vertexai.js";
+export * from "./options/openai.js";
+export * from "./options/groq.js";
+
 export interface TextFallbackOptions {
     _option_id: "text-fallback";    //For specific models should be format as "provider-model"
     max_tokens?: number;

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -8,12 +8,12 @@ import { AwsCredentialIdentity, Provider } from "@aws-sdk/types";
 import {
     AbstractDriver, AIModel, Completion, CompletionChunkObject, DataSource, DriverOptions, EmbeddingsOptions, EmbeddingsResult,
     ExecutionOptions, ExecutionTokenUsage, ImageGeneration, Modalities, PromptOptions, PromptSegment,
-    TextFallbackOptions, ToolDefinition, ToolUse, TrainingJob, TrainingJobStatus, TrainingOptions
+    TextFallbackOptions, ToolDefinition, ToolUse, TrainingJob, TrainingJobStatus, TrainingOptions,
+    BedrockClaudeOptions, BedrockPalmyraOptions, getMaxTokensLimit, NovaCanvasOptions
 } from "@llumiverse/core";
 import { transformAsyncIterator } from "@llumiverse/core/async";
 import { formatNovaPrompt, NovaMessagesPrompt } from "@llumiverse/core/formatters";
 import { LRUCache } from "mnemonist";
-import { BedrockClaudeOptions, BedrockPalmyraOptions, getMaxTokensLimit, NovaCanvasOptions } from "../../../core/src/options/bedrock.js";
 import { converseConcatMessages, converseJSONprefill, converseSystemToMessages, fortmatConversePrompt } from "./converse.js";
 import { formatNovaImageGenerationPayload, NovaImageGenerationTaskType } from "./nova-image-payload.js";
 import { forceUploadFile } from "./s3.js";

--- a/drivers/src/bedrock/nova-image-payload.ts
+++ b/drivers/src/bedrock/nova-image-payload.ts
@@ -1,6 +1,5 @@
-import { ExecutionOptions } from "@llumiverse/core";
+import { ExecutionOptions, NovaCanvasOptions } from "@llumiverse/core";
 import { NovaMessage, NovaMessagesPrompt } from "@llumiverse/core/formatters";
-import { NovaCanvasOptions } from "../../../core/src/options/bedrock.js";
 
 function getFirstImageFromPrompt(prompt: NovaMessage[]) {
 

--- a/drivers/src/vertexai/models/claude.ts
+++ b/drivers/src/vertexai/models/claude.ts
@@ -1,8 +1,10 @@
 import * as AnthropicAPI from '@anthropic-ai/sdk';
 import { ContentBlock, ContentBlockParam, Message, TextBlockParam } from "@anthropic-ai/sdk/resources/index.js";
-import { AIModel, Completion, CompletionChunkObject, ExecutionOptions, JSONObject, ModelType, PromptOptions, PromptRole, PromptSegment, readStreamAsBase64, ToolUse } from "@llumiverse/core";
+import {
+    AIModel, Completion, CompletionChunkObject, ExecutionOptions, JSONObject, ModelType,
+    PromptOptions, PromptRole, PromptSegment, readStreamAsBase64, ToolUse, VertexAIClaudeOptions
+} from "@llumiverse/core";
 import { asyncMap } from "@llumiverse/core/async";
-import { VertexAIClaudeOptions } from "../../../../core/src/options/vertexai.js";
 import { VertexAIDriver } from "../index.js";
 import { ModelDefinition } from "../models.js";
 

--- a/drivers/src/vertexai/models/imagen.ts
+++ b/drivers/src/vertexai/models/imagen.ts
@@ -1,4 +1,7 @@
-import { AIModel, Completion, ExecutionOptions, ImageGeneration, Modalities, ModelType, PromptRole, PromptSegment, readStreamAsBase64 } from "@llumiverse/core";
+import {
+    AIModel, Completion, ExecutionOptions, ImageGeneration, Modalities,
+    ModelType, PromptRole, PromptSegment, readStreamAsBase64, ImagenOptions
+} from "@llumiverse/core";
 import { VertexAIDriver } from "../index.js";
 
 const projectId = process.env.GOOGLE_PROJECT_ID;
@@ -11,8 +14,6 @@ const { PredictionServiceClient } = aiplatform.v1;
 
 // Import the helper module for converting arbitrary protobuf.Value objects
 import { helpers } from '@google-cloud/aiplatform';
-import { ImagenOptions } from "../../../../core/src/options/vertexai.js";
-
 interface ImagenBaseReference {
     referenceType: "REFERENCE_TYPE_RAW" | "REFERENCE_TYPE_MASK" | "REFERENCE_TYPE_SUBJECT" |
     "REFERENCE_TYPE_CONTROL" | "REFERENCE_TYPE_STYLE";


### PR DESCRIPTION
Moves model specific type exporting under options.ts, which allows them to be imported from llumiverse/core.

This fixes some build issues with using the relative path imports. (i.e. ../../../core/options/bedrock.js)