### PR TITLE
chore: move model capabilities to llumiverse/common

### DIFF
--- a/common/src/capability.ts
+++ b/common/src/capability.ts
@@ -1,7 +1,7 @@
 import { getModelCapabilitiesBedrock } from "./capability/bedrock.js";
 import { getModelCapabilitiesOpenAI } from "./capability/openai.js";
 import { getModelCapabilitiesVertexAI } from "./capability/vertexai.js";
-import { ModelCapabilities, ModelModalities } from "@llumiverse/common";
+import { ModelCapabilities, ModelModalities } from "./types.js";
 
 export function getModelCapabilities(model: string, provider?: string): ModelCapabilities {
     const capabilities = _getModelCapabilities(model, provider);

--- a/common/src/capability/bedrock.ts
+++ b/common/src/capability/bedrock.ts
@@ -1,4 +1,4 @@
-import { ModelModalities, ModelCapabilities } from "@llumiverse/common";
+import { ModelModalities, ModelCapabilities } from "../types.js";
 
 // Record of Bedrock model capabilities keyed by model ID.
 const RECORD_MODEL_CAPABILITIES: Record<string, ModelCapabilities> = {

--- a/common/src/capability/openai.ts
+++ b/common/src/capability/openai.ts
@@ -1,4 +1,4 @@
-import { ModelModalities } from "@llumiverse/common";
+import { ModelModalities } from "../types.js"; 
 
 // Record of OpenAI model capabilities keyed by model ID (lowercased)
 const RECORD_MODEL_CAPABILITIES: Record<string, { input: ModelModalities; output: ModelModalities; tool_support?: boolean }> = {

--- a/common/src/capability/vertexai.ts
+++ b/common/src/capability/vertexai.ts
@@ -1,4 +1,4 @@
-import { ModelModalities } from "@llumiverse/common";
+import { ModelModalities } from "../types.js";
 
 // Record of Vertex AI model capabilities keyed by model ID (last path segment, lowercased)
 const RECORD_MODEL_CAPABILITIES: Record<string, { input: ModelModalities; output: ModelModalities; tool_support?: boolean }> = {

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -1,4 +1,6 @@
 export * from "./types.js";
+export * from "./capability.js";
+export * from "./options.js";
 
 export * from "./options/bedrock.js";
 export * from "./options/fallback.js";

--- a/common/src/options.ts
+++ b/common/src/options.ts
@@ -1,12 +1,9 @@
-import {
-    getBedrockOptions,
-    textOptionsFallback,
-    getGroqOptions,
-    getOpenAiOptions,
-    getVertexAiOptions,
-    ModelOptions,
-    ModelOptionsInfo
-} from "@llumiverse/common";
+import { getBedrockOptions } from "./options/bedrock.js";
+import { getGroqOptions } from "./options/groq.js";
+import { getOpenAiOptions } from "./options/openai.js";
+import { getVertexAiOptions } from "./options/vertexai.js";
+import { textOptionsFallback } from "./options/fallback.js";
+import { ModelOptionsInfo, ModelOptions } from "./types.js";
 
 export function getOptions(model: string, provider?: string, options?: ModelOptions): ModelOptionsInfo {
     switch (provider?.toLowerCase()) {

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -1,6 +1,4 @@
 export * from "./Driver.js";
 export * from "./json.js";
 export * from "./stream.js";
-export * from "./options.js";
-export * from "./capability.js";
 export * from "@llumiverse/common";


### PR DESCRIPTION
Moving model capabilities to llumiverse/common to provide leaner access to utility functions like supportToolUse