### PR TITLE
feat: refactor bedrock prompt formatting, additional file support for tools

### DIFF
--- a/drivers/src/bedrock/converse.ts
+++ b/drivers/src/bedrock/converse.ts
@@ -226,11 +226,9 @@ export async function formatConversePrompt(segments: PromptSegment[], schema?: J
             if (segment.content) {
                 toolContentBlocks.push({ text: segment.content });
             }
-            //Handle attached files concurrently
-            if (segment.files) {
-                toolContentBlocks.push(
-                    ...await Promise.all(segment.files.map(processFileToToolContentBlock))
-                );
+            //Handle attached files
+            for (const file of segment.files ?? []) {
+                toolContentBlocks.push(await processFileToToolContentBlock(file));
             }
             messages.push({
                 content: [{
@@ -248,11 +246,9 @@ export async function formatConversePrompt(segments: PromptSegment[], schema?: J
             if (segment.content) {
                 contentBlocks.push({ text: segment.content });
             }
-            //Handle attached files concurrently
-            if (segment.files) {
-                contentBlocks.push(
-                    ...await Promise.all(segment.files.map(processFileToContentBlock))
-                );
+            //Handle attached files
+            for (const file of segment.files ?? []) {
+                contentBlocks.push(await processFileToContentBlock(file));
             }
             messages.push({
                 content: contentBlocks,


### PR DESCRIPTION
Refactors bedrock prompt formatting to support more file types for tool use result (the result from the tool the model requested).

Also adds some small fixes such as making sure to add safety messages (there was a bug where they were only added if there was a schema).

Throws an error if the tool use result does not have an `tool_use_id` which is required.