### PR TITLE
fix: VertexAI Imagen and Anthropic use project from options

### DIFF
--- a/drivers/src/vertexai/index.ts
+++ b/drivers/src/vertexai/index.ts
@@ -124,7 +124,7 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
             this.anthropicClient = new AnthropicVertex({
                 timeout: 20 * 60 * 10000, // Set to 20 minutes, 10 minute default, setting this disables long request error: https://github.com/anthropics/anthropic-sdk-typescript?#long-requests
                 region: "us-east5",
-                projectId: process.env.GOOGLE_PROJECT_ID,
+                projectId: this.options.project,
             });
         }
         return this.anthropicClient;

--- a/drivers/src/vertexai/models/imagen.ts
+++ b/drivers/src/vertexai/models/imagen.ts
@@ -4,7 +4,6 @@ import {
 } from "@llumiverse/core";
 import { VertexAIDriver } from "../index.js";
 
-const projectId = process.env.GOOGLE_PROJECT_ID;
 const location = 'us-central1';
 
 import aiplatform, { protos } from '@google-cloud/aiplatform';
@@ -354,7 +353,7 @@ export class ImagenModelDefinition {
         const modelName = options.model.split("/").pop() ?? '';
 
         // Configure the parent resource
-        const endpoint = `projects/${projectId}/locations/${location}/publishers/google/models/${modelName}`;
+        const endpoint = `projects/${driver.options.project}/locations/${location}/publishers/google/models/${modelName}`;
 
         const instanceValue = helpers.toValue(prompt);
         if (!instanceValue) {


### PR DESCRIPTION
VertexAI Imagen and Anthropic were mistakenly using the project from the env file instead of the driver options.