### PR TITLE
feat: VertexAI Gemini, throw if finish_reason is not allow listed

### DIFF
--- a/drivers/src/vertexai/models/gemini.ts
+++ b/drivers/src/vertexai/models/gemini.ts
@@ -466,6 +466,12 @@ export function mergeConsecutiveRole(contents: Content[] | undefined): Content[]
     return result;
 }
 
+const validFinishReasons: FinishReason[] = [
+    FinishReason.MAX_TOKENS,
+    FinishReason.STOP,
+    FinishReason.FINISH_REASON_UNSPECIFIED
+]
+
 export class GeminiModelDefinition implements ModelDefinition<GenerateContentPrompt> {
 
     model: AIModel
@@ -660,6 +666,13 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
                 default: finish_reason = candidate.finishReason;
             }
             const content = candidate.content;
+
+            if (candidate.finishReason && !validFinishReasons.includes(candidate.finishReason)) {
+                throw new Error(`Invalid finish reason: ${candidate.finishReason}, `
+                    + `finish message: ${candidate.finishMessage}, `
+                    + `content: ${JSON.stringify(content, null, 2)}, safety: ${JSON.stringify(candidate.safetyRatings, null, 2)}`);
+            }
+
             if (content) {
                 tool_use = collectToolUseParts(content);
 
@@ -669,6 +682,8 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
                 conversation = updateConversation(conversation, [cleanedContent]);
             }
         }
+
+        
 
         if (tool_use) {
             finish_reason = "tool_use";
@@ -704,6 +719,11 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
                         case FinishReason.MAX_TOKENS: finish_reason = "length"; break;
                         case FinishReason.STOP: finish_reason = "stop"; break;
                         default: finish_reason = candidate.finishReason;
+                    }
+                    if (candidate.finishReason && !validFinishReasons.includes(candidate.finishReason)) {
+                        throw new Error(`Invalid finish reason: ${candidate.finishReason}, `
+                            + `finish message: ${candidate.finishMessage}, `
+                            + `content: ${JSON.stringify(candidate.content, null, 2)}, safety: ${JSON.stringify(candidate.safetyRatings, null, 2)}`);
                     }
                     if (candidate.content?.role === 'model') {
                         const text = collectTextParts(candidate.content);

--- a/drivers/src/vertexai/models/gemini.ts
+++ b/drivers/src/vertexai/models/gemini.ts
@@ -466,7 +466,7 @@ export function mergeConsecutiveRole(contents: Content[] | undefined): Content[]
     return result;
 }
 
-const validFinishReasons: FinishReason[] = [
+const supportedFinishReasons: FinishReason[] = [
     FinishReason.MAX_TOKENS,
     FinishReason.STOP,
     FinishReason.FINISH_REASON_UNSPECIFIED
@@ -667,8 +667,8 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
             }
             const content = candidate.content;
 
-            if (candidate.finishReason && !validFinishReasons.includes(candidate.finishReason)) {
-                throw new Error(`Invalid finish reason: ${candidate.finishReason}, `
+            if (candidate.finishReason && !supportedFinishReasons.includes(candidate.finishReason)) {
+                throw new Error(`Unsupported finish reason: ${candidate.finishReason}, `
                     + `finish message: ${candidate.finishMessage}, `
                     + `content: ${JSON.stringify(content, null, 2)}, safety: ${JSON.stringify(candidate.safetyRatings, null, 2)}`);
             }
@@ -720,8 +720,8 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
                         case FinishReason.STOP: finish_reason = "stop"; break;
                         default: finish_reason = candidate.finishReason;
                     }
-                    if (candidate.finishReason && !validFinishReasons.includes(candidate.finishReason)) {
-                        throw new Error(`Invalid finish reason: ${candidate.finishReason}, `
+                    if (candidate.finishReason && !supportedFinishReasons.includes(candidate.finishReason)) {
+                        throw new Error(`Unsupported finish reason: ${candidate.finishReason}, `
                             + `finish message: ${candidate.finishMessage}, `
                             + `content: ${JSON.stringify(candidate.content, null, 2)}, safety: ${JSON.stringify(candidate.safetyRatings, null, 2)}`);
                     }


### PR DESCRIPTION
Throw for all finish reasons other than:
stop,
max_tokens
unspecified


The initial impetus for this was "MALFORMED_FUNCTION_CALL" which means the model generation of the function call did not satisfy Google's parser, and thus trying to act on this function call is somewhat futile.

By throwing an error, dependant software can retry based on the error rather than checking for a model specific finish reason.
