### PR TITLE
chore: drop Node 18 and Node 20 support

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: 22.x
     steps:
       - uses: actions/checkout@main
       - uses: pnpm/action-setup@v4

--- a/drivers/README.md
+++ b/drivers/README.md
@@ -28,7 +28,7 @@ New capabilities and platform can easily be added by creating a new driver for t
 
 ## Requirements
 
-* node v18+, or bun 1.0+
+* node v22+, or bun 1.0+
 
 ## Installation 
 


### PR DESCRIPTION
Many dependencies are dropping Node 18 support, we definitely do not support it.

Node 20, we are not using or testing it, better to just remove it.