### PR TITLE
feat: LLama MaaS support on VertexAI. LLama 4 and 3.

### DIFF
--- a/common/src/options/vertexai.ts
+++ b/common/src/options/vertexai.ts
@@ -282,6 +282,36 @@ export function getVertexAiOptions(model: string, option?: ModelOptions): ModelO
                 ...commonOptions,
             ]
         };
+    } else if (model.includes("llama")) {
+        const max_tokens_limit = getLlamaMaxTokensLimit(model);
+        const excludeOptions = ["max_tokens", "presence_penalty", "frequency_penalty", "stop_sequence"];
+        let commonOptions = textOptionsFallback.options.filter((option) => !excludeOptions.includes(option.name));
+        const max_tokens: ModelOptionInfoItem[] = [{
+            name: SharedOptions.max_tokens, type: OptionType.numeric, min: 1, max: max_tokens_limit,
+            integer: true, step: 200, description: "The maximum number of tokens to generate"
+        }];
+        
+        //Set max temperature to 1.0 for Llama models
+        commonOptions = commonOptions.map((option) => {
+            if (
+                option.name === SharedOptions.temperature &&
+                option.type === OptionType.numeric
+            ) {
+                return {
+                    ...option,
+                    max: 1.0,
+                };
+            }
+            return option;
+        });
+
+        return {
+            _option_id: "text-fallback",
+            options: [
+                ...max_tokens,
+                ...commonOptions,
+            ]
+        };
     }
     return textOptionsFallback;
 }
@@ -314,4 +344,8 @@ function getClaudeMaxTokensLimit(model: string, option?: VertexAIClaudeOptions):
     else {
         return 4096;
     }
+}
+
+function getLlamaMaxTokensLimit(_model: string): number {
+    return 8192;
 }

--- a/core/src/capability/vertexai.ts
+++ b/core/src/capability/vertexai.ts
@@ -30,6 +30,7 @@ const RECORD_FAMILY_CAPABILITIES: Record<string, { input: ModelModalities; outpu
     "claude-3-7": { input: { text: true, image: true, video: false, audio: false, embed: false }, output: { text: true, image: false, video: false, audio: false, embed: false }, tool_support: true },
     "claude-3": { input: { text: true, image: true, video: false, audio: false, embed: false }, output: { text: true, image: false, video: false, audio: false, embed: false }, tool_support: true },
     "claude": { input: { text: true, image: true, video: false, audio: false, embed: false }, output: { text: true, image: false, video: false, audio: false, embed: false }, tool_support: true },
+    "llama": { input: { text: true, image: false, video: false, audio: false, embed: false }, output: { text: true, image: false, video: false, audio: false, embed: false }, tool_support: false },
 };
 
 // Fallback pattern lists for inferring modalities and tool support

--- a/drivers/src/vertexai/index.ts
+++ b/drivers/src/vertexai/index.ts
@@ -2,7 +2,7 @@ import {
     AIModel,
     AbstractDriver,
     Completion,
-    CompletionChunkObject,
+    CompletionChunk,
     DriverOptions,
     EmbeddingsResult,
     ExecutionOptions,
@@ -186,7 +186,7 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
     async requestTextCompletionStream(
         prompt: VertexAIPrompt,
         options: ExecutionOptions,
-    ): Promise<AsyncIterable<CompletionChunkObject>> {
+    ): Promise<AsyncIterable<CompletionChunk>> {
         return getModelDefinition(options.model).requestTextCompletionStream(this, prompt, options);
     }
 

--- a/drivers/src/vertexai/index.ts
+++ b/drivers/src/vertexai/index.ts
@@ -52,8 +52,9 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
     aiplatform: v1beta1.ModelServiceClient | undefined;
     anthropicClient: AnthropicVertex | undefined;
     fetchClient: FetchClient | undefined;
-    modelGarden: v1beta1.ModelGardenServiceClient | undefined;
     googleGenAI: GoogleGenAI | undefined;
+    llamaClient: FetchClient & { region?: string } | undefined;
+    modelGarden: v1beta1.ModelGardenServiceClient | undefined;
 
     authClient: JSONClient | GoogleAuth<JSONClient>;
 
@@ -63,8 +64,9 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
         this.aiplatform = undefined;
         this.anthropicClient = undefined;
         this.fetchClient = undefined
-        this.modelGarden = undefined;
         this.googleGenAI = undefined;
+        this.modelGarden = undefined;
+        this.llamaClient = undefined;
 
         this.authClient = options.googleAuthOptions?.authClient ?? new GoogleAuth(options.googleAuthOptions);
     }
