### PR TITLE
fix: bedrock only accepts non empty toolConfig array

### DIFF
--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -540,8 +540,8 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
             }
         };
 
-        //Only add tools if they are defined
-        if (tool_defs) {
+        //Only add tools if they are defined and not empty
+        if (tool_defs?.length) {
             request.toolConfig = {
                 tools: tool_defs,
             }


### PR DESCRIPTION
Ensure that tool configuration is only added when the tool array is defined and not empty. 