### PR TITLE
feat: add prompts to execution errors

### DIFF
--- a/core/src/Driver.ts
+++ b/core/src/Driver.ts
@@ -143,7 +143,10 @@ export abstract class AbstractDriver<OptionsT extends DriverOptions = DriverOpti
 
     async execute(segments: PromptSegment[], options: ExecutionOptions): Promise<ExecutionResponse<PromptT>> {
         const prompt = await this.createPrompt(segments, options);
-        return this._execute(prompt, options);
+        return this._execute(prompt, options).catch((error: any) => {
+            (error as any).prompt = prompt;
+            throw error;
+        });
     }
 
     async _execute(prompt: PromptT, options: ExecutionOptions): Promise<ExecutionResponse<PromptT>> {


### PR DESCRIPTION
## Adds prompt property with the final prompt to execution errors

This allows better user feedback and debugging as it means the user can still get the final prompt processed by llumiverse even when the execution fails.