@@ -97,6 +99,24 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
             });
         }
         return this.fetchClient;
+    }
+
+    public getLLamaClient(region: string = "us-central1"): FetchClient {
+        //Lazy initialisation
+        if (!this.llamaClient || this.llamaClient["region"] !== region) {
+            this.llamaClient = createFetchClient({
+                region: region,
+                project: this.options.project,
+                apiVersion: "v1beta1",
+            }).withAuthCallback(async () => {
+                const accessTokenResponse = await this.authClient.getAccessToken();
+                const token = typeof accessTokenResponse === 'string' ? accessTokenResponse : accessTokenResponse?.token;
+                return `Bearer ${token}`;
+            });
+            // Store the region for potential client reuse
+            this.llamaClient["region"] = region;
+        }
+        return this.llamaClient;
     }
 
     public getAnthropicClient(): AnthropicVertex {
@@ -199,14 +219,31 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
         );
 
         //Model Garden Publisher models - Pretrained models
-        const publishers = ["google", "anthropic"];
-        const supportedModels = { google: ["gemini", "imagen"], anthropic: ["claude"] };
+        const publishers = ["google", "anthropic", "meta"];
+        // Meta "maas" models are LLama Models-As-A-Service. Non-maas models are not pre-deployed.
+        const supportedModels = { google: ["gemini", "imagen"], anthropic: ["claude"], meta: ["maas"] };
+        // Additional models not in the listings, but we want to include
+        // TODO: Remove once the models are available in the listing API, or no longer needed
+        const additionalModels = {
+            google: [],
+            anthropic: [],
+            meta: [
+                "llama-4-maverick-17b-128e-instruct-maas",
+                "llama-4-scout-17b-16e-instruct-maas",
+                "llama-3.3-70b-instruct-maas",
+                "llama-3.2-90b-vision-instruct-maas",
+                "llama-3.1-405b-instruct-maas",
+                "llama-3.1-70b-instruct-maas",
+                "llama-3.1-8b-instruct-maas",
+            ],
+        }
 
         //Used to exclude retired models that are still in the listing API but not available for use.
         //Or models we do not support yet
         const unsupportedModelsByPublisher = {
             google: ["gemini-pro", "gemini-ultra"],
             anthropic: [],
+            meta: [],
         };
 
         for (const publisher of publishers) {
@@ -249,6 +286,21 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
                     tool_support: modelCapability.tool_support,
                 } satisfies AIModel<string>;
             }));
+
+            // Add additional models that are not in the listing
+            for (const additionalModel of additionalModels[publisher as keyof typeof additionalModels]) {
+                const publisherModelName = `publishers/${publisher}/models/${additionalModel}`;
+                const modelCapability = getModelCapabilities(additionalModel, "vertexai");
+                models.push({
+                    id: publisherModelName,
+                    name: additionalModel,
+                    provider: 'vertexai',
+                    owner: publisher,
+                    input_modalities: modelModalitiesToArray(modelCapability.input),
+                    output_modalities: modelModalitiesToArray(modelCapability.output),
+                    tool_support: modelCapability.tool_support,
+                } satisfies AIModel<string>);
+            }
         }
 
         //Remove duplicates

