### PR TITLE
fix: use Uint8Array directly instead of buffer which extends it.

### DIFF
--- a/core/src/stream.ts
+++ b/core/src/stream.ts
@@ -8,7 +8,9 @@ export async function readStreamAsString(stream: ReadableStream): Promise<string
 }
 
 export async function readStreamAsUint8Array(stream: ReadableStream): Promise<Uint8Array> {
-    return _readStreamAsBuffer(stream);
+    // We return a Uint8Array for strict type checking, even though the buffer extends Uint8Array.
+    const buffer = await _readStreamAsBuffer(stream);
+    return new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
 }
 
 async function _readStreamAsBuffer(stream: ReadableStream): Promise<Buffer> {


### PR DESCRIPTION
In the utility function: readStreamAsUint8Array, we returned a buffer, because that is used to get the underlying data, and buffer extends Uint8Array so it passed typescript type checking.

However when using strict type checking (such as in external libraries), this will fail.
So we create a new Uint8Array object to return instead.