### PR TITLE
feat: VertexAI Claude refactor

### DIFF
--- a/common/src/options/bedrock.ts
+++ b/common/src/options/bedrock.ts
@@ -43,11 +43,11 @@ export interface BedrockPalmyraOptions extends BaseConverseOptions {
     presence_penalty?: number;
 }
 
-export function getMaxTokensLimit(model: string, option?: ModelOptions): number | undefined {
+export function getMaxTokensLimitBedrock(model: string, option?: ModelOptions): number | undefined {
     // Claude models
     if (model.includes("claude")) {
         if (model.includes("-4-")) {
-            if(model.includes("opus-")) {
+            if (model.includes("opus-")) {
                 return 32768;
             }
             return 65536;
@@ -109,7 +109,7 @@ export function getMaxTokensLimit(model: string, option?: ModelOptions): number 
         if (model.includes("command-a")) {
             return 8192;
         }
-        return 4096;   
+        return 4096;
     }
     // Meta models
     else if (model.includes("llama")) {
@@ -214,7 +214,7 @@ export function getBedrockOptions(model: string, option?: ModelOptions): ModelOp
             ]
         };
     } else {
-        const max_tokens_limit = getMaxTokensLimit(model, option);
+        const max_tokens_limit = getMaxTokensLimitBedrock(model, option);
         //Not canvas, i.e normal AWS bedrock converse
         const baseConverseOptions: ModelOptionInfoItem[] = [
             {

--- a/drivers/package.json
+++ b/drivers/package.json
@@ -53,7 +53,7 @@
     "vitest": "^3.0.9"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.52.0",
+    "@anthropic-ai/sdk": "^0.54.0",
     "@anthropic-ai/vertex-sdk": "^0.11.4",
     "@aws-sdk/client-bedrock": "^3.816.0",
     "@aws-sdk/client-bedrock-runtime": "^3.816.0",

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -9,7 +9,7 @@ import {
     AbstractDriver, AIModel, Completion, CompletionChunkObject, DataSource, DriverOptions, EmbeddingsOptions, EmbeddingsResult,
     ExecutionOptions, ExecutionTokenUsage, ImageGeneration, Modalities, PromptOptions, PromptSegment,
     TextFallbackOptions, ToolDefinition, ToolUse, TrainingJob, TrainingJobStatus, TrainingOptions,
-    BedrockClaudeOptions, BedrockPalmyraOptions, getMaxTokensLimit, NovaCanvasOptions,
+    BedrockClaudeOptions, BedrockPalmyraOptions, getMaxTokensLimitBedrock, NovaCanvasOptions,
     modelModalitiesToArray, getModelCapabilities
 } from "@llumiverse/core";
 import { transformAsyncIterator } from "@llumiverse/core/async";
@@ -318,7 +318,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
                     ...additionalField,
                     reasoning_config: {
                         type: thinking ? "enabled" : "disabled",
-                        budget_tokens: thinking_options.thinking_budget_tokens,
+                        budget_tokens: thinking_options.thinking_budget_tokens ?? 1024,
                     }
                 };
                 if (thinking && (thinking_options.thinking_budget_tokens ?? 0) > 64000) {
@@ -330,7 +330,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
             }
             //Needs max_tokens to be set
             if (!model_options.max_tokens) {
-                model_options.max_tokens = getMaxTokensLimit(options.model, model_options);
+                model_options.max_tokens = getMaxTokensLimitBedrock(options.model, model_options);
             }
             additionalField = { ...additionalField, top_k: model_options.top_k };
         } else if (options.model.includes("meta")) {

--- a/drivers/src/vertexai/models/claude.ts
+++ b/drivers/src/vertexai/models/claude.ts
@@ -346,7 +346,7 @@ export class ClaudeModelDefinition implements ModelDefinition<ClaudePrompt> {
 function createPromptFromResponse(response: Message): ClaudePrompt {
     return {
         messages: [{
-            role: PromptRole.assistant,
+            role: response.role,
             content: response.content,
         }],
         system: undefined

--- a/drivers/src/vertexai/models/claude.ts
+++ b/drivers/src/vertexai/models/claude.ts
@@ -57,6 +57,7 @@ function collectAllTextContent(content: ContentBlock[], includeThoughts: boolean
     return textParts.join(includeThoughts ? '\n\n' : '\n');
 }
 
+//Used to get a max_token value when not specified in the model options. Claude requires it to be set.
 function maxToken(option: StatelessExecutionOptions): number {
     const modelOptions = option.model_options as VertexAIClaudeOptions | undefined;
     if (modelOptions && typeof modelOptions.max_tokens === "number") {

--- a/drivers/src/vertexai/models/claude.ts
+++ b/drivers/src/vertexai/models/claude.ts
@@ -1,14 +1,13 @@
-import * as AnthropicAPI from '@anthropic-ai/sdk';
-import { ContentBlock, ContentBlockParam, ImageBlockParam, Message, TextBlockParam } from "@anthropic-ai/sdk/resources/index.js";
+import { ContentBlock, ContentBlockParam, DocumentBlockParam, ImageBlockParam, Message, MessageParam, TextBlockParam, ToolResultBlockParam } from "@anthropic-ai/sdk/resources/index.js";
 import {
-    AIModel, Completion, CompletionChunkObject, ExecutionOptions, JSONObject, ModelType,
-    PromptOptions, PromptRole, PromptSegment, readStreamAsBase64, ToolUse, VertexAIClaudeOptions
+    AIModel, Completion, CompletionChunkObject, ExecutionOptions, getMaxTokensLimitVertexAi, JSONObject, ModelType,
+    PromptRole, PromptSegment, readStreamAsBase64, StatelessExecutionOptions, ToolUse, VertexAIClaudeOptions
 } from "@llumiverse/core";
 import { asyncMap } from "@llumiverse/core/async";
 import { VertexAIDriver } from "../index.js";
 import { ModelDefinition } from "../models.js";
-
-type MessageParam = AnthropicAPI.Anthropic.MessageParam;
+import { MessageCreateParamsBase, MessageCreateParamsNonStreaming, RawMessageStreamEvent } from "@anthropic-ai/sdk/resources/messages.js";
+import { MessageStreamParams } from "@anthropic-ai/sdk/resources/index.mjs";
 
 interface ClaudePrompt {
     messages: MessageParam[];
@@ -35,18 +34,23 @@ function collectTextParts(content: any) {
     return out.join('\n');
 }
 
-function maxToken(max_tokens: number | undefined, model: string): number {
-    const contains = (str: string, substr: string) => str.indexOf(substr) !== -1;
-    if (max_tokens) {
-        return max_tokens;
-    } else if (contains(model, "claude-3-5")) {
-        return 8192;
+function maxToken(option: StatelessExecutionOptions): number {
+    const modelOptions = option.model_options as VertexAIClaudeOptions | undefined;
+    if (modelOptions && typeof modelOptions.max_tokens === "number") {
+        return modelOptions.max_tokens;
     } else {
-        return 4096
+        // Fallback to the default max tokens limit for the model
+        if (option.model.includes('claude-3-7-sonnet')) {
+            return 64000; // Claude 3.7 can go up to 128k with a beta header, but when no max tokens is specified, we default to 64k.
+        }
+        return getMaxTokensLimitVertexAi(option.model);
     }
 }
 
-async function collectImageBlocks(segment: PromptSegment, contentBlocks: ContentBlockParam[]) {
+async function collectFileBlocks(segment: PromptSegment, contentBlocks: ContentBlockParam[], restrictedTypes: boolean = false): Promise<void> {
+    // When restrictedTypes is true, we only allow text files and images.
+    // i.e. output is Array<TextBlockParam | ImageBlockParam>
+    
     for (const file of segment.files || []) {
         if (file.mime_type?.startsWith("image/")) {
             const allowedTypes = ["image/png", "image/jpeg", "image/gif", "image/webp"];
@@ -62,16 +66,18 @@ async function collectImageBlocks(segment: PromptSegment, contentBlocks: Content
                     data: await readStreamAsBase64(await file.getStream()),
                     media_type: mimeType
                 }
-            });
-        } else if (file.mime_type?.startsWith("text/")) {
-            contentBlocks.push({
-                source: {
-                    type: 'text',
-                    data: await readStreamAsBase64(await file.getStream()),
-                    media_type: 'text/plain'
-                },
-                type: 'document'
-            });
+            } satisfies ImageBlockParam);
+        } else if (!restrictedTypes) {
+            if (file.mime_type?.startsWith("text/")) {
+                contentBlocks.push({
+                    source: {
+                        type: 'text',
+                        data: await readStreamAsBase64(await file.getStream()),
+                        media_type: 'text/plain'
+                    },
+                    type: 'document'
+                } satisfies DocumentBlockParam);
+            }
         }
     }
 }
@@ -87,36 +93,37 @@ export class ClaudeModelDefinition implements ModelDefinition<ClaudePrompt> {
             provider: 'vertexai',
             type: ModelType.Text,
             can_stream: true,
-        } as AIModel;
+        } satisfies AIModel;
     }
 
-    async createPrompt(_driver: VertexAIDriver, segments: PromptSegment[], options: PromptOptions): Promise<ClaudePrompt> {
+    async createPrompt(_driver: VertexAIDriver, segments: PromptSegment[], options: ExecutionOptions): Promise<ClaudePrompt> {
         // Convert the prompt to the format expected by the Claude API
-        const systemSegments: TextBlockParam[] = segments
+        const system: TextBlockParam[] = segments
             .filter(segment => segment.role === PromptRole.system)
             .map(segment => ({
                 text: segment.content,
                 type: 'text'
             }));
 
-        const safetySegments: TextBlockParam[] = segments
-            .filter(segment => segment.role === PromptRole.safety)
-            .map(segment => ({
-                text: segment.content,
-                type: 'text'
-            }));
-
         if (options.result_schema) {
+            let schemaText: string = '';
+            if (options.tools && options.tools.length > 0) {
+                schemaText = "When not calling tools, the answer must be a JSON object using the following JSON Schema:\n" + JSON.stringify(options.result_schema);
+            } else {
+                schemaText = "The answer must be a JSON object using the following JSON Schema:\n" + JSON.stringify(options.result_schema);
+            }
+
             const schemaSegments: TextBlockParam = {
-                text: "The answer must be a JSON object using the following JSON Schema:\n" + JSON.stringify(options.result_schema),
+                text: schemaText,
                 type: 'text'
             }
-            safetySegments.push(schemaSegments);
+            system.push(schemaSegments);
         }
 
-        const messages: MessageParam[] = [];
+        let messages: MessageParam[] = [];
+        const safetyMessages: MessageParam[] = [];
         for (const segment of segments) {
-            if (segment.role === PromptRole.system || segment.role === PromptRole.safety) {
+            if (segment.role === PromptRole.system) {
                 continue;
             }
 
@@ -125,38 +132,58 @@ export class ClaudeModelDefinition implements ModelDefinition<ClaudePrompt> {
                     throw new Error("Tool prompt segment must have a tool use ID");
                 }
 
-                const imageBlocks: ImageBlockParam[] = [];
-                await collectImageBlocks(segment, imageBlocks);
+                const contentBlocks: Array<TextBlockParam | ImageBlockParam> = [];
+
+                if (segment.content) {
+                    contentBlocks.push({
+                        type: 'text',
+                        text: segment.content
+                    } satisfies TextBlockParam);
+                }
+                
+                await collectFileBlocks(segment, contentBlocks, true);
 
                 messages.push({
                     role: 'user',
                     content: [{
                         type: 'tool_result',
                         tool_use_id: segment.tool_use_id,
-                        content: [{
-                            type: 'text',
-                            text: segment.content || ''
-                        }, ...imageBlocks]
-                    }]
+                        content: contentBlocks,
+                    } satisfies ToolResultBlockParam]
                 });
 
             } else {
                 const contentBlocks: ContentBlockParam[] = [];
-                collectImageBlocks(segment, contentBlocks);
+                
                 if (segment.content) {
                     contentBlocks.push({
                         type: 'text',
                         text: segment.content
+                    } satisfies TextBlockParam);
+                }
+
+                await collectFileBlocks(segment, contentBlocks);
+
+                if (contentBlocks.length === 0) {
+                    continue; // skip empty segments
+                }
+
+                if (segment.role === PromptRole.safety) {
+                    safetyMessages.push({
+                        role: 'user',
+                        content: contentBlocks
+                    });
+                } else {
+                    messages.push({
+                        role: segment.role === PromptRole.assistant ? 'assistant' : 'user',
+                        content: contentBlocks
                     });
                 }
-                messages.push({
-                    role: segment.role === PromptRole.assistant ? 'assistant' : 'user',
-                    content: contentBlocks
-                });
+                
             }
         }
 
-        const system = systemSegments.concat(safetySegments);
+        messages = messages.concat(safetyMessages);
 
         return {
             messages: messages,
@@ -166,9 +193,6 @@ export class ClaudeModelDefinition implements ModelDefinition<ClaudePrompt> {
 
     async requestTextCompletion(driver: VertexAIDriver, prompt: ClaudePrompt, options: ExecutionOptions): Promise<Completion> {
         const client = driver.getAnthropicClient();
-        const splits = options.model.split("/");
-        const modelName = splits[splits.length - 1];
-        options = { ...options, model: modelName };
         options.model_options = options.model_options as VertexAIClaudeOptions;
 
         if (options.model_options?._option_id !== "vertexai-claude") {
@@ -177,23 +201,11 @@ export class ClaudeModelDefinition implements ModelDefinition<ClaudePrompt> {
 
         let conversation = updateConversation(options.conversation as ClaudePrompt, prompt);
 
-        const result = await client.messages.create({
-            ...conversation, // messages, system,
-            tools: options.tools, // we are using the same shape as claude for tools
-            temperature: options.model_options?.temperature,
-            model: modelName,
-            max_tokens: maxToken(options.model_options?.max_tokens, modelName),
-            top_p: options.model_options?.top_p,
-            top_k: options.model_options?.top_k,
-            stop_sequences: options.model_options?.stop_sequence,
-            thinking: options.model_options?.thinking_mode ?
-                {
-                    budget_tokens: options.model_options?.thinking_budget_tokens ?? 1024,
-                    type: "enabled"
-                } : {
-                    type: "disabled"
-                }
-        }) as Message;
+        const { payload, requestOptions } = getClaudePayload(options, conversation);
+        // disable streaming, the create function is overloaded so payload type matters.
+        const nonStreamingPayload: MessageCreateParamsNonStreaming = { ...payload, stream: false };
+
+        const result = await client.messages.create(nonStreamingPayload, requestOptions) satisfies Message;
 
         const text = collectTextParts(result.content);
         const tool_use = collectTools(result.content);
@@ -201,7 +213,6 @@ export class ClaudeModelDefinition implements ModelDefinition<ClaudePrompt> {
         conversation = updateConversation(conversation, createPromptFromResponse(result));
 
         return {
-            chat: [prompt, { role: result.role, content: result.content }],
             result: text ?? '',
             tool_use,
             token_usage: {
@@ -212,51 +223,72 @@ export class ClaudeModelDefinition implements ModelDefinition<ClaudePrompt> {
             // make sure we set finish_reason to the correct value (claude is normally setting this by itself)
             finish_reason: tool_use ? "tool_use" : claudeFinishReason(result?.stop_reason ?? ''),
             conversation
-        } as Completion;
+        } satisfies Completion;
     }
 
     async requestTextCompletionStream(driver: VertexAIDriver, prompt: ClaudePrompt, options: ExecutionOptions): Promise<AsyncIterable<CompletionChunkObject>> {
         const client = driver.getAnthropicClient();
-        const splits = options.model.split("/");
-        const modelName = splits[splits.length - 1];
-        options = { ...options, model: modelName };
-        options.model_options = options.model_options as VertexAIClaudeOptions;
+        const model_options = options.model_options as VertexAIClaudeOptions | undefined;
 
-        if (options.model_options?._option_id !== "vertexai-claude") {
+        if (model_options?._option_id !== "vertexai-claude") {
             driver.logger.warn("Invalid model options", { options: options.model_options });
         }
 
-        const response_stream = await client.messages.stream({
-            ...prompt, // messages, system,
-            tools: options.tools, // we are using the same shape as claude for tools
-            temperature: options.model_options?.temperature,
-            model: modelName,
-            max_tokens: maxToken(options.model_options?.max_tokens, modelName),
-            top_p: options.model_options?.top_p,
-            top_k: options.model_options?.top_k,
-            stop_sequences: options.model_options?.stop_sequence,
-            thinking: options.model_options?.thinking_mode ?
-                {
-                    budget_tokens: options.model_options?.thinking_budget_tokens ?? 1024,
-                    type: "enabled"
-                } : {
-                    type: "disabled"
-                }
-        });
+        const { payload, requestOptions } = getClaudePayload(options, prompt);
+        const streamingPayload: MessageStreamParams = { ...payload, stream: true };
 
-        const stream = asyncMap(response_stream, async (item: any) => {
-            if (item.type == "message_start") {
-                return {
-                    result: '',
-                    token_usage: { prompt: item?.message?.usage?.input_tokens, result: item?.message?.usage?.output_tokens },
-                    finish_reason: undefined,
-                }
+        const response_stream = await client.messages.stream(streamingPayload, requestOptions);
+
+        const stream = asyncMap(response_stream, async (streamEvent: RawMessageStreamEvent) => {
+            console.log(JSON.stringify(streamEvent, null, 2));
+            switch (streamEvent.type) {
+                case "message_start":
+                    return {
+                        result: '',
+                        token_usage: {
+                            prompt: streamEvent.message.usage.input_tokens,
+                            result: streamEvent.message.usage.output_tokens
+                        }
+                    } satisfies CompletionChunkObject;
+
+                case "content_block_delta":
+                    // Handle different delta types
+                    switch (streamEvent.delta.type) {
+                        case "text_delta":
+                            return {
+                                result: streamEvent.delta.text ?? ''
+                            } satisfies CompletionChunkObject;
+                        case "thinking_delta":
+                            if (model_options?.include_thoughts) {
+                                return {
+                                    result: streamEvent.delta.thinking ?? '',
+                                } satisfies CompletionChunkObject;
+                            }
+                            break;
+                        case "signature_delta":
+                            // Signature deltas, signify the end of the thoughts.
+                            if (model_options?.include_thoughts) {
+                                return {
+                                    result: '\n\n', // Double newline for more spacing
+                                } satisfies CompletionChunkObject;
+                            }
+                            break;
+                    }
+                    break;
+                case "message_delta":
+                    return {
+                        result: '',
+                        token_usage: {
+                            result: streamEvent.usage.output_tokens
+                        },
+                        finish_reason: claudeFinishReason(streamEvent.delta.stop_reason ?? undefined),
+                    } satisfies CompletionChunkObject;
             }
+
+            // Default case for all other event types
             return {
-                result: item?.delta?.text ?? '',
-                token_usage: { result: item?.usage?.output_tokens },
-                finish_reason: claudeFinishReason(item?.delta?.stop_reason ?? ''),
-            }
+                result: ''
+            } satisfies CompletionChunkObject;
         });
 
         return stream;
@@ -302,4 +334,44 @@ function updateConversation(conversation: ClaudePrompt | undefined | null, promp
         messages: baseMessages.concat(prompt.messages || []),
         system: baseSystemMessages.concat(prompt.system || [])
     };
+}
+interface RequestOptions {
+    headers?: Record<string, string>;
+}
+
+function getClaudePayload(options: ExecutionOptions, prompt: ClaudePrompt): { payload: MessageCreateParamsBase, requestOptions: RequestOptions | undefined} {
+    const splits = options.model.split("/");
+    const modelName = splits[splits.length - 1];
+    const model_options = options.model_options as VertexAIClaudeOptions;
+
+    // Add beta header for Claude 3.7 models to enable 128k output tokens
+    let requestOptions: RequestOptions | undefined = undefined;
+    if (modelName.includes('claude-3-7-sonnet') && (model_options?.max_tokens ?? 0) > 64000) {
+        requestOptions = {
+            headers: {
+                'anthropic-beta': 'output-128k-2025-02-19'
+            }
+        };
+    }
+
+    const payload = {
+        messages: prompt.messages,
+        system: prompt.system,
+        tools: options.tools, // we are using the same shape as claude for tools
+        temperature: model_options?.temperature,
+        model: modelName,
+        max_tokens: maxToken(options),
+        top_p: model_options?.top_p,
+        top_k: model_options?.top_k,
+        stop_sequences: model_options?.stop_sequence,
+        thinking: model_options?.thinking_mode ?
+            {
+                budget_tokens: model_options?.thinking_budget_tokens ?? 1024,
+                type: "enabled" as const
+            } : {
+                type: "disabled" as const
+            }
+    };
+
+    return { payload, requestOptions };
 }

--- a/drivers/src/vertexai/models/claude.ts
+++ b/drivers/src/vertexai/models/claude.ts
@@ -27,7 +27,7 @@ export function collectTools(content: ContentBlock[]): ToolUse[] | undefined {
     const out: ToolUse[] = [];
 
     for (const block of content) {
-        if (block?.type === "tool_use") {
+        if (block.type === "tool_use") {
             out.push({
                 id: block.id,
                 tool_name: block.name,
@@ -40,12 +40,11 @@ export function collectTools(content: ContentBlock[]): ToolUse[] | undefined {
 }
 
 function collectAllTextContent(content: ContentBlock[], includeThoughts: boolean = false) {
-    const textParts = [];
-    
+    const textParts: string[] = [];
+
+    // First pass: collect thinking blocks
     for (const block of content) {
-        if (block.type === 'text' && block.text) {
-            textParts.push(block.text);
-        } else if (includeThoughts) {
+        if (includeThoughts) {
             if (block.type === 'thinking' && block.thinking) {
                 textParts.push(block.thinking);
             } else if (block.type === 'redacted_thinking' && block.data) {
@@ -53,8 +52,18 @@ function collectAllTextContent(content: ContentBlock[], includeThoughts: boolean
             }
         }
     }
-    
-    return textParts.join(includeThoughts ? '\n\n' : '\n');
+    if (textParts.length > 0) {
+        textParts.push(''); // Create a new line after thinking blocks
+    }
+
+    // Second pass: collect text blocks
+    for (const block of content) {
+        if (block.type === 'text' && block.text) {
+            textParts.push(block.text);
+        }
+    }
+
+    return textParts.join('\n');
 }
 
 //Used to get a max_token value when not specified in the model options. Claude requires it to be set.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,8 +89,8 @@ importers:
   drivers:
     dependencies:
       '@anthropic-ai/sdk':
-        specifier: ^0.52.0
-        version: 0.52.0
+        specifier: ^0.54.0
+        version: 0.54.0
       '@anthropic-ai/vertex-sdk':
         specifier: ^0.11.4
         version: 0.11.4
@@ -198,8 +198,8 @@ importers:
 
 packages:
 
-  '@anthropic-ai/sdk@0.52.0':
-    resolution: {integrity: sha512-d4c+fg+xy9e46c8+YnrrgIQR45CZlAi7PwdzIfDXDM6ACxEZli1/fxhURsq30ZpMZy6LvSkr41jGq5aF5TD7rQ==}
+  '@anthropic-ai/sdk@0.54.0':
+    resolution: {integrity: sha512-xyoCtHJnt/qg5GG6IgK+UJEndz8h8ljzt/caKXmq3LfBF81nC/BW6E4x2rOWCZcvsLyVW+e8U5mtIr6UCE/kJw==}
     hasBin: true
 
   '@anthropic-ai/vertex-sdk@0.11.4':
@@ -2599,11 +2599,11 @@ packages:
 
 snapshots:
 
-  '@anthropic-ai/sdk@0.52.0': {}
+  '@anthropic-ai/sdk@0.54.0': {}
 
   '@anthropic-ai/vertex-sdk@0.11.4':
     dependencies:
-      '@anthropic-ai/sdk': 0.52.0
+      '@anthropic-ai/sdk': 0.54.0
       google-auth-library: 9.15.1
     transitivePeerDependencies:
       - encoding


### PR DESCRIPTION
Refactors the vertexai claude implementation for better code quality.

Handles the beta header output-128k-2025-02-19 for 128k output window.

Now allows visible thinking output, optionally. Off by default.
Includes support for redacted thinking blocks.