--- a/drivers/src/vertexai/models.ts
+++ b/drivers/src/vertexai/models.ts
@@ -1,4 +1,4 @@
-import { AIModel, Completion, CompletionChunkObject, PromptOptions, PromptSegment, ExecutionOptions } from "@llumiverse/core";
+import { AIModel, Completion, PromptOptions, PromptSegment, ExecutionOptions, CompletionChunk } from "@llumiverse/core";
 import { VertexAIDriver , trimModelName} from "./index.js";
 import { GeminiModelDefinition } from "./models/gemini.js";
 import { ClaudeModelDefinition } from "./models/claude.js";
@@ -9,7 +9,7 @@ export interface ModelDefinition<PromptT = any> {
     versions?: string[]; // the versions of the model that are available. ex: ['001', '002']
     createPrompt: (driver: VertexAIDriver, segments: PromptSegment[], options: PromptOptions) => Promise<PromptT>;
     requestTextCompletion: (driver: VertexAIDriver, prompt: PromptT, options: ExecutionOptions) => Promise<Completion>;
-    requestTextCompletionStream: (driver: VertexAIDriver, prompt: PromptT, options: ExecutionOptions) => Promise<AsyncIterable<CompletionChunkObject>>;
+    requestTextCompletionStream: (driver: VertexAIDriver, prompt: PromptT, options: ExecutionOptions) => Promise<AsyncIterable<CompletionChunk>>;
     preValidationProcessing?(result: Completion, options: ExecutionOptions): { result: Completion, options: ExecutionOptions };
 }
 

