### PR TITLE
fix: explicitly set timeout for Anthropic vertexai

### DIFF
--- a/drivers/src/vertexai/index.ts
+++ b/drivers/src/vertexai/index.ts
@@ -122,6 +122,7 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
         //Lazy initialisation
         if (!this.anthropicClient) {
             this.anthropicClient = new AnthropicVertex({
+                timeout: 20 * 60 * 10000, // Set to 20 minutes, 10 minute default, setting this disables long request error: https://github.com/anthropics/anthropic-sdk-typescript?#long-requests
                 region: "us-east5",
                 projectId: process.env.GOOGLE_PROJECT_ID,
             });


### PR DESCRIPTION
Setting a timeout explicitly disables the long-request error. https://github.com/anthropics/anthropic-sdk-typescript?#long-requests

Also increased it from 10 minutes to 20 minutes.