--- a/drivers/src/vertexai/models.ts
+++ b/drivers/src/vertexai/models.ts
@@ -2,6 +2,7 @@ import { AIModel, Completion, CompletionChunkObject, PromptOptions, PromptSegmen
 import { VertexAIDriver , trimModelName} from "./index.js";
 import { GeminiModelDefinition } from "./models/gemini.js";
 import { ClaudeModelDefinition } from "./models/claude.js";
+import { LLamaModelDefinition } from "./models/llama.js";
 
 export interface ModelDefinition<PromptT = any> {
     model: AIModel;
@@ -21,6 +22,8 @@ export function getModelDefinition(model: string): ModelDefinition {
         return new ClaudeModelDefinition(modelName);
     } else if (publisher?.includes("google")) {
         return new GeminiModelDefinition(modelName);
+    } else if (publisher?.includes("meta")) {
+        return new LLamaModelDefinition(modelName);
     }
 
     //Fallback, assume it is Gemini.

--- a/drivers/src/vertexai/models/llama.ts
+++ b/drivers/src/vertexai/models/llama.ts
@@ -1,0 +1,343 @@
+import {
+    AIModel, Completion, CompletionChunkObject, ExecutionOptions, ModelType,
+    PromptOptions, PromptRole, PromptSegment
+} from "@llumiverse/core";
+import { VertexAIDriver } from "../index.js";
+import { ModelDefinition } from "../models.js";
+
+interface LLamaMessage {
+    role: string;
+    content: string;
+}
+
+interface LLamaPrompt {
+    messages: LLamaMessage[];
+    system?: string;
+}
+
+// // Define specific options for Llama MaaS
+// interface LLamaModelOptions {
+//     temperature?: number;
+//     max_tokens?: number;
+//     top_p?: number;
+//     top_k?: number;
+// }
+
+// // Define specific options for Llama MaaS
+// interface LLamaModelOptions {
+//     temperature?: number;
+//     max_tokens?: number;
+//     top_p?: number;
+//     top_k?: number;
+// }
+
+interface LLamaResponse {
+    id: string;
+    object: string;
+    created: number;
+    model: string;
+    choices: {
+        index: number;
+        message: {
+            role: string;
+            content: string;
+        };
+        finish_reason: string;
+    }[];
+    usage: {
+        prompt_tokens: number;
+        completion_tokens: number;
+        total_tokens: number;
+    };
+}
+
+interface LLamaStreamResponse {
+    id: string;
+    object: string;
+    created: number;
+    model: string;
+    choices: {
+        index: number;
+        delta: {
+            role?: string;
+            content?: string;
+        };
+        finish_reason: string | null;
+    }[];
+}
+
+/**
+ * Convert a stream to a string
+ */
+async function streamToString(stream: any): Promise<string> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) {
+        chunks.push(Buffer.from(chunk));
+    }
+    return Buffer.concat(chunks).toString('utf-8');
+}
+
+/**
+ * Get the max token limit for the model
+ */
+function maxToken(max_tokens: number | undefined, _model: string): number {
+    return max_tokens || 8192;
+}
+
+/**
+ * Update the conversation messages
+ * @param conversation The previous conversation context
+ * @param prompt The new prompt to add to the conversation
+ * @returns Updated conversation with combined messages
+ */
+function updateConversation(conversation: LLamaPrompt | undefined | null, prompt: LLamaPrompt): LLamaPrompt {
+    const baseMessages = conversation ? conversation.messages : [];
+    const baseSystem = conversation?.system || undefined;
+
+    return {
+        messages: [...baseMessages, ...(prompt.messages || [])],
+        system: prompt.system || baseSystem
+    };
+}
+
+export class LLamaModelDefinition implements ModelDefinition<LLamaPrompt> {
+
+    model: AIModel
+
+    constructor(modelId: string) {
+        this.model = {
+            id: modelId,
+            name: modelId,
+            provider: 'vertexai',
+            type: ModelType.Text,
+            can_stream: false,
+        } as AIModel;
+    }
+
+    // Return the appropriate region based on the Llama model
+    getLlamaModelRegion(modelName: string): string {
+        // Llama 4 models are in us-east5, Llama 3.x models are in us-central1
+        if (modelName.startsWith('llama-4')) {
+            return 'us-east5';
+        } else {
+            return 'us-central1';
+        }
+    }
+
+    async createPrompt(_driver: VertexAIDriver, segments: PromptSegment[], _options: PromptOptions): Promise<LLamaPrompt> {
+        const messages: LLamaMessage[] = [];
+        let systemContent = '';
+
+        // Process segments and convert them to the Llama MaaS format
+        for (const segment of segments) {
+            if (segment.role === PromptRole.system) {
+                // Collect system messages
+                systemContent += (systemContent ? "\n" : "") + segment.content;
+                continue;
+            }
+
+            if (segment.role === PromptRole.safety) {
+                // Add safety instructions to system content
+                systemContent += (systemContent ? "\n" : "") + segment.content;
+                continue;
+            }
+
+            // Convert the prompt segments to messages
+            const role = segment.role === PromptRole.assistant ? 'assistant' :
+                segment.role === PromptRole.user ? 'user' : 'user';
+
+            // Combine files and text content if needed
+            let messageContent = segment.content || '';
+
+            // Add any files as text attachments
+            if (segment.files && segment.files.length > 0) {
+                for (const file of segment.files) {
+                    if (file.mime_type?.startsWith("text/")) {
+                        const fileStream = await file.getStream();
+                        const fileContent = await streamToString(fileStream);
+                        messageContent += `\n\nFile content:\n${fileContent}`;
+                    }
+                    // Note: Images are not supported in this basic implementation
+                }
+            }
+
+            messages.push({
+                role: role,
+                content: messageContent
+            });
+        }
+
+        // Return the prompt in the format expected by Llama MaaS API
+        return {
+            messages: messages,
+            system: systemContent || undefined
+        };
+    }
+
+    async requestTextCompletion(driver: VertexAIDriver, prompt: LLamaPrompt, options: ExecutionOptions): Promise<Completion> {
+        const splits = options.model.split("/");
+
+        let conversation = updateConversation(options.conversation as LLamaPrompt, prompt);
+
+        // Extract model name for API payload (without publisher path)
+        const modelName = splits[splits.length - 1];
+
+        // Determine the correct region based on model name
+        const region = this.getLlamaModelRegion(modelName);
+
+        // Build the request payload with the correct model format "meta/MODEL"
+        const payload: Record<string, any> = {
+            model: `meta/${modelName}`,
+            messages: conversation.messages,
+            stream: false,
+            // Add a default max_tokens to avoid truncated responses
+            max_tokens: 1024
+        };
+
+        // Construct the API endpoint for the OpenAI-compatible Llama MaaS API
+        const openaiEndpoint = `endpoints/openapi/chat/completions`;
+
+        // Make the API call using the FetchClient's post method
+        const client = driver.getLLamaClient(region);
+        const result = await client.post(openaiEndpoint, {
+            payload
+        }) as LLamaResponse;
+
+        console.log("Llama response:", result);
+        console.error("Llama response:", JSON.stringify(result, null, 2));
+
+        // Extract response data
+        const assistantMessage = result?.choices[0]?.message;
+        const text = assistantMessage?.content;
+
+        // Update conversation with the response
+        conversation = updateConversation(conversation, {
+            messages: [{
+                role: assistantMessage?.role,
+                content: text
+            }],
+            system: undefined
+        });
+
+        return {
+            chat: [prompt, { role: assistantMessage?.role, content: text }],
+            result: text,
+            token_usage: {
+                prompt: result.usage.prompt_tokens,
+                result: result.usage.completion_tokens,
+                total: result.usage.total_tokens
+            },
+            finish_reason: result.choices[0].finish_reason,
+            conversation
+        } as Completion;
+    }
+
+    async requestTextCompletionStream(driver: VertexAIDriver, prompt: LLamaPrompt, options: ExecutionOptions): Promise<AsyncIterable<CompletionChunkObject>> {
+        const splits = options.model.split("/");
+        const modelName = splits[splits.length - 1];
+
+        // Determine the correct region based on model name
+        const region = this.getLlamaModelRegion(modelName);
+
+        const client = driver.getLLamaClient(region);
+
+        let conversation = updateConversation(options.conversation as LLamaPrompt, prompt);
+
+        // Construct the API endpoint for the OpenAI-compatible Llama MaaS API
+        const openaiEndpoint = `endpoints/openapi/chat/completions`;
+
+        // Build the request payload with the correct model format "meta/MODEL"
+        const payload: Record<string, any> = {
+            model: `meta/${modelName}`,
+            messages: conversation.messages,
+            stream: true,
+        };
+
+        // Add optional parameters if they exist
+        const modelOptions = options.model_options as any;
+        if (modelOptions?.temperature !== undefined) {
+            payload.temperature = modelOptions.temperature;
+        }
+
+        if (modelOptions?.max_tokens !== undefined) {
+            payload.max_tokens = modelOptions.max_tokens;
+        } else {
+            payload.max_tokens = maxToken(undefined, modelName);
+        }
+
+        if (modelOptions?.top_p !== undefined) {
+            payload.top_p = modelOptions.top_p;
+        }
+
+        if (conversation.system) {
+            payload.system = conversation.system;
+        }
+
+        // Make the streaming API call
+        const response = await client.fetch(openaiEndpoint, {
+            method: 'POST',
+            body: JSON.stringify(payload)
+        });
+
+        // Create an async generator to parse the SSE stream
+        const parseStream = async function* () {
+            const reader = response.body!.getReader();
+            const decoder = new TextDecoder('utf-8');
+            let buffer = '';
+
+            while (true) {
+                const { done, value } = await reader.read();
+                if (done) break;
+
+                buffer += decoder.decode(value, { stream: true });
+                const lines = buffer.split('\n');
+                buffer = lines.pop() || '';
+
+                for (const line of lines) {
+                    if (line.startsWith('data:')) {
+                        const data = line.slice(5).trim();
+
+                        if (data === '[DONE]') {
+                            continue;
+                        }
+
+                        try {
+                            const parsedData = JSON.parse(data) as LLamaStreamResponse;
+                            const choice = parsedData.choices[0];
+
+                            yield {
+                                result: choice.delta?.content || '',
+                                token_usage: { prompt: 0, result: 0 }, // Not available in the stream
+                                finish_reason: choice.finish_reason || undefined,
+                            } as CompletionChunkObject;
+                        } catch (error) {
+                            console.error('Error parsing SSE data:', error);
+                        }
+                    }
+                }
+            }
+
+            if (buffer.length > 0) {
+                const lines = buffer.split('\n');
+                for (const line of lines) {
+                    if (line.startsWith('data:') && line.slice(5).trim() !== '[DONE]') {
+                        try {
+                            const parsedData = JSON.parse(line.slice(5).trim()) as LLamaStreamResponse;
+                            const choice = parsedData.choices[0];
+
+                            yield {
+                                result: choice.delta?.content || '',
+                                token_usage: { prompt: 0, result: 0 },
+                                finish_reason: choice.finish_reason || undefined,
+                            } as CompletionChunkObject;
+                        } catch (error) {
+                            console.error('Error parsing SSE data:', error);
+                        }
+                    }
+                }
+            }
+        };
+
+        return parseStream();
+    }
+}

--- a/drivers/src/vertexai/models/llama.ts
+++ b/drivers/src/vertexai/models/llama.ts
@@ -234,6 +234,8 @@ export class LLamaModelDefinition implements ModelDefinition<LLamaPrompt> {
         };
 
         // Make POST request to the Llama MaaS API
+        //TODO: Fix error handling with the fetch client, errors will return a empty response
+        //But not throw any error
         const region = this.getLlamaModelRegion(modelName);
         const client = driver.getLLamaClient(region);
         const openaiEndpoint = `endpoints/openapi/chat/completions`;

--- a/drivers/test/all-models.test.ts
+++ b/drivers/test/all-models.test.ts
@@ -27,10 +27,9 @@ if (process.env.GOOGLE_PROJECT_ID && process.env.GOOGLE_REGION) {
             region: process.env.GOOGLE_REGION as string,
         }),
         models: [
-            //"publishers/google/models/gemini-2.0-flash-lite-001",
+            "publishers/google/models/gemini-2.0-flash-lite-001",
            // "gemini-1.5-flash", //legacy id format
-            //"publishers/anthropic/models/claude-3-7-sonnet",
-            //"publishers/meta/models/llama-4-maverick-17b-128e-instruct-maas",
+            "publishers/anthropic/models/claude-3-7-sonnet",
             "publishers/meta/models/llama-4-scout-17b-16e-instruct-maas"
         ]
     })

--- a/drivers/test/all-models.test.ts
+++ b/drivers/test/all-models.test.ts
@@ -27,9 +27,11 @@ if (process.env.GOOGLE_PROJECT_ID && process.env.GOOGLE_REGION) {
             region: process.env.GOOGLE_REGION as string,
         }),
         models: [
-            "publishers/google/models/gemini-2.0-flash-lite-001",
-            "gemini-1.5-flash", //legacy id format
-            "publishers/anthropic/models/claude-3-7-sonnet",
+            //"publishers/google/models/gemini-2.0-flash-lite-001",
+           // "gemini-1.5-flash", //legacy id format
+            //"publishers/anthropic/models/claude-3-7-sonnet",
+            //"publishers/meta/models/llama-4-maverick-17b-128e-instruct-maas",
+            "publishers/meta/models/llama-4-scout-17b-16e-instruct-maas"
         ]
     })
 } else {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1987,6 +1987,7 @@ packages:
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
 
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}


### PR DESCRIPTION
Adds support for the new LLama MaaS (Models as a Service) API.
This adds support for LLama 4, 3.3, 3.2 and 3.1.

Not all models show up in the Listing API properly, so I've hardcoded them as a list.
Only text input and output support

Included models:
llama-4-maverick-17b-128e-instruct-maas
llama-4-scout-17b-16e-instruct-maas
llama-3.3-70b-instruct-maas
llama-3.2-90b-vision-instruct-maas
llama-3.1-405b-instruct-maas
llama-3.1-70b-instruct-maas
llama-3.1-8b-instruct-maas