### PR TITLE
feat: CompletionResult[] type for Completion.result and nano-banana support

### DIFF
--- a/common/src/capability.ts
+++ b/common/src/capability.ts
@@ -5,6 +5,13 @@ import { getModelCapabilitiesVertexAI } from "./capability/vertexai.js";
 import { ModelCapabilities, ModelModalities, Providers } from "./types.js";
 
 export function getModelCapabilities(model: string, provider?: string | Providers): ModelCapabilities {
+    //Check for locations/<location>/ prefix and remove it
+    if (model.startsWith("locations/")) {
+        const parts = model.split("/");
+        if (parts.length >= 3) {
+            model = parts.slice(2).join("/");
+        }
+    }
     const capabilities = _getModelCapabilities(model, provider);
     // Globally disable audio and video for all models, as we don't support them yet
     // We also do not support tool use while streaming

--- a/common/src/capability/vertexai.ts
+++ b/common/src/capability/vertexai.ts
@@ -26,6 +26,7 @@ const RECORD_FAMILY_CAPABILITIES: Record<string, { input: ModelModalities; outpu
     "gemini-1.5": { input: { text: true, image: true, video: true, audio: true, embed: false }, output: { text: true, image: false, video: false, audio: false, embed: false }, tool_support: true },
     "gemini-2.0": { input: { text: true, image: true, video: true, audio: true, embed: false }, output: { text: true, image: false, video: false, audio: false, embed: false }, tool_support: true },
     "gemini-2.5": { input: { text: true, image: true, video: true, audio: true, embed: false }, output: { text: true, image: false, video: false, audio: false, embed: false }, tool_support: true },
+    "gemini-2.5-flash-image": { input: { text: true, image: true, video: false, audio: false, embed: false }, output: { text: true, image: true, video: false, audio: false, embed: false }, tool_support: false },
     "imagen-3.0-generate": { input: { text: true, image: false, video: false, audio: false, embed: false }, output: { text: false, image: true, video: false, audio: false, embed: false }, tool_support: false },
     "imagen-3.0-fast-generate": { input: { text: true, image: false, video: false, audio: false, embed: false }, output: { text: false, image: true, video: false, audio: false, embed: false }, tool_support: false },
     "imagen-3.0-capability": { input: { text: true, image: true, video: false, audio: false, embed: false }, output: { text: false, image: true, video: false, audio: false, embed: false }, tool_support: false },

--- a/common/src/options/vertexai.ts
+++ b/common/src/options/vertexai.ts
@@ -291,7 +291,7 @@ function getGeminiOptions(model: string, _option?: ModelOptions): ModelOptionsIn
     }
     const max_tokens_limit = getGeminiMaxTokensLimit(model);
     const excludeOptions = ["max_tokens"];
-    let commonOptions = textOptionsFallback.options.filter((option) => !excludeOptions.includes(option.name));
+    const commonOptions = textOptionsFallback.options.filter((option) => !excludeOptions.includes(option.name));
 
     const max_tokens: ModelOptionInfoItem[] = [{
         name: SharedOptions.max_tokens, type: OptionType.numeric, min: 1, max: max_tokens_limit,
@@ -375,7 +375,7 @@ function getGeminiOptions(model: string, _option?: ModelOptions): ModelOptionsIn
 function getClaudeOptions(model: string, option?: ModelOptions): ModelOptionsInfo {
     const max_tokens_limit = getClaudeMaxTokensLimit(model);
     const excludeOptions = ["max_tokens", "presence_penalty", "frequency_penalty"];
-    let commonOptions = textOptionsFallback.options.filter((option) => !excludeOptions.includes(option.name));
+    const commonOptions = textOptionsFallback.options.filter((option) => !excludeOptions.includes(option.name));
     const max_tokens: ModelOptionInfoItem[] = [{
         name: SharedOptions.max_tokens, type: OptionType.numeric, min: 1, max: max_tokens_limit,
         integer: true, step: 200, description: "The maximum number of tokens to generate"

--- a/common/src/options/vertexai.ts
+++ b/common/src/options/vertexai.ts
@@ -245,6 +245,50 @@ function getImagenOptions(model: string, option?: ModelOptions): ModelOptionsInf
 }
 
 function getGeminiOptions(model: string, _option?: ModelOptions): ModelOptionsInfo {
+    // Special handling for gemini-2.5-flash-image
+    if (model.includes("gemini-2.5-flash-image")) {
+        const options: ModelOptionInfoItem[] = [
+            {
+                name: SharedOptions.temperature,
+                type: OptionType.numeric,
+                min: 0.0,
+                max: 2.0,
+                default: 0.7,
+                step: 0.01,
+                description: "Sampling temperature"
+            },
+            {
+                name: SharedOptions.top_p,
+                type: OptionType.numeric,
+                min: 0.0,
+                max: 1.0,
+                step: 0.01,
+                description: "Nucleus sampling probability"
+            },
+            {
+                name: "candidate_count",
+                type: OptionType.numeric,
+                min: 1,
+                max: 8,
+                default: 1,
+                integer: true,
+                description: "Number of candidates to generate"
+            },
+            {
+                name: SharedOptions.max_tokens,
+                type: OptionType.numeric,
+                min: 1,
+                max: 32768,
+                integer: true,
+                step: 200,
+                description: "Maximum output tokens"
+            }
+        ];
+        return {
+            _option_id: "vertexai-gemini",
+            options
+        };
+    }
     const max_tokens_limit = getGeminiMaxTokensLimit(model);
     const excludeOptions = ["max_tokens"];
     let commonOptions = textOptionsFallback.options.filter((option) => !excludeOptions.includes(option.name));
@@ -260,7 +304,7 @@ function getGeminiOptions(model: string, _option?: ModelOptions): ModelOptionsIn
 
     if (model.includes("-2.5-")) {
         // Gemini 2.5 thinking models
-        
+
         // Set budget token ranges based on model variant
         let budgetMin = -1;
         let budgetMax = 24576;
@@ -287,7 +331,7 @@ function getGeminiOptions(model: string, _option?: ModelOptions): ModelOptionsIn
                 "Range: 128-32768 tokens. " +
                 "Cannot disable thinking - minimum 128 tokens. Set to -1 for dynamic thinking.";
         }
-        
+
         const geminiThinkingOptions: ModelOptionInfoItem[] = [
             {
                 name: "include_thoughts",
@@ -391,7 +435,7 @@ function getLlamaOptions(model: string): ModelOptionsInfo {
         name: SharedOptions.max_tokens, type: OptionType.numeric, min: 1, max: max_tokens_limit,
         integer: true, step: 200, description: "The maximum number of tokens to generate"
     }];
-    
+
     // Set max temperature to 1.0 for Llama models
     commonOptions = commonOptions.map((option) => {
         if (
@@ -416,6 +460,9 @@ function getLlamaOptions(model: string): ModelOptionsInfo {
 }
 
 function getGeminiMaxTokensLimit(model: string): number {
+    if (model.includes("gemini-2.5-flash-image")) {
+        return 32768;
+    }
     if (model.includes("thinking") || model.includes("-2.5-")) {
         return 65536;
     }
@@ -427,7 +474,7 @@ function getGeminiMaxTokensLimit(model: string): number {
 
 function getClaudeMaxTokensLimit(model: string): number {
     if (model.includes("-4-")) {
-        if(model.includes("opus-")) {
+        if (model.includes("opus-")) {
             return 32768;
         }
         return 65536;

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -573,7 +573,7 @@ export interface TrainingOptions {
 
 export interface TrainingPromptOptions {
     segments: PromptSegment[];
-    completion: string | JSONObject;
+    completion: CompletionResult[]
     model: string; // the model to train
     schema?: JSONSchema; // the result schema f any
 }

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -152,7 +152,7 @@ export interface EmbeddingsResult {
 export interface ResultValidationError {
     code: 'validation_error' | 'json_error' | 'content_policy_violation';
     message: string;
-    data?: string;
+    data?: CompletionResult[];
 }
 
 // ============== Result Types ===============
@@ -178,6 +178,17 @@ export interface ImageResult extends BaseResult {
 }
 
 export type CompletionResult = TextResult | JsonResult | ImageResult;
+
+export function resultAsString(result: CompletionResult): string {
+    switch (result.type) {
+        case "text":
+            return result.value;
+        case "json":
+            return JSON.stringify(result.value, null, 2);
+        case "image":
+            return result.value;
+    }
+}
 
 //Internal structure used in driver implementation.
 export interface CompletionChunkObject {
@@ -233,12 +244,6 @@ export interface Completion {
      * The conversation context. This is an opaque structure that can be passed to the next request to restore the context.
      */
     conversation?: unknown;
-}
-
-export interface ImageGeneration {
-
-    images?: string[];
-
 }
 
 export interface ExecutionResponse<PromptT = any> extends Completion {

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -196,7 +196,7 @@ export function parseResultAsJson(results: CompletionResult[]): any {
         //TODO: Handle multiple json type results
     }
 
-    const textResults = results.filter(r => r.type === "text").join();
+    const textResults = results.filter(r => r.type === "text").join("");
     try {
         return JSON.parse(textResults);
     }

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -189,6 +189,23 @@ export function resultAsString(result: CompletionResult): string {
     }
 }
 
+export function parseResultAsJson(results: CompletionResult[]): any {
+    const jsonResults = results.filter(r => r.type === "json");
+    if (jsonResults.length == 1) {
+        return jsonResults[0];
+    } else if (jsonResults.length > 1) {
+        return jsonResults;
+    }
+
+    const textResults = results.filter(r => r.type === "text").join();
+    try {
+        return JSON.parse(textResults);
+    }
+    catch {
+        throw new Error("No JSON result found or failed to parse text");
+    }
+}
+
 //Internal structure used in driver implementation.
 export interface CompletionChunkObject {
     result: CompletionResult[];

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -178,7 +178,10 @@ export interface ImageResult extends BaseResult {
 
 export type CompletionResult = TextResult | JsonResult | ImageResult;
 
-export function resultAsString(result: CompletionResult): string {
+/**
+ * Output as string
+ */
+export function completionResultToString(result: CompletionResult): string {
     switch (result.type) {
         case "text":
             return result.value;
@@ -189,19 +192,40 @@ export function resultAsString(result: CompletionResult): string {
     }
 }
 
-export function parseResultAsJson(results: CompletionResult[]): any {
+/**
+ * Output as JSON, only handles the first JSON result or tries to parse text as JSON
+ * Expects the text to be pure JSON if no JSON result is found
+ * Throws if no JSON result is found or if parsing fails
+ */
+export function parseCompletionResultsToJson(results: CompletionResult[]): any {
     const jsonResults = results.filter(r => r.type === "json");
     if (jsonResults.length >= 1) {
         return jsonResults[0].value;
         //TODO: Handle multiple json type results
     }
 
-    const textResults = results.filter(r => r.type === "text").join("");
+    const textResults = results.filter(r => r.type === "text").join();
+    if (textResults.length === 0) {
+        throw new Error("No JSON result found or failed to parse text");
+    }
     try {
         return JSON.parse(textResults);
     }
     catch {
         throw new Error("No JSON result found or failed to parse text");
+    }
+}
+
+/**
+ * Output as JSON if possible, otherwise as concatenated text
+ * Joins text results with the specified separator, default is empty string
+ * If multiple JSON results are found only the first one is returned
+ */
+export function parseCompletionResults(result: CompletionResult[], separator: string = ""): any {
+    try {
+        return parseCompletionResultsToJson(result);
+    } catch {
+        return result.map(completionResultToString).join(separator);
     }
 }
 

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -64,7 +64,7 @@ export const ProviderList: Record<Providers, ProviderParams> = {
     replicate:
     {
         id: Providers.replicate,
-        name: "Repicate",
+        name: "Replicate",
         requiresApiKey: true,
         requiresEndpointUrl: false,
         supportSearch: true,
@@ -185,9 +185,6 @@ export interface CompletionChunkObject {
     token_usage?: ExecutionTokenUsage;
     finish_reason?: "stop" | "length" | string;
 }
-
-//Internal structure used in driver implementation.
-export type CompletionChunk = CompletionChunkObject | string;
 
 export interface ToolDefinition {
     name: string,

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -155,10 +155,33 @@ export interface ResultValidationError {
     data?: string;
 }
 
-//ResultT should be either JSONObject or string
+// ============== Result Types ===============
+
+export interface BaseResult {
+    type: "text" | "json" | "image";
+    value: any;
+}
+
+export interface TextResult extends BaseResult {
+    type: "text";
+    value: string;
+}
+
+export interface JsonResult extends BaseResult {
+    type: "json";
+    value: JSONValue;
+}
+
+export interface ImageResult extends BaseResult {
+    type: "image";
+    value: string; // base64 data url or real url
+}
+
+export type CompletionResult = TextResult | JsonResult | ImageResult;
+
 //Internal structure used in driver implementation.
-export interface CompletionChunkObject<ResultT = any> {
-    result: ResultT;
+export interface CompletionChunkObject {
+    result: CompletionResult[];
     token_usage?: ExecutionTokenUsage;
     finish_reason?: "stop" | "length" | string;
 }
@@ -185,10 +208,9 @@ export interface ToolUse<ParamsT = JSONObject> {
     tool_input: ParamsT | null
 }
 
-//ResultT should be either JSONObject or string
-export interface Completion<ResultT = any> {
+export interface Completion {
     // the driver impl must return the result and optionally the token_usage. the execution time is computed by the extended abstract driver
-    result: ResultT;
+    result: CompletionResult[];
     token_usage?: ExecutionTokenUsage;
     /**
      * Contains the tools from which the model awaits information.

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -169,7 +169,6 @@ export interface TextResult extends BaseResult {
 
 export interface JsonResult extends BaseResult {
     type: "json";
-    value: JSONValue;
 }
 
 export interface ImageResult extends BaseResult {

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -191,10 +191,9 @@ export function resultAsString(result: CompletionResult): string {
 
 export function parseResultAsJson(results: CompletionResult[]): any {
     const jsonResults = results.filter(r => r.type === "json");
-    if (jsonResults.length == 1) {
-        return jsonResults[0];
-    } else if (jsonResults.length > 1) {
-        return jsonResults;
+    if (jsonResults.length >= 1) {
+        return jsonResults[0].value;
+        //TODO: Handle multiple json type results
     }
 
     const textResults = results.filter(r => r.type === "text").join();

--- a/core/src/CompletionStream.ts
+++ b/core/src/CompletionStream.ts
@@ -23,13 +23,12 @@ export class DefaultCompletionStream<PromptT = any> implements CompletionStream<
         );
 
         const start = Date.now();
-        let stream;
         let finish_reason: string | undefined = undefined;
         let promptTokens: number = 0;
         let resultTokens: number | undefined = undefined;
 
         try {
-            stream = await this.driver.requestTextCompletionStream(this.prompt, this.options);
+            const stream = await this.driver.requestTextCompletionStream(this.prompt, this.options);
             for await (const chunk of stream) {
                 if (chunk) {
                     if (typeof chunk === 'string') {

--- a/core/src/CompletionStream.ts
+++ b/core/src/CompletionStream.ts
@@ -115,7 +115,7 @@ export class DefaultCompletionStream<PromptT = any> implements CompletionStream<
 
         // Return undefined for the ExecutionTokenUsage object if there is nothing to fill it with.
         // Allows for checking for truthy-ness on token_usage, rather than it's internals. For testing and downstream usage.
-        let tokens: ExecutionTokenUsage | undefined = resultTokens ?
+        const tokens: ExecutionTokenUsage | undefined = resultTokens ?
             { prompt: promptTokens, result: resultTokens, total: resultTokens + promptTokens, } : undefined
 
         this.completion = {

--- a/core/src/CompletionStream.ts
+++ b/core/src/CompletionStream.ts
@@ -3,22 +3,20 @@ import { AbstractDriver } from "./Driver.js";
 
 export class DefaultCompletionStream<PromptT = any> implements CompletionStream<PromptT> {
 
-    chunks: string[];
+    chunks: number; // Counter for number of chunks instead of storing strings
     completion: ExecutionResponse<PromptT> | undefined;
 
     constructor(public driver: AbstractDriver<DriverOptions, PromptT>,
         public prompt: PromptT,
         public options: ExecutionOptions) {
-        this.chunks = [];
+        this.chunks = 0;
     }
 
     async *[Symbol.asyncIterator]() {
         // reset state
         this.completion = undefined;
-        if (this.chunks.length > 0) {
-            this.chunks = [];
-        }
-        const chunks = this.chunks;
+        this.chunks = 0;
+        const accumulatedResults: any[] = []; // Accumulate CompletionResult[] from chunks
 
         this.driver.logger.debug(
             `[${this.driver.provider}] Streaming Execution of ${this.options.model} with prompt`,
@@ -35,7 +33,7 @@ export class DefaultCompletionStream<PromptT = any> implements CompletionStream<
             for await (const chunk of stream) {
                 if (chunk) {
                     if (typeof chunk === 'string') {
-                        chunks.push(chunk);
+                        this.chunks++;
                         yield chunk;
                     } else {
                         if (chunk.finish_reason) {                           //Do not replace non-null values with null values
@@ -49,8 +47,66 @@ export class DefaultCompletionStream<PromptT = any> implements CompletionStream<
                             resultTokens = Math.max(resultTokens ?? 0, chunk.token_usage.result ?? 0);
                         }
                         if (chunk.result) {
-                            chunks.push(chunk.result);
-                            yield chunk.result;
+                            // Process each result in the chunk, combining consecutive text/JSON
+                            for (const result of chunk.result) {
+                                // Check if we can combine with the last accumulated result
+                                const lastResult = accumulatedResults[accumulatedResults.length - 1];
+
+                                if (lastResult &&
+                                    ((lastResult.type === 'text' && result.type === 'text') ||
+                                        (lastResult.type === 'json' && result.type === 'json'))) {
+                                    // Combine consecutive text or JSON results
+                                    if (result.type === 'text') {
+                                        lastResult.value += result.value;
+                                    } else if (result.type === 'json') {
+                                        // For JSON, combine the parsed objects directly
+                                        try {
+                                            const lastParsed = lastResult.value;
+                                            const currentParsed = result.value;
+                                            if (lastParsed !== null && typeof lastParsed === 'object' &&
+                                                currentParsed !== null && typeof currentParsed === 'object') {
+                                                const combined = { ...lastParsed, ...currentParsed };
+                                                lastResult.value = combined;
+                                            } else {
+                                                // If not objects, convert to string and concatenate
+                                                const lastStr = typeof lastParsed === 'string' ? lastParsed : JSON.stringify(lastParsed);
+                                                const currentStr = typeof currentParsed === 'string' ? currentParsed : JSON.stringify(currentParsed);
+                                                lastResult.value = lastStr + currentStr;
+                                            }
+                                        } catch {
+                                            // If anything fails, just concatenate string representations
+                                            lastResult.value = String(lastResult.value) + String(result.value);
+                                        }
+                                    }
+                                } else {
+                                    // Add as new result
+                                    accumulatedResults.push(result);
+                                }
+                            }
+
+                            // Convert CompletionResult[] to string for streaming
+                            // Only yield if we have results to show
+                            if (chunk.result.length > 0) {
+                                const resultText = chunk.result.map(r => {
+                                    switch (r.type) {
+                                        case 'text':
+                                            return r.value;
+                                        case 'json':
+                                            return JSON.stringify(r.value);
+                                        case 'image':
+                                            // Show truncated image placeholder for streaming
+                                            const truncatedValue = typeof r.value === 'string' ? r.value.slice(0, 10) : String(r.value).slice(0, 10);
+                                            return `\n[Image: ${truncatedValue}...]\n`;
+                                        default:
+                                            return String((r as any).value || '');
+                                    }
+                                }).join('');
+
+                                if (resultText) {
+                                    this.chunks++;
+                                    yield resultText;
+                                }
+                            }
                         }
                     }
                 }
@@ -60,24 +116,24 @@ export class DefaultCompletionStream<PromptT = any> implements CompletionStream<
             throw error;
         }
 
-        const content = chunks.join('');
-
         // Return undefined for the ExecutionTokenUsage object if there is nothing to fill it with.
-        // Allows for checking for truthyness on token_usage, rather than it's internals. For testing and downstream usage.
+        // Allows for checking for truthy-ness on token_usage, rather than it's internals. For testing and downstream usage.
         let tokens: ExecutionTokenUsage | undefined = resultTokens ?
             { prompt: promptTokens, result: resultTokens, total: resultTokens + promptTokens, } : undefined
 
         this.completion = {
-            result: content,
+            result: accumulatedResults, // Return the accumulated CompletionResult[] instead of text
             prompt: this.prompt,
             execution_time: Date.now() - start,
             token_usage: tokens,
             finish_reason: finish_reason,
-            chunks: chunks.length,
+            chunks: this.chunks,
         }
 
         try {
-            this.driver.validateResult(this.completion, this.options);
+            if (this.completion) {
+                this.driver.validateResult(this.completion, this.options);
+            }
         } catch (error: any) {
             error.prompt = this.prompt;
             throw error;
@@ -103,9 +159,23 @@ export class FallbackCompletionStream<PromptT = any> implements CompletionStream
         );
         try {
             const completion = await this.driver._execute(this.prompt, this.options);
-            const content = typeof completion.result === 'string' ? completion.result : JSON.stringify(completion.result);
+            // For fallback streaming, yield the text content but keep the original completion
+            const content = completion.result.map(r => {
+                switch (r.type) {
+                    case 'text':
+                        return r.value;
+                    case 'json':
+                        return JSON.stringify(r.value);
+                    case 'image':
+                        // Show truncated image placeholder for streaming
+                        const truncatedValue = typeof r.value === 'string' ? r.value.slice(0, 10) : String(r.value).slice(0, 10);
+                        return `[Image: ${truncatedValue}...]`;
+                    default:
+                        return String((r as any).value || '');
+                }
+            }).join('');
             yield content;
-            this.completion = completion;
+            this.completion = completion; // Return the original completion with untouched CompletionResult[]
         } catch (error: any) {
             error.prompt = this.prompt;
             throw error;

--- a/core/src/CompletionStream.ts
+++ b/core/src/CompletionStream.ts
@@ -45,7 +45,7 @@ export class DefaultCompletionStream<PromptT = any> implements CompletionStream<
                             promptTokens = Math.max(promptTokens, chunk.token_usage.prompt ?? 0);
                             resultTokens = Math.max(resultTokens ?? 0, chunk.token_usage.result ?? 0);
                         }
-                        if (chunk.result) {
+                        if (Array.isArray(chunk.result) && chunk.result.length > 0) {
                             // Process each result in the chunk, combining consecutive text/JSON
                             for (const result of chunk.result) {
                                 // Check if we can combine with the last accumulated result
@@ -85,26 +85,24 @@ export class DefaultCompletionStream<PromptT = any> implements CompletionStream<
 
                             // Convert CompletionResult[] to string for streaming
                             // Only yield if we have results to show
-                            if (chunk.result.length > 0) {
-                                const resultText = chunk.result.map(r => {
-                                    switch (r.type) {
-                                        case 'text':
-                                            return r.value;
-                                        case 'json':
-                                            return JSON.stringify(r.value);
-                                        case 'image':
-                                            // Show truncated image placeholder for streaming
-                                            const truncatedValue = typeof r.value === 'string' ? r.value.slice(0, 10) : String(r.value).slice(0, 10);
-                                            return `\n[Image: ${truncatedValue}...]\n`;
-                                        default:
-                                            return String((r as any).value || '');
-                                    }
-                                }).join('');
-
-                                if (resultText) {
-                                    this.chunks++;
-                                    yield resultText;
+                            const resultText = chunk.result.map(r => {
+                                switch (r.type) {
+                                    case 'text':
+                                        return r.value;
+                                    case 'json':
+                                        return JSON.stringify(r.value);
+                                    case 'image':
+                                        // Show truncated image placeholder for streaming
+                                        const truncatedValue = typeof r.value === 'string' ? r.value.slice(0, 10) : String(r.value).slice(0, 10);
+                                        return `\n[Image: ${truncatedValue}...]\n`;
+                                    default:
+                                        return String((r as any).value || '');
                                 }
+                            }).join('');
+
+                            if (resultText) {
+                                this.chunks++;
+                                yield resultText;
                             }
                         }
                     }

--- a/core/src/Driver.ts
+++ b/core/src/Driver.ts
@@ -9,7 +9,7 @@ import { formatTextPrompt } from "./formatters/index.js";
 import {
     AIModel,
     Completion,
-    CompletionChunk,
+    CompletionChunkObject,
     CompletionStream,
     DataSource,
     DriverOptions,
@@ -17,7 +17,6 @@ import {
     EmbeddingsResult,
     ExecutionOptions,
     ExecutionResponse,
-    ImageGeneration,
     Logger,
     Modalities,
     ModelSearchPayload,
@@ -225,9 +224,9 @@ export abstract class AbstractDriver<OptionsT extends DriverOptions = DriverOpti
 
     abstract requestTextCompletion(prompt: PromptT, options: ExecutionOptions): Promise<Completion>;
 
-    abstract requestTextCompletionStream(prompt: PromptT, options: ExecutionOptions): Promise<AsyncIterable<CompletionChunk>>;
+    abstract requestTextCompletionStream(prompt: PromptT, options: ExecutionOptions): Promise<AsyncIterable<CompletionChunkObject>>;
 
-    async requestImageGeneration(_prompt: PromptT, _options: ExecutionOptions): Promise<Completion<ImageGeneration>> {
+    async requestImageGeneration(_prompt: PromptT, _options: ExecutionOptions): Promise<Completion> {
         throw new Error("Image generation not implemented.");
         //Cannot be made abstract, as abstract methods are required in the derived class
     }

--- a/core/src/async.ts
+++ b/core/src/async.ts
@@ -1,5 +1,5 @@
 import type { ServerSentEvent } from "@vertesia/api-fetch-client"
-import { CompletionChunk } from "@llumiverse/common";
+import { CompletionChunkObject } from "@llumiverse/common";
 
 export async function* asyncMap<T, R>(asyncIterable: AsyncIterable<T>, callback: (value: T, index: number) => R) {
     let i = 0;
@@ -18,9 +18,9 @@ export function oneAsyncIterator<T>(value: T): AsyncIterable<T> {
 /**
  * Given a ReadableStream of server sent events, tran
  */
-export function transformSSEStream(stream: ReadableStream<ServerSentEvent>, transform: (data: string) => CompletionChunk): ReadableStream<CompletionChunk> & AsyncIterable<CompletionChunk> {
+export function transformSSEStream(stream: ReadableStream<ServerSentEvent>, transform: (data: string) => CompletionChunkObject): ReadableStream<CompletionChunkObject> & AsyncIterable<CompletionChunkObject> {
     // on node and bun the ReadableStream is an async iterable
-    return stream.pipeThrough(new TransformStream<ServerSentEvent, CompletionChunk>({
+    return stream.pipeThrough(new TransformStream<ServerSentEvent, CompletionChunkObject>({
         transform(event: ServerSentEvent, controller) {
             if (event.type === 'event' && event.data && event.data !== '[DONE]') {
                 try {
@@ -32,7 +32,7 @@ export function transformSSEStream(stream: ReadableStream<ServerSentEvent>, tran
                 }
             }
         }
-    })) as ReadableStream<CompletionChunk> & AsyncIterable<CompletionChunk>;
+    })) satisfies ReadableStream<CompletionChunkObject> & AsyncIterable<CompletionChunkObject>;
 }
 
 export class EventStream<T, ReturnT = any> implements AsyncIterable<T> {

--- a/core/src/validation.ts
+++ b/core/src/validation.ts
@@ -2,7 +2,7 @@ import { Ajv } from 'ajv';
 import addFormats from 'ajv-formats';
 import { extractAndParseJSON } from "./json.js";
 import { resolveField } from './resolver.js';
-import { CompletionResult, resultAsString, ResultValidationError } from "@llumiverse/common";
+import { CompletionResult, completionResultToString, ResultValidationError } from "@llumiverse/common";
 
 
 const ajv = new Ajv({
@@ -28,14 +28,14 @@ export class ValidationError extends Error implements ResultValidationError {
     }
 }
 
-export function validateResult(data: CompletionResult[], schema: Object) : CompletionResult[] {
+export function validateResult(data: CompletionResult[], schema: Object): CompletionResult[] {
     let json;
     if (Array.isArray(data)) {
         const jsonResults = data.filter(r => r.type === "json");
         if (jsonResults.length > 0) {
             json = jsonResults[0].value;
         } else {
-            const stringResult = data.map(resultAsString).join("");
+            const stringResult = data.map(completionResultToString).join("");
             try {
                 json = extractAndParseJSON(stringResult);
             } catch (error: any) {
@@ -76,5 +76,5 @@ export function validateResult(data: CompletionResult[], schema: Object) : Compl
         }
     }
 
-    return [{ type: "json", value: json}];
+    return [{ type: "json", value: json }];
 }

--- a/core/src/validation.ts
+++ b/core/src/validation.ts
@@ -30,16 +30,20 @@ export class ValidationError extends Error implements ResultValidationError {
 
 export function validateResult(data: CompletionResult[], schema: Object) : CompletionResult[] {
     let json;
-    const jsonResults = data.filter(r => r.type === "json");
-    if (jsonResults.length > 0) {
-        json = jsonResults[0].value;
-    } else {
-        const stringResult = data.map(resultAsString).join();
-        try {
-            json = extractAndParseJSON(stringResult);
-        } catch (error: any) {
-            throw new ValidationError("json_error", error.message)
+    if (Array.isArray(data)) {
+        const jsonResults = data.filter(r => r.type === "json");
+        if (jsonResults.length > 0) {
+            json = jsonResults[0].value;
+        } else {
+            const stringResult = data.map(resultAsString).join();
+            try {
+                json = extractAndParseJSON(stringResult);
+            } catch (error: any) {
+                throw new ValidationError("json_error", error.message)
+            }
         }
+    } else {
+        throw new Error("Data to validate must be an array")
     }
 
     const validate = ajv.compile(schema);

--- a/core/src/validation.ts
+++ b/core/src/validation.ts
@@ -2,7 +2,7 @@ import { Ajv } from 'ajv';
 import addFormats from 'ajv-formats';
 import { extractAndParseJSON } from "./json.js";
 import { resolveField } from './resolver.js';
-import { CompletionResult, parseResultAsJson, resultAsString, ResultValidationError } from "@llumiverse/common";
+import { CompletionResult, resultAsString, ResultValidationError } from "@llumiverse/common";
 
 
 const ajv = new Ajv({

--- a/core/src/validation.ts
+++ b/core/src/validation.ts
@@ -35,7 +35,7 @@ export function validateResult(data: CompletionResult[], schema: Object) : Compl
         if (jsonResults.length > 0) {
             json = jsonResults[0].value;
         } else {
-            const stringResult = data.map(resultAsString).join();
+            const stringResult = data.map(resultAsString).join("");
             try {
                 json = extractAndParseJSON(stringResult);
             } catch (error: any) {

--- a/core/test/utils.test.ts
+++ b/core/test/utils.test.ts
@@ -2,8 +2,8 @@ import Ajv from 'ajv';
 import fs, { readFileSync } from 'fs';
 import { describe, expect, test } from "vitest";
 import { extractAndParseJSON, parseJSON } from "../src/json";
-import { CompletionResult, JSONArray, JSONObject, JsonResult } from '@llumiverse/common';
-import { validateResult } from '../src/validation';
+import { JSONArray, JSONObject, JsonResult } from '@llumiverse/common';
+import { validateResult, ValidationError } from '../src/validation';
 import { readDataFile } from './utils';
 
 describe('Core Utilities', () => {
@@ -48,7 +48,7 @@ describe('Core Utilities', () => {
     test('Fail at validating JSON against schema', () => {
         const schema = parseJSON(readDataFile('ciia-schema.json')) as any;
         const content: JsonResult[] = [{ type: "json", value: parseJSON(readDataFile('ciia-data-wrong.json')) }];
-        expect(() => validateResult(content, schema)).toThrowError('validation_error');
+        expect(() => validateResult(content, schema)).toThrowError(ValidationError);
     });
 
     test('JSON parser should coerce types', () => {
@@ -75,14 +75,14 @@ describe('Core Utilities', () => {
     test('JSON parser should not validate if date is wrong', () => {
         const schema = parseJSON(readDataFile('ciia-schema.json')) as any;
         const content: JsonResult[] = [{ type: "json", value: parseJSON(readDataFile('ciia-data-date-wrong.json')) }];
-        expect(() => validateResult(content, schema)).toThrowError('validation_error');
+        expect(() => validateResult(content, schema)).toThrowError(ValidationError);
         console.debug(content, schema);
     });
 
     test('JSON parser should not validate if date is required but null', () => {
         const schema = parseJSON(readDataFile('ciia-schema-date-required.json')) as any;
         const content: JsonResult[] = [{ type: "json", value: parseJSON(readDataFile('ciia-data-date-empty.json')) }];
-        expect(() => validateResult(content, schema)).toThrowError('validation_error');
+        expect(() => validateResult(content, schema)).toThrowError(ValidationError);
         console.debug(content, schema);
     });
 

--- a/core/test/utils.test.ts
+++ b/core/test/utils.test.ts
@@ -1,7 +1,8 @@
 import Ajv from 'ajv';
 import fs, { readFileSync } from 'fs';
 import { describe, expect, test } from "vitest";
-import { JSONArray, JSONObject, extractAndParseJSON, parseJSON } from "../src/json";
+import { extractAndParseJSON, parseJSON } from "../src/json";
+import { CompletionResult, JSONArray, JSONObject, JsonResult } from '@llumiverse/common';
 import { validateResult } from '../src/validation';
 import { readDataFile } from './utils';
 
@@ -29,9 +30,9 @@ describe('Core Utilities', () => {
     });
 
     test('Validate JSON against schema', () => {
-        const ajv = new Ajv({ coerceTypes: true, allowDate: true, strict: false});
+        const ajv = new Ajv({ coerceTypes: true, allowDate: true, strict: false });
         const schema = parseJSON(readDataFile('ciia-schema.json')) as any;
-        const content = parseJSON(readDataFile('ciia-data.json')) as any;
+        const content: JsonResult[] = [{type: "json", value: parseJSON(readDataFile('ciia-data.json'))}];
         const res = validateResult(content, schema);
         console.debug(res);
     });
@@ -39,50 +40,50 @@ describe('Core Utilities', () => {
     test('Validate JSON against complex schema', () => {
         const ajv = new Ajv({ coerceTypes: true, allowDate: true, strict: false});
         const schema = parseJSON(readDataFile('complex-schema.json')) as any;
-        const content = parseJSON(readDataFile('complex-document.json')) as any;
+        const content: JsonResult[] = [{type: "json", value: parseJSON(readDataFile('complex-document.json'))}];
         const res = validateResult(content, schema);
         console.debug(res);
     });
 
     test('Fail at validating JSON against schema', () => {
         const schema = parseJSON(readDataFile('ciia-schema.json')) as any;
-        const content = parseJSON(readDataFile('ciia-data-wrong.json')) as any;   
-        expect((content, schema) => validateResult(content, schema).toThrowError('validation_error')); 
+        const content: JsonResult[] = [{type: "json", value: parseJSON(readDataFile('ciia-data-wrong.json'))}];
+        expect(() => validateResult(content, schema)).toThrowError('validation_error');
      
     });
 
     test('JSON parser should coerce types', () => {
         const schema = parseJSON(readDataFile('ciia-schema.json')) as any;
-        const content = parseJSON(readDataFile('ciia-data-wrong-types.json')) as any;   
+        const content: JsonResult[] = [{type: "json", value: parseJSON(readDataFile('ciia-data-wrong-types.json'))}];
         const res = validateResult(content, schema);
         console.debug(res);
     });
 
     test('JSON parser should validate if date is empty string', () => {
         const schema = parseJSON(readDataFile('ciia-schema.json')) as any;
-        const content = parseJSON(readDataFile('ciia-data-date-empty.json')) as any;   
+        const content: JsonResult[] = [{type: "json", value: parseJSON(readDataFile('ciia-data-date-empty.json'))}];
         const res = validateResult(content, schema);
         console.debug(res);
     });
 
     test('JSON parser should validate if date is null', () => {
         const schema = parseJSON(readDataFile('ciia-schema.json')) as any;
-        const content = parseJSON(readDataFile('ciia-data-date-null.json')) as any;   
+        const content: JsonResult[] = [{type: "json", value: parseJSON(readDataFile('ciia-data-date-null.json'))}];
         const res = validateResult(content, schema);
         console.debug(res);
     });
 
     test('JSON parser should not validate if date is wrong', () => {
         const schema = parseJSON(readDataFile('ciia-schema.json')) as any;
-        const content = parseJSON(readDataFile('ciia-data-date-wrong.json')) as any;   
-        expect((content, schema) => validateResult(content, schema).toThrowError('validation_error'));
+        const content: JsonResult[] = [{type: "json", value: parseJSON(readDataFile('ciia-data-date-wrong.json'))}];
+        expect(() => validateResult(content, schema)).toThrowError('validation_error');
         console.debug(content, schema);
     });
 
     test('JSON parser should not validate if date is required but null', () => {
         const schema = parseJSON(readDataFile('ciia-schema-date-required.json')) as any;
-        const content = parseJSON(readDataFile('ciia-data-date-empty.json')) as any;   
-        expect((content, schema) => validateResult(content, schema).toThrowError('validation_error'));
+        const content: JsonResult[] = [{type: "json", value: parseJSON(readDataFile('ciia-data-date-empty.json'))}];
+        expect(() => validateResult(content, schema)).toThrowError('validation_error');
         console.debug(content, schema);
     });
 
@@ -92,7 +93,7 @@ describe('Core Utilities', () => {
     test.each(dataFiles)('Validate JSON against schema: %s', (dataFile) => {
         const base = dataFile.replace('.data.json', '');
         const schema = parseJSON(readDataFile(`${base}.schema.json`)) as any;
-        const content = parseJSON(readDataFile(dataFile)) as any;
+        const content: JsonResult[] = [{type: "json", value: parseJSON(readDataFile(dataFile))}];
         const res = validateResult(content, schema);
         console.debug(res);
     });

--- a/core/test/utils.test.ts
+++ b/core/test/utils.test.ts
@@ -32,57 +32,56 @@ describe('Core Utilities', () => {
     test('Validate JSON against schema', () => {
         const ajv = new Ajv({ coerceTypes: true, allowDate: true, strict: false });
         const schema = parseJSON(readDataFile('ciia-schema.json')) as any;
-        const content: JsonResult[] = [{type: "json", value: parseJSON(readDataFile('ciia-data.json'))}];
+        const content: JsonResult[] = [{ type: "json", value: parseJSON(readDataFile('ciia-data.json')) }];
         const res = validateResult(content, schema);
         console.debug(res);
     });
 
     test('Validate JSON against complex schema', () => {
-        const ajv = new Ajv({ coerceTypes: true, allowDate: true, strict: false});
+        const ajv = new Ajv({ coerceTypes: true, allowDate: true, strict: false });
         const schema = parseJSON(readDataFile('complex-schema.json')) as any;
-        const content: JsonResult[] = [{type: "json", value: parseJSON(readDataFile('complex-document.json'))}];
+        const content: JsonResult[] = [{ type: "json", value: parseJSON(readDataFile('complex-document.json')) }];
         const res = validateResult(content, schema);
         console.debug(res);
     });
 
     test('Fail at validating JSON against schema', () => {
         const schema = parseJSON(readDataFile('ciia-schema.json')) as any;
-        const content: JsonResult[] = [{type: "json", value: parseJSON(readDataFile('ciia-data-wrong.json'))}];
+        const content: JsonResult[] = [{ type: "json", value: parseJSON(readDataFile('ciia-data-wrong.json')) }];
         expect(() => validateResult(content, schema)).toThrowError('validation_error');
-     
     });
 
     test('JSON parser should coerce types', () => {
         const schema = parseJSON(readDataFile('ciia-schema.json')) as any;
-        const content: JsonResult[] = [{type: "json", value: parseJSON(readDataFile('ciia-data-wrong-types.json'))}];
+        const content: JsonResult[] = [{ type: "json", value: parseJSON(readDataFile('ciia-data-wrong-types.json')) }];
         const res = validateResult(content, schema);
         console.debug(res);
     });
 
     test('JSON parser should validate if date is empty string', () => {
         const schema = parseJSON(readDataFile('ciia-schema.json')) as any;
-        const content: JsonResult[] = [{type: "json", value: parseJSON(readDataFile('ciia-data-date-empty.json'))}];
+        const content: JsonResult[] = [{ type: "json", value: parseJSON(readDataFile('ciia-data-date-empty.json')) }];
         const res = validateResult(content, schema);
         console.debug(res);
     });
 
     test('JSON parser should validate if date is null', () => {
         const schema = parseJSON(readDataFile('ciia-schema.json')) as any;
-        const content: JsonResult[] = [{type: "json", value: parseJSON(readDataFile('ciia-data-date-null.json'))}];
+        const content: JsonResult[] = [{ type: "json", value: parseJSON(readDataFile('ciia-data-date-null.json')) }];
         const res = validateResult(content, schema);
         console.debug(res);
     });
 
     test('JSON parser should not validate if date is wrong', () => {
         const schema = parseJSON(readDataFile('ciia-schema.json')) as any;
-        const content: JsonResult[] = [{type: "json", value: parseJSON(readDataFile('ciia-data-date-wrong.json'))}];
+        const content: JsonResult[] = [{ type: "json", value: parseJSON(readDataFile('ciia-data-date-wrong.json')) }];
         expect(() => validateResult(content, schema)).toThrowError('validation_error');
         console.debug(content, schema);
     });
 
     test('JSON parser should not validate if date is required but null', () => {
         const schema = parseJSON(readDataFile('ciia-schema-date-required.json')) as any;
-        const content: JsonResult[] = [{type: "json", value: parseJSON(readDataFile('ciia-data-date-empty.json'))}];
+        const content: JsonResult[] = [{ type: "json", value: parseJSON(readDataFile('ciia-data-date-empty.json')) }];
         expect(() => validateResult(content, schema)).toThrowError('validation_error');
         console.debug(content, schema);
     });
@@ -93,7 +92,7 @@ describe('Core Utilities', () => {
     test.each(dataFiles)('Validate JSON against schema: %s', (dataFile) => {
         const base = dataFile.replace('.data.json', '');
         const schema = parseJSON(readDataFile(`${base}.schema.json`)) as any;
-        const content: JsonResult[] = [{type: "json", value: parseJSON(readDataFile(dataFile))}];
+        const content: JsonResult[] = [{ type: "json", value: parseJSON(readDataFile(dataFile)) }];
         const res = validateResult(content, schema);
         console.debug(res);
     });

--- a/drivers/package.json
+++ b/drivers/package.json
@@ -68,7 +68,7 @@
         "@azure/identity": "^4.10.1",
         "@azure/openai": "2.0.0",
         "@google-cloud/aiplatform": "^3.35.0",
-        "@google/genai": "^1.17.0",
+        "@google/genai": "^1.20.0",
         "@huggingface/inference": "2.6.7",
         "@llumiverse/common": "workspace:*",
         "@llumiverse/core": "workspace:*",

--- a/drivers/package.json
+++ b/drivers/package.json
@@ -68,7 +68,7 @@
         "@azure/identity": "^4.10.1",
         "@azure/openai": "2.0.0",
         "@google-cloud/aiplatform": "^3.35.0",
-        "@google/genai": "^1.7.0",
+        "@google/genai": "^1.17.0",
         "@huggingface/inference": "2.6.7",
         "@llumiverse/common": "workspace:*",
         "@llumiverse/core": "workspace:*",

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -508,7 +508,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
         //If last message is "```json", add corresponding ``` as a stop sequence.
         if (prompt.messages && prompt.messages.length > 0) {
             if (prompt.messages[prompt.messages.length - 1].content?.[0].text === "```json") {
-                let stopSeq = model_options.stop_sequence;
+                const stopSeq = model_options.stop_sequence;
                 if (!stopSeq) {
                     model_options.stop_sequence = ["```"];
                 } else if (!stopSeq.includes("```")) {

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -583,11 +583,11 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
 
         const decoder = new TextDecoder();
         const body = decoder.decode(res.body);
-        const result = JSON.parse(body);
+        const bedrockResult = JSON.parse(body);
 
         return {
-            error: result.error,
-            result: result.images.map((image: any) => ({
+            error: bedrockResult.error,
+            result: bedrockResult.images.map((image: any) => ({
                 type: "image" as const,
                 value: image
             }))

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -7,7 +7,7 @@ import { S3Client } from "@aws-sdk/client-s3";
 import { AwsCredentialIdentity, Provider } from "@aws-sdk/types";
 import {
     AbstractDriver, AIModel, Completion, CompletionChunkObject, DataSource, DriverOptions, EmbeddingsOptions, EmbeddingsResult,
-    ExecutionOptions, ExecutionTokenUsage, ImageGeneration, Modalities, PromptSegment,
+    ExecutionOptions, ExecutionTokenUsage, Modalities, PromptSegment,
     TextFallbackOptions, ToolDefinition, ToolUse, TrainingJob, TrainingJobStatus, TrainingOptions,
     BedrockClaudeOptions, BedrockPalmyraOptions, BedrockGptOssOptions, getMaxTokensLimitBedrock, NovaCanvasOptions,
     modelModalitiesToArray, getModelCapabilities,
@@ -171,7 +171,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
         }
 
         const completionResult: CompletionChunkObject = {
-            result: reasoning + resultText,
+            result: reasoning + resultText ? [{ type: "text", value: reasoning + resultText }] : [],
             token_usage: {
                 prompt: result.usage?.inputTokens,
                 result: result.usage?.outputTokens,
@@ -252,7 +252,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
         }
 
         const completionResult: CompletionChunkObject = {
-            result: reasoning + output,
+            result: reasoning + output ? [{ type: "text", value: reasoning + output }] : [],
             token_usage: token_usage,
             finish_reason: converseFinishReason(stop_reason),
         };
@@ -551,7 +551,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
     }
 
 
-    async requestImageGeneration(prompt: NovaMessagesPrompt, options: ExecutionOptions): Promise<Completion<ImageGeneration>> {
+    async requestImageGeneration(prompt: NovaMessagesPrompt, options: ExecutionOptions): Promise<Completion> {
         if (options.output_modality !== Modalities.image) {
             throw new Error(`Image generation requires image output_modality`);
         }
@@ -587,9 +587,10 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
 
         return {
             error: result.error,
-            result: {
-                images: result.images,
-            }
+            result: result.images.map((image: any) => ({
+                type: "image" as const,
+                value: image
+            }))
         }
     }
 

--- a/drivers/src/groq/index.ts
+++ b/drivers/src/groq/index.ts
@@ -52,7 +52,7 @@ export class GroqDriver extends AbstractDriver<GroqDriverOptions, ChatCompletion
             ...opts,
             multimodal: true,
         });
-        
+
         // Convert OpenAI ChatCompletionMessageParam[] to Groq ChatCompletionMessageParam[]
         // Handle differences between OpenAI and Groq SDK types
         const groqMessages: ChatCompletionMessageParam[] = openaiMessages.map(msg => {
@@ -60,7 +60,7 @@ export class GroqDriver extends AbstractDriver<GroqDriverOptions, ChatCompletion
             if (msg.role === 'developer' || msg.role === 'system') {
                 const systemMsg: ChatCompletionMessageParam = {
                     role: 'system',
-                    content: Array.isArray(msg.content) 
+                    content: Array.isArray(msg.content)
                         ? msg.content.map(part => part.text).join('\n')
                         : msg.content,
                     // Preserve name if present
@@ -68,23 +68,23 @@ export class GroqDriver extends AbstractDriver<GroqDriverOptions, ChatCompletion
                 };
                 return systemMsg;
             }
-            
+
             // Handle user messages - filter content parts to only supported types
             if (msg.role === 'user') {
-                let content: string | Array<{type: 'text', text: string} | {type: 'image_url', image_url: {url: string, detail?: 'auto' | 'low' | 'high'}}> | undefined = undefined;
-                
+                let content: string | Array<{ type: 'text', text: string } | { type: 'image_url', image_url: { url: string, detail?: 'auto' | 'low' | 'high' } }> | undefined = undefined;
+
                 if (typeof msg.content === 'string') {
                     content = msg.content;
                 } else if (Array.isArray(msg.content)) {
                     // Filter to only text and image_url parts that Groq supports
-                    const supportedParts = msg.content.filter(part => 
+                    const supportedParts = msg.content.filter(part =>
                         part.type === 'text' || part.type === 'image_url'
                     ).map(part => {
                         if (part.type === 'text') {
                             return { type: 'text' as const, text: part.text };
                         } else if (part.type === 'image_url') {
-                            return { 
-                                type: 'image_url' as const, 
+                            return {
+                                type: 'image_url' as const,
                                 image_url: {
                                     url: part.image_url.url,
                                     ...(part.image_url.detail && { detail: part.image_url.detail })
@@ -92,11 +92,11 @@ export class GroqDriver extends AbstractDriver<GroqDriverOptions, ChatCompletion
                             };
                         }
                         return null;
-                    }).filter(Boolean) as Array<{type: 'text', text: string} | {type: 'image_url', image_url: {url: string, detail?: 'auto' | 'low' | 'high'}}>;
-                    
+                    }).filter(Boolean) as Array<{ type: 'text', text: string } | { type: 'image_url', image_url: { url: string, detail?: 'auto' | 'low' | 'high' } }>;
+
                     content = supportedParts.length > 0 ? supportedParts : 'Content not supported';
                 }
-                
+
                 const userMsg: ChatCompletionMessageParam = {
                     role: 'user',
                     content: content ?? "",
@@ -105,12 +105,12 @@ export class GroqDriver extends AbstractDriver<GroqDriverOptions, ChatCompletion
                 };
                 return userMsg;
             }
-            
+
             // Handle assistant messages - handle content arrays if needed
             if (msg.role === 'assistant') {
                 const assistantMsg: ChatCompletionMessageParam = {
                     role: 'assistant',
-                    content: Array.isArray(msg.content) 
+                    content: Array.isArray(msg.content)
                         ? msg.content.map(part => 'text' in part ? part.text : '').filter(Boolean).join('\n') || null
                         : msg.content,
                     // Preserve other assistant message properties
@@ -119,19 +119,19 @@ export class GroqDriver extends AbstractDriver<GroqDriverOptions, ChatCompletion
                 };
                 return assistantMsg;
             }
-            
+
             // For tool and function messages, they should be compatible
             if (msg.role === 'tool') {
                 const toolMsg: ChatCompletionMessageParam = {
                     role: 'tool',
                     tool_call_id: msg.tool_call_id,
-                    content: Array.isArray(msg.content) 
+                    content: Array.isArray(msg.content)
                         ? msg.content.map(part => part.text).join('\n')
                         : msg.content
                 };
                 return toolMsg;
             }
-            
+
             if (msg.role === 'function') {
                 const functionMsg: ChatCompletionMessageParam = {
                     role: 'function',
@@ -140,7 +140,7 @@ export class GroqDriver extends AbstractDriver<GroqDriverOptions, ChatCompletion
                 };
                 return functionMsg;
             }
-            
+
             // Fallback - should not reach here but provides type safety
             throw new Error(`Unsupported message role: ${(msg as any).role}`);
         });
@@ -152,7 +152,7 @@ export class GroqDriver extends AbstractDriver<GroqDriverOptions, ChatCompletion
         if (!tools || tools.length === 0) {
             return undefined;
         }
-        
+
         return tools.map(tool => ({
             type: 'function' as const,
             function: {
@@ -167,7 +167,7 @@ export class GroqDriver extends AbstractDriver<GroqDriverOptions, ChatCompletion
         if (!message.tool_calls || message.tool_calls.length === 0) {
             return undefined;
         }
-        
+
         return message.tool_calls.map((toolCall: any) => ({
             id: toolCall.id,
             tool_name: toolCall.function.name,
@@ -179,7 +179,7 @@ export class GroqDriver extends AbstractDriver<GroqDriverOptions, ChatCompletion
         return messages.map(message => {
             // Remove any reasoning field from message objects
             const { reasoning, ...sanitizedMessage } = message as any;
-            
+
             // If message has content array, filter out reasoning content types
             if (Array.isArray(sanitizedMessage.content)) {
                 sanitizedMessage.content = sanitizedMessage.content.filter((part: any) => {
@@ -187,20 +187,20 @@ export class GroqDriver extends AbstractDriver<GroqDriverOptions, ChatCompletion
                     return part.type !== 'reasoning' && !('reasoning' in part);
                 });
             }
-            
+
             return sanitizedMessage as ChatCompletionMessageParam;
         });
     }
 
     async requestTextCompletion(messages: ChatCompletionMessageParam[], options: ExecutionOptions): Promise<Completion> {
         if (options.model_options?._option_id !== "text-fallback" && options.model_options?._option_id !== "groq-deepseek-thinking") {
-            this.logger.warn("Invalid model options", {options: options.model_options });
+            this.logger.warn("Invalid model options", { options: options.model_options });
         }
         options.model_options = options.model_options as TextFallbackOptions;
 
         // Update conversation with current messages
         let conversation = updateConversation(options.conversation as ChatCompletionMessageParam[], messages);
-        
+
         // Filter out any reasoning content that Groq doesn't support
         conversation = this.sanitizeMessagesForGroq(conversation);
 
@@ -235,7 +235,7 @@ export class GroqDriver extends AbstractDriver<GroqDriverOptions, ChatCompletion
         }
 
         return {
-            result: result,
+            result: result ? [{ type: "text", value: result }] : [],
             token_usage: {
                 prompt: res.usage?.prompt_tokens,
                 result: res.usage?.completion_tokens,
@@ -248,15 +248,15 @@ export class GroqDriver extends AbstractDriver<GroqDriverOptions, ChatCompletion
         };
     }
 
-    async requestTextCompletionStream(messages: ChatCompletionMessageParam[], options: ExecutionOptions): Promise <AsyncIterable<CompletionChunkObject>> {
+    async requestTextCompletionStream(messages: ChatCompletionMessageParam[], options: ExecutionOptions): Promise<AsyncIterable<CompletionChunkObject>> {
         if (options.model_options?._option_id !== "text-fallback") {
-            this.logger.warn("Invalid model options", {options: options.model_options });
+            this.logger.warn("Invalid model options", { options: options.model_options });
         }
         options.model_options = options.model_options as TextFallbackOptions;
 
         // Update conversation with current messages
         let conversation = updateConversation(options.conversation as ChatCompletionMessageParam[], messages);
-        
+
         // Filter out any reasoning content that Groq doesn't support
         conversation = this.sanitizeMessagesForGroq(conversation);
 
@@ -279,14 +279,14 @@ export class GroqDriver extends AbstractDriver<GroqDriverOptions, ChatCompletion
         return transformAsyncIterator(res, (chunk) => {
             const choice = chunk.choices[0];
             let finish_reason = choice.finish_reason;
-            
+
             // Check for tool calls in the delta
             if (choice.delta.tool_calls && choice.delta.tool_calls.length > 0) {
                 finish_reason = "tool_calls";
             }
 
             return {
-                result: choice.delta.content ?? '',
+                result: choice.delta.content ? [{ type: "text", value: choice.delta.content }] : [],
                 finish_reason: finish_reason,
                 token_usage: {
                     prompt: chunk.x_groq?.usage?.prompt_tokens,

--- a/drivers/src/mistral/index.ts
+++ b/drivers/src/mistral/index.ts
@@ -115,8 +115,9 @@ export class MistralAIDriver extends AbstractDriver<MistralAIDriverOptions, Open
 
         return transformSSEStream(stream, (data: string) => {
             const json = JSON.parse(data);
+            const content = json.choices[0]?.delta.content;
             return {
-                result: json.choices[0]?.delta.content ?? '',
+                result: content ? [{ type: "text", value: content }] : [],
                 finish_reason: json.choices[0]?.finish_reason,      //Uses expected "stop" , "length" format
                 token_usage: {
                     prompt: json.usage?.prompt_tokens,

--- a/drivers/src/mistral/index.ts
+++ b/drivers/src/mistral/index.ts
@@ -1,4 +1,4 @@
-import { AIModel, AbstractDriver, Completion, CompletionChunk, DriverOptions, EmbeddingsOptions, EmbeddingsResult, ExecutionOptions, PromptSegment, TextFallbackOptions } from "@llumiverse/core";
+import { AIModel, AbstractDriver, Completion, CompletionChunkObject, DriverOptions, EmbeddingsOptions, EmbeddingsResult, ExecutionOptions, PromptSegment, TextFallbackOptions } from "@llumiverse/core";
 import { transformSSEStream } from "@llumiverse/core/async";
 import { getJSONSafetyNotice } from "@llumiverse/core/formatters";
 import { formatOpenAILikeTextPrompt, OpenAITextMessage } from "../openai/openai_format.js";
@@ -64,7 +64,7 @@ export class MistralAIDriver extends AbstractDriver<MistralAIDriverOptions, Open
 
     async requestTextCompletion(messages: OpenAITextMessage[], options: ExecutionOptions): Promise<Completion> {
         if (options.model_options?._option_id !== "text-fallback") {
-            this.logger.warn("Invalid model options", {options: options.model_options });
+            this.logger.warn("Invalid model options", { options: options.model_options });
         }
         options.model_options = options.model_options as TextFallbackOptions;
 
@@ -82,7 +82,7 @@ export class MistralAIDriver extends AbstractDriver<MistralAIDriverOptions, Open
         const result = choice.message.content;
 
         return {
-            result: result,
+            result: result ? [{ type: "text", value: result }] : [],
             token_usage: {
                 prompt: res.usage.prompt_tokens,
                 result: res.usage.completion_tokens,
@@ -93,9 +93,9 @@ export class MistralAIDriver extends AbstractDriver<MistralAIDriverOptions, Open
         };
     }
 
-    async requestTextCompletionStream(messages: OpenAITextMessage[], options: ExecutionOptions): Promise<AsyncIterable<CompletionChunk>> {
+    async requestTextCompletionStream(messages: OpenAITextMessage[], options: ExecutionOptions): Promise<AsyncIterable<CompletionChunkObject>> {
         if (options.model_options?._option_id !== "text-fallback") {
-            this.logger.warn("Invalid model options", {options: options.model_options });
+            this.logger.warn("Invalid model options", { options: options.model_options });
         }
         options.model_options = options.model_options as TextFallbackOptions;
 
@@ -152,7 +152,7 @@ export class MistralAIDriver extends AbstractDriver<MistralAIDriverOptions, Open
         const r = await this.client.post('/v1/embeddings', {
             payload: {
                 model,
-                input: [ text ],
+                input: [text],
                 encoding_format: "float"
             },
         });

--- a/drivers/src/replicate.ts
+++ b/drivers/src/replicate.ts
@@ -2,7 +2,7 @@ import {
     AIModel,
     AbstractDriver,
     Completion,
-    CompletionChunk,
+    CompletionChunkObject,
     DataSource,
     DriverOptions,
     EmbeddingsResult,
@@ -64,12 +64,12 @@ export class ReplicateDriver extends AbstractDriver<DriverOptions, string> {
         };
     }
 
-    async requestTextCompletionStream(prompt: string, options: ExecutionOptions): Promise<AsyncIterable<CompletionChunk>> {
+    async requestTextCompletionStream(prompt: string, options: ExecutionOptions): Promise<AsyncIterable<CompletionChunkObject>> {
         if (options.model_options?._option_id !== "text-fallback") {
-            this.logger.warn("Invalid model options", {options: options.model_options });
+            this.logger.warn("Invalid model options", { options: options.model_options });
         }
         options.model_options = options.model_options as TextFallbackOptions;
-        
+
         const model = ReplicateDriver.parseModelId(options.model);
         const predictionData = {
             input: {
@@ -84,7 +84,7 @@ export class ReplicateDriver extends AbstractDriver<DriverOptions, string> {
         const prediction =
             await this.service.predictions.create(predictionData);
 
-        const stream = new EventStream<CompletionChunk>();
+        const stream = new EventStream<CompletionChunkObject>();
 
         const source = new EventSource(prediction.urls.stream!);
         source.addEventListener("output", (e: any) => {
@@ -97,7 +97,7 @@ export class ReplicateDriver extends AbstractDriver<DriverOptions, string> {
             } catch (error) {
                 error = JSON.stringify(e);
             }
-            this.logger?.error("Error in SSE stream", {e, error});
+            this.logger?.error("Error in SSE stream", { e, error });
         });
         source.addEventListener("done", () => {
             try {
@@ -111,7 +111,7 @@ export class ReplicateDriver extends AbstractDriver<DriverOptions, string> {
 
     async requestTextCompletion(prompt: string, options: ExecutionOptions) {
         if (options.model_options?._option_id !== "text-fallback") {
-            this.logger.warn("Invalid model options", {options: options.model_options });
+            this.logger.warn("Invalid model options", { options: options.model_options });
         }
         options.model_options = options.model_options as TextFallbackOptions;
         const model = ReplicateDriver.parseModelId(options.model);
@@ -298,7 +298,7 @@ function jobInfo(job: Prediction, modelName?: string): TrainingJob {
         status = TrainingJobStatus.succeeded;
     } else if (jobStatus === 'failed') {
         status = TrainingJobStatus.failed;
-        const error = job.error as any; 
+        const error = job.error as any;
         if (typeof error === 'string') {
             details = error;
         } else {

--- a/drivers/src/replicate.ts
+++ b/drivers/src/replicate.ts
@@ -88,7 +88,7 @@ export class ReplicateDriver extends AbstractDriver<DriverOptions, string> {
 
         const source = new EventSource(prediction.urls.stream!);
         source.addEventListener("output", (e: any) => {
-            stream.push(e.data);
+            stream.push({result: [{ type: "text", value: e.data }] });
         });
         source.addEventListener("error", (e: any) => {
             let error: any;
@@ -136,9 +136,9 @@ export class ReplicateDriver extends AbstractDriver<DriverOptions, string> {
         //not streaming, wait for the result
         const res = await this.service.wait(prediction, {});
 
-        const text = res.output.join("");
+        const text: string = res.output.join("");
         return {
-            result: text,
+            result: [{ type: "text" as const, value: text }],
             original_response: options.include_original_response ? res : undefined,
         };
     }

--- a/drivers/src/test/utils.ts
+++ b/drivers/src/test/utils.ts
@@ -8,7 +8,7 @@ export function throwError(message: string, prompt: PromptSegment[]): never {
 
 export function createValidationErrorCompletion(segments: PromptSegment[]) {
     return {
-        result: "An invalid result",
+        result: [{ type: "text", value: "An invalid result" }],
         prompt: segments,
         execution_time: 3000,
         error: {

--- a/drivers/src/togetherai/index.ts
+++ b/drivers/src/togetherai/index.ts
@@ -1,4 +1,4 @@
-import { AIModel, AbstractDriver, Completion, CompletionChunk, DriverOptions, EmbeddingsResult, ExecutionOptions, TextFallbackOptions } from "@llumiverse/core";
+import { AIModel, AbstractDriver, Completion, CompletionChunkObject, DriverOptions, EmbeddingsResult, ExecutionOptions, TextFallbackOptions } from "@llumiverse/core";
 import { transformSSEStream } from "@llumiverse/core/async";
 import { FetchClient } from "@vertesia/api-fetch-client";
 import { TextCompletion, TogetherModelInfo } from "./interfaces.js";
@@ -29,9 +29,9 @@ export class TogetherAIDriver extends AbstractDriver<TogetherAIDriverOptions, st
             } : undefined;
     }
 
-    async requestTextCompletion(prompt: string, options: ExecutionOptions): Promise<Completion<any>> {
+    async requestTextCompletion(prompt: string, options: ExecutionOptions): Promise<Completion> {
         if (options.model_options?._option_id !== "text-fallback") {
-            this.logger.warn("Invalid model options", {options: options.model_options });
+            this.logger.warn("Invalid model options", { options: options.model_options });
         }
         options.model_options = options.model_options as TextFallbackOptions;
 
@@ -60,7 +60,7 @@ export class TogetherAIDriver extends AbstractDriver<TogetherAIDriverOptions, st
         const text = choice.text ?? '';
         const usage = res.usage || {};
         return {
-            result: text,
+            result: [{ type: "text", value: text }],
             token_usage: {
                 prompt: usage.prompt_tokens,
                 result: usage.completion_tokens,
@@ -71,9 +71,9 @@ export class TogetherAIDriver extends AbstractDriver<TogetherAIDriverOptions, st
         }
     }
 
-    async requestTextCompletionStream(prompt: string, options: ExecutionOptions): Promise<AsyncIterable<CompletionChunk>> {
+    async requestTextCompletionStream(prompt: string, options: ExecutionOptions): Promise<AsyncIterable<CompletionChunkObject>> {
         if (options.model_options?._option_id !== "text-fallback") {
-            this.logger.warn("Invalid model options", {options: options.model_options });
+            this.logger.warn("Invalid model options", { options: options.model_options });
         }
         options.model_options = options.model_options as TextFallbackOptions;
 

--- a/drivers/src/togetherai/index.ts
+++ b/drivers/src/togetherai/index.ts
@@ -103,7 +103,7 @@ export class TogetherAIDriver extends AbstractDriver<TogetherAIDriverOptions, st
         return transformSSEStream(stream, (data: string) => {
             const json = JSON.parse(data);
             return {
-                result: json.choices[0]?.text ?? '',
+                result: [{ type: "text", value: json.choices[0]?.text ?? '' }],
                 finish_reason: json.choices[0]?.finish_reason,          //Uses expected "stop" , "length" format
                 token_usage: {
                     prompt: json.usage?.prompt_tokens,

--- a/drivers/src/vertexai/index.ts
+++ b/drivers/src/vertexai/index.ts
@@ -281,7 +281,7 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
             parent: `projects/${this.options.project}/locations/${this.options.region}`,
         });
         const publisherPromises = publishers.map(async (publisher) => {
-            let [response] = await modelGarden.listPublisherModels({
+            const [response] = await modelGarden.listPublisherModels({
                 parent: `publishers/${publisher}`,
                 orderBy: "name",
                 listAllVersions: true,

--- a/drivers/src/vertexai/index.ts
+++ b/drivers/src/vertexai/index.ts
@@ -77,7 +77,7 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
         if (!this.googleGenAI) {
             this.googleGenAI = new GoogleGenAI({
                 project: this.options.project,
-                location: this.options.region,
+                location: "global",
                 vertexai: true,
                 googleAuthOptions: {
                     authClient: this.authClient as JSONClient,

--- a/drivers/src/vertexai/index.ts
+++ b/drivers/src/vertexai/index.ts
@@ -2,11 +2,10 @@ import {
     AIModel,
     AbstractDriver,
     Completion,
-    CompletionChunk,
+    CompletionChunkObject,
     DriverOptions,
     EmbeddingsResult,
     ExecutionOptions,
-    ImageGeneration,
     Modalities,
     ModelSearchPayload,
     PromptSegment,
@@ -54,7 +53,7 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
     googleGenAI: GoogleGenAI | undefined;
     llamaClient: FetchClient & { region?: string } | undefined;
     modelGarden: v1beta1.ModelGardenServiceClient | undefined;
-    imagenClient: PredictionServiceClient| undefined;
+    imagenClient: PredictionServiceClient | undefined;
 
     authClient: JSONClient | GoogleAuth<JSONClient>;
 
@@ -73,7 +72,7 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
     }
 
     public getGoogleGenAIClient(): GoogleGenAI {
-        //Lazy initialisation
+        //Lazy initialization
         if (!this.googleGenAI) {
             this.googleGenAI = new GoogleGenAI({
                 project: this.options.project,
@@ -88,7 +87,7 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
     }
 
     public getFetchClient(): FetchClient {
-        //Lazy initialisation
+        //Lazy initialization
         if (!this.fetchClient) {
             this.fetchClient = createFetchClient({
                 region: this.options.region,
@@ -103,7 +102,7 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
     }
 
     public getLLamaClient(region: string = "us-central1"): FetchClient {
-        //Lazy initialisation
+        //Lazy initialization
         if (!this.llamaClient || this.llamaClient["region"] !== region) {
             this.llamaClient = createFetchClient({
                 region: region,
@@ -121,7 +120,7 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
     }
 
     public getAnthropicClient(): AnthropicVertex {
-        //Lazy initialisation
+        //Lazy initialization
         if (!this.anthropicClient) {
             this.anthropicClient = new AnthropicVertex({
                 timeout: 20 * 60 * 10000, // Set to 20 minutes, 10 minute default, setting this disables long request error: https://github.com/anthropics/anthropic-sdk-typescript?#long-requests
@@ -138,7 +137,7 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
     }
 
     public getAIPlatformClient(): v1beta1.ModelServiceClient {
-        //Lazy initialisation
+        //Lazy initialization
         if (!this.aiplatform) {
             this.aiplatform = new v1beta1.ModelServiceClient({
                 projectId: this.options.project,
@@ -150,7 +149,7 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
     }
 
     public getModelGardenClient(): v1beta1.ModelGardenServiceClient {
-        //Lazy initialisation
+        //Lazy initialization
         if (!this.modelGarden) {
             this.modelGarden = new v1beta1.ModelGardenServiceClient({
                 projectId: this.options.project,
@@ -162,7 +161,7 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
     }
 
     public getImagenClient(): PredictionServiceClient {
-        //Lazy initialisation
+        //Lazy initialization
         if (!this.imagenClient) {
             // TODO: make location configurable, fixed to us-central1 for now
             this.imagenClient = new PredictionServiceClient({
@@ -200,20 +199,20 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
         return getModelDefinition(options.model).createPrompt(this, segments, options);
     }
 
-    async requestTextCompletion(prompt: VertexAIPrompt, options: ExecutionOptions): Promise<Completion<any>> {
+    async requestTextCompletion(prompt: VertexAIPrompt, options: ExecutionOptions): Promise<Completion> {
         return getModelDefinition(options.model).requestTextCompletion(this, prompt, options);
     }
     async requestTextCompletionStream(
         prompt: VertexAIPrompt,
         options: ExecutionOptions,
-    ): Promise<AsyncIterable<CompletionChunk>> {
+    ): Promise<AsyncIterable<CompletionChunkObject>> {
         return getModelDefinition(options.model).requestTextCompletionStream(this, prompt, options);
     }
 
     async requestImageGeneration(
         _prompt: ImagenPrompt,
         _options: ExecutionOptions,
-    ): Promise<Completion<ImageGeneration>> {
+    ): Promise<Completion> {
         const splits = _options.model.split("/");
         const modelName = trimModelName(splits[splits.length - 1]);
         return new ImagenModelDefinition(modelName).requestImageGeneration(this, _prompt, _options);

--- a/drivers/src/vertexai/models.ts
+++ b/drivers/src/vertexai/models.ts
@@ -1,5 +1,5 @@
-import { AIModel, Completion, PromptSegment, ExecutionOptions, CompletionChunk } from "@llumiverse/core";
-import { VertexAIDriver , trimModelName} from "./index.js";
+import { AIModel, Completion, PromptSegment, ExecutionOptions, CompletionChunkObject } from "@llumiverse/core";
+import { VertexAIDriver, trimModelName } from "./index.js";
 import { GeminiModelDefinition } from "./models/gemini.js";
 import { ClaudeModelDefinition } from "./models/claude.js";
 import { LLamaModelDefinition } from "./models/llama.js";
@@ -9,7 +9,7 @@ export interface ModelDefinition<PromptT = any> {
     versions?: string[]; // the versions of the model that are available. ex: ['001', '002']
     createPrompt: (driver: VertexAIDriver, segments: PromptSegment[], options: ExecutionOptions) => Promise<PromptT>;
     requestTextCompletion: (driver: VertexAIDriver, prompt: PromptT, options: ExecutionOptions) => Promise<Completion>;
-    requestTextCompletionStream: (driver: VertexAIDriver, prompt: PromptT, options: ExecutionOptions) => Promise<AsyncIterable<CompletionChunk>>;
+    requestTextCompletionStream: (driver: VertexAIDriver, prompt: PromptT, options: ExecutionOptions) => Promise<AsyncIterable<CompletionChunkObject>>;
     preValidationProcessing?(result: Completion, options: ExecutionOptions): { result: Completion, options: ExecutionOptions };
 }
 
@@ -17,7 +17,7 @@ export function getModelDefinition(model: string): ModelDefinition {
     const splits = model.split("/");
     const publisher = splits[1];
     const modelName = trimModelName(splits[splits.length - 1]);
-    
+
     if (publisher?.includes("anthropic")) {
         return new ClaudeModelDefinition(modelName);
     } else if (publisher?.includes("google")) {

--- a/drivers/src/vertexai/models/gemini.ts
+++ b/drivers/src/vertexai/models/gemini.ts
@@ -713,13 +713,17 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
 
     async requestTextCompletion(driver: VertexAIDriver, prompt: GenerateContentPrompt, options: ExecutionOptions): Promise<Completion> {
         const splits = options.model.split("/");
+        let region: string | undefined = undefined;
+        if (splits[0] !== "locations" && splits.length >= 2) {
+            region = splits[1];
+        } 
         const modelName = splits[splits.length - 1];
         options = { ...options, model: modelName };
 
         let conversation = updateConversation(options.conversation as Content[], prompt.contents);
         prompt.contents = conversation;
 
-        const client = driver.getGoogleGenAIClient();
+        const client = driver.getGoogleGenAIClient(region);
 
         const payload = getGeminiPayload(options, prompt);
         const response = await client.models.generateContent(payload);
@@ -773,10 +777,14 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
 
     async requestTextCompletionStream(driver: VertexAIDriver, prompt: GenerateContentPrompt, options: ExecutionOptions): Promise<AsyncIterable<CompletionChunkObject>> {
         const splits = options.model.split("/");
+        let region: string | undefined = undefined;
+        if (splits[0] !== "locations" && splits.length >= 2) {
+            region = splits[1];
+        } 
         const modelName = splits[splits.length - 1];
         options = { ...options, model: modelName };
 
-        const client = driver.getGoogleGenAIClient();
+        const client = driver.getGoogleGenAIClient(region);
 
         const payload = getGeminiPayload(options, prompt);
         const response = await client.models.generateContentStream(payload);

--- a/drivers/src/vertexai/models/gemini.ts
+++ b/drivers/src/vertexai/models/gemini.ts
@@ -723,6 +723,10 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
         let conversation = updateConversation(options.conversation as Content[], prompt.contents);
         prompt.contents = conversation;
 
+        if (options.model.includes("gemini-2.5-flash-image")) {
+            region = "global"; // Gemini Flash Image only available in global region, this is for nano-banana model
+        }
+
         const client = driver.getGoogleGenAIClient(region);
 
         const payload = getGeminiPayload(options, prompt);
@@ -783,6 +787,10 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
         } 
         const modelName = splits[splits.length - 1];
         options = { ...options, model: modelName };
+
+        if (options.model.includes("gemini-2.5-flash-image")) {
+            region = "global"; // Gemini Flash Image only available in global region, this is for nano-banana model
+        }
 
         const client = driver.getGoogleGenAIClient(region);
 

--- a/drivers/src/vertexai/models/gemini.ts
+++ b/drivers/src/vertexai/models/gemini.ts
@@ -4,7 +4,7 @@ import {
     HarmBlockThreshold, HarmCategory, Part, SafetySetting, Schema, Tool, Type
 } from "@google/genai";
 import {
-    AIModel, Completion, CompletionChunkObject, ExecutionOptions,
+    AIModel, Completion, CompletionChunkObject, CompletionResult, ExecutionOptions,
     ExecutionTokenUsage, getMaxTokensLimitVertexAi, JSONObject, JSONSchema, ModelType, PromptOptions, PromptRole,
     PromptSegment, readStreamAsBase64, StatelessExecutionOptions, ToolDefinition, ToolUse,
     VertexAIGeminiOptions
@@ -54,7 +54,7 @@ function getGeminiPayload(options: ExecutionOptions, prompt: GenerateContentProm
     const thinkingConfigNeeded = model_options?.include_thoughts
         || model_options?.thinking_budget_tokens
         || options.model.includes("gemini-2.5");
-    
+
     const configNanoBanana: GenerateContentConfig = {
         responseModalities: ["TEXT", "IMAGE"]
     }
@@ -347,7 +347,7 @@ function cleanEmptyFieldsContent(content: Content, result_schema?: JSONSchema): 
                 const jsonText = JSON.parse(part.text);
                 // Skip cleaning if not an object
                 if (typeof jsonText === 'object' && jsonText !== null && !Array.isArray(jsonText)) {
-                    const cleanedJson = removeEmptyFields(jsonText, result_schema);       
+                    const cleanedJson = removeEmptyFields(jsonText, result_schema);
                     newPart.text = JSON.stringify(cleanedJson);
                 } else {
                     // Keep original if not an object (string, number, array, etc.)
@@ -382,14 +382,14 @@ function removeEmptyFields(object: JSONObject | any[], schema: JSONSchema): JSON
     if (typeof object == 'object' || object === null) {
         return removeEmptyJSONObject(object, schema);
     }
-    
+
     return object;
 }
 
 function removeEmptyJSONObject(object: JSONObject, schema: JSONSchema): JSONObject {
     // Get the original required properties from schema
     const requiredProps = schema.required || [];
-    const cleanedResult: JSONObject = {...object};
+    const cleanedResult: JSONObject = { ...object };
 
     // Process each property
     for (const [key, value] of Object.entries(object)) {
@@ -413,40 +413,46 @@ function removeEmptyJSONObject(object: JSONObject, schema: JSONSchema): JSONObje
 
 function removeEmptyJSONArray(array: any[], schema: JSONSchema): any[] {
     const cleanedArray = array.map(item => {
-        return removeEmptyFields(item, schema); 
+        return removeEmptyFields(item, schema);
     });
 
     // Filter out empty objects from the array
     return cleanedArray.filter(item => !isEmpty(item));
 }
 
-function collectTextParts(content: Content) {
-    const out = [];
+function collectTextParts(content: Content): CompletionResult[] {
+    const results: CompletionResult[] = [];
     const parts = content.parts;
     if (parts) {
         for (const part of parts) {
             if (part.text) {
-                out.push(part.text);
+                results.push({
+                    type: "text",
+                    value: part.text
+                });
             }
         }
     }
-    return out.join('\n');
+    return results;
 }
 
-function collectInlineDataParts(content: Content) {
-    const out = [];
+function collectInlineDataParts(content: Content): CompletionResult[] {
+    const results: CompletionResult[] = [];
     const parts = content.parts;
     if (parts) {
         for (const part of parts) {
             if (part.inlineData) {
                 const base64ImageBytes: string = part.inlineData.data ?? "";
-                const imageUrl = `data:${part.inlineData.mimeType};base64,${base64ImageBytes.slice(0, 100)}`;
-                console.log(imageUrl)
-                out.push(imageUrl);
+                const mimeType = part.inlineData.mimeType ?? "image/png";
+                const imageUrl = `data:${mimeType};base64,${base64ImageBytes}`;
+                results.push({
+                    type: "image",
+                    value: imageUrl
+                });
             }
         }
     }
-    return out.join('\n');
+    return results;
 }
 
 function collectToolUseParts(content: Content): ToolUse[] | undefined {
@@ -467,7 +473,7 @@ function collectToolUseParts(content: Content): ToolUse[] | undefined {
 export function mergeConsecutiveRole(contents: Content[] | undefined): Content[] {
     if (!contents || contents.length === 0) return [];
 
-    const needsMerging = contents.some((content, i) => 
+    const needsMerging = contents.some((content, i) =>
         i < contents.length - 1 && content.role === contents[i + 1].role
     );
     // If no merging needed, return original array
@@ -548,8 +554,16 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
             return { result, options };
         }
         try {
-            const jsonResult = JSON.parse(result.result);
-            result.result = JSON.stringify(removeEmptyFields(jsonResult, options.result_schema));
+            // Extract text content for JSON processing - only process first text result
+            const textResult = result.result.find(r => r.type === 'text')?.value;
+            if (textResult) {
+                const jsonResult = JSON.parse(textResult);
+                const cleanedJson = JSON.stringify(removeEmptyFields(jsonResult, options.result_schema));
+                // Replace the text result with cleaned version
+                result.result = result.result.map(r =>
+                    r.type === 'text' ? { ...r, value: cleanedJson } : r
+                );
+            }
             return { result, options };
         } catch (error) {
             // Log error during processing but don't fail the completion
@@ -567,7 +581,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
         const schema = options.result_schema;
         let contents: Content[] = [];
         let system: Content | undefined = { role: "user", parts: [] }; // Single content block for system messages
-        
+
         const safety: Content[] = [];
 
         for (const msg of segments) {
@@ -580,7 +594,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
 
                 if (msg.content) {
                     system.parts?.push({
-                      text: msg.content
+                        text: msg.content
                     });
                 }
             } else if (msg.role === PromptRole.tool) {
@@ -654,7 +668,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
                 }
             }
         }
-        
+
         // If no system messages, set system to undefined.
         if (!system.parts || system.parts.length === 0) {
             system = undefined;
@@ -667,7 +681,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
 
         // Merge consecutive messages with the same role. Note: this may not be necessary, works without it, keeping to match previous behavior.
         contents = mergeConsecutiveRole(contents);
-        
+
         return { contents, system };
     }
 
@@ -681,7 +695,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
         tokenUsage.result = (usageMetadata.candidatesTokenCount ?? 0)
             + (usageMetadata.thoughtsTokenCount ?? 0)
             + (usageMetadata.toolUsePromptTokenCount ?? 0);
-        
+
         if ((tokenUsage.total ?? 0) != (tokenUsage.prompt ?? 0) + tokenUsage.result) {
             console.warn("[VertexAI] Gemini token usage mismatch: total does not equal prompt + result", {
                 total: tokenUsage.total,
@@ -689,7 +703,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
                 result: tokenUsage.result
             });
         }
-        
+
         if (!tokenUsage.result) {
             tokenUsage.result = undefined; // If no result, mark as undefined
         }
@@ -711,31 +725,6 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
         const response = await client.models.generateContent(payload);
 
         const token_usage: ExecutionTokenUsage = this.usageMetadataToTokenUsage(response.usageMetadata);
-
-        /*
-        example for nano banana - gemini 2.5 flash image preview
-                ### Edit Images
-
-        Editing images is better done using the Gemini native image generation model.
-        Configs are not supported in this model (except modality).
-
-        ```javascript
-        import { GoogleGenAI } from '@google/genai';
-
-        const ai = new GoogleGenAI({});
-
-        const response = await ai.models.generateContent({
-        model: 'gemini-2.5-flash-image-preview',
-        contents: [imagePart, 'koala eating a nano banana']
-        });
-        for (const part of response.candidates[0].content.parts) {
-        if (part.inlineData) {
-            const base64ImageBytes: string = part.inlineData.data;
-            const imageUrl = `data:image/png;base64,${base64ImageBytes}`;
-        }
-        }
-        ```
-        */
 
         let tool_use: ToolUse[] | undefined;
         let finish_reason: string | undefined, result: any;
@@ -759,19 +748,21 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
 
                 // We clean the content before validation, so we can update the conversation.
                 const cleanedContent = cleanEmptyFieldsContent(content, options.result_schema);
-                result = collectTextParts(cleanedContent);
+                const textResults = collectTextParts(cleanedContent);
+                const imageResults = collectInlineDataParts(cleanedContent);
+                result = [...textResults, ...imageResults];
                 conversation = updateConversation(conversation, [cleanedContent]);
             }
         }
 
-        
+
 
         if (tool_use) {
             finish_reason = "tool_use";
         }
 
         return {
-            result: result ?? '',
+            result: result && result.length > 0 ? result : [{ type: "text" as const, value: '' }],
             token_usage: token_usage,
             finish_reason: finish_reason,
             original_response: options.include_original_response ? response : undefined,
@@ -790,31 +781,6 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
         const payload = getGeminiPayload(options, prompt);
         const response = await client.models.generateContentStream(payload);
 
-        /*
-        example for nano banana - gemini 2.5 flash image preview
-                ### Edit Images
-
-        Editing images is better done using the Gemini native image generation model.
-        Configs are not supported in this model (except modality).
-
-        ```javascript
-        import { GoogleGenAI } from '@google/genai';
-
-        const ai = new GoogleGenAI({});
-
-        const response = await ai.models.generateContent({
-        model: 'gemini-2.5-flash-image-preview',
-        contents: [imagePart, 'koala eating a nano banana']
-        });
-        for (const part of response.candidates[0].content.parts) {
-        if (part.inlineData) {
-            const base64ImageBytes: string = part.inlineData.data;
-            const imageUrl = `data:image/png;base64,${base64ImageBytes}`;
-        }
-        }
-        ```
-        */
-
         const stream = asyncMap(response, async (item) => {
             const token_usage: ExecutionTokenUsage = this.usageMetadataToTokenUsage(item.usageMetadata);
             if (item.candidates && item.candidates.length > 0) {
@@ -832,13 +798,15 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
                             + `content: ${JSON.stringify(candidate.content, null, 2)}, safety: ${JSON.stringify(candidate.safetyRatings, null, 2)}`);
                     }
                     if (candidate.content?.role === 'model') {
-                        const text = collectTextParts(candidate.content) + collectInlineDataParts(candidate.content);
+                        const textResults = collectTextParts(candidate.content);
+                        const imageResults = collectInlineDataParts(candidate.content);
+                        const combinedResults = [...textResults, ...imageResults];
                         tool_use = collectToolUseParts(candidate.content);
                         if (tool_use) {
                             finish_reason = "tool_use";
                         }
                         return {
-                            result: text,
+                            result: combinedResults.length > 0 ? combinedResults : [],
                             token_usage: token_usage,
                             finish_reason: finish_reason,
                             tool_use,
@@ -848,7 +816,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
             }
             //No normal output, returning block reason if it exists.
             return {
-                result: item.promptFeedback?.blockReasonMessage ?? "",
+                result: item.promptFeedback?.blockReasonMessage ? [{ type: "text" as const, value: item.promptFeedback.blockReasonMessage }] : [],
                 finish_reason: item.promptFeedback?.blockReason ?? "",
                 token_usage: token_usage,
             };

--- a/drivers/src/vertexai/models/gemini.ts
+++ b/drivers/src/vertexai/models/gemini.ts
@@ -714,7 +714,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
     async requestTextCompletion(driver: VertexAIDriver, prompt: GenerateContentPrompt, options: ExecutionOptions): Promise<Completion> {
         const splits = options.model.split("/");
         let region: string | undefined = undefined;
-        if (splits[0] !== "locations" && splits.length >= 2) {
+        if (splits[0] === "locations" && splits.length >= 2) {
             region = splits[1];
         } 
         const modelName = splits[splits.length - 1];
@@ -778,7 +778,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
     async requestTextCompletionStream(driver: VertexAIDriver, prompt: GenerateContentPrompt, options: ExecutionOptions): Promise<AsyncIterable<CompletionChunkObject>> {
         const splits = options.model.split("/");
         let region: string | undefined = undefined;
-        if (splits[0] !== "locations" && splits.length >= 2) {
+        if (splits[0] === "locations" && splits.length >= 2) {
             region = splits[1];
         } 
         const modelName = splits[splits.length - 1];

--- a/drivers/src/vertexai/models/imagen.ts
+++ b/drivers/src/vertexai/models/imagen.ts
@@ -1,5 +1,5 @@
 import {
-    AIModel, Completion, ExecutionOptions, ImageGeneration, Modalities,
+    AIModel, Completion, ExecutionOptions, Modalities,
     ModelType, PromptRole, PromptSegment, readStreamAsBase64, ImagenOptions
 } from "@llumiverse/core";
 import { VertexAIDriver } from "../index.js";
@@ -322,9 +322,9 @@ export class ImagenModelDefinition {
         return prompt
     }
 
-    async requestImageGeneration(driver: VertexAIDriver, prompt: ImagenPrompt, options: ExecutionOptions): Promise<Completion<ImageGeneration>> {
+    async requestImageGeneration(driver: VertexAIDriver, prompt: ImagenPrompt, options: ExecutionOptions): Promise<Completion> {
         if (options.model_options?._option_id !== "vertexai-imagen") {
-            driver.logger.warn("Invalid model options", {options: options.model_options });
+            driver.logger.warn("Invalid model options", { options: options.model_options });
         }
         options.model_options = options.model_options as ImagenOptions | undefined;
 
@@ -336,7 +336,7 @@ export class ImagenModelDefinition {
 
         driver.logger.info("Task type: " + taskType);
 
-        const modelName = options.model.split("/").pop() ?? '';
+            const modelName = options.model.split("/").pop() ?? '';
 
         // Configure the parent resource
         // TODO: make location configurable, fixed to us-central1 for now
@@ -382,9 +382,10 @@ export class ImagenModelDefinition {
         );
 
         return {
-            result: {
-                images
-            },
+            result: images.map(image => ({
+                type: "image" as const,
+                value: image
+            })),
         };
     }
 }

--- a/drivers/src/vertexai/models/llama.ts
+++ b/drivers/src/vertexai/models/llama.ts
@@ -210,7 +210,7 @@ export class LLamaModelDefinition implements ModelDefinition<LLamaPrompt> {
         const splits = options.model.split("/");
         const modelName = splits[splits.length - 1];
 
-        let conversation = updateConversation(options.conversation as LLamaPrompt, prompt);
+        const conversation = updateConversation(options.conversation as LLamaPrompt, prompt);
 
         const modelOptions = options.model_options as TextFallbackOptions;
 

--- a/drivers/src/vertexai/models/llama.ts
+++ b/drivers/src/vertexai/models/llama.ts
@@ -1,5 +1,5 @@
 import {
-    AIModel, Completion, CompletionChunk, CompletionChunkObject, ExecutionOptions, ModelType,
+    AIModel, Completion, CompletionChunkObject, ExecutionOptions, ModelType,
     PromptOptions, PromptRole, PromptSegment,
     TextFallbackOptions
 } from "@llumiverse/core";
@@ -195,7 +195,7 @@ export class LLamaModelDefinition implements ModelDefinition<LLamaPrompt> {
         });
 
         return {
-            result: text,
+            result: [{ type: "text", value: text }],
             token_usage: {
                 prompt: result.usage.prompt_tokens,
                 result: result.usage.completion_tokens,
@@ -206,7 +206,7 @@ export class LLamaModelDefinition implements ModelDefinition<LLamaPrompt> {
         };
     }
 
-    async requestTextCompletionStream(driver: VertexAIDriver, prompt: LLamaPrompt, options: ExecutionOptions): Promise<AsyncIterable<CompletionChunk>> {
+    async requestTextCompletionStream(driver: VertexAIDriver, prompt: LLamaPrompt, options: ExecutionOptions): Promise<AsyncIterable<CompletionChunkObject>> {
         const splits = options.model.split("/");
         const modelName = splits[splits.length - 1];
 
@@ -247,8 +247,9 @@ export class LLamaModelDefinition implements ModelDefinition<LLamaPrompt> {
         return transformSSEStream(stream, (data: string): CompletionChunkObject => {
             const json = JSON.parse(data) as LLamaStreamResponse;
             const choice = json.choices?.[0];
+            const content = choice?.delta?.content ?? '';
             return {
-                result: choice?.delta?.content ?? '',
+                result: content ? [{ type: "text", value: content }] : [],
                 finish_reason: choice?.finish_reason,
                 token_usage: json.usage ? {
                     prompt: json.usage.prompt_tokens,

--- a/drivers/src/xai/index.ts
+++ b/drivers/src/xai/index.ts
@@ -5,7 +5,7 @@ import OpenAI from "openai";
 import { BaseOpenAIDriver } from "../openai/index.js";
 
 export interface xAiDriverOptions extends DriverOptions {
-    
+
     apiKey: string;
 
     endpoint?: string;
@@ -17,7 +17,7 @@ export class xAIDriver extends BaseOpenAIDriver {
     service: OpenAI;
     provider: "xai";
     xai_service: FetchClient;
-    DEFAULT_ENDPOINT = "https://api.x.ai/v1"; 
+    DEFAULT_ENDPOINT = "https://api.x.ai/v1";
 
     constructor(opts: xAiDriverOptions) {
         super(opts);
@@ -29,8 +29,8 @@ export class xAIDriver extends BaseOpenAIDriver {
         this.service = new OpenAI({
             apiKey: opts.apiKey,
             baseURL: opts.endpoint ?? this.DEFAULT_ENDPOINT,
-          });
-        this.xai_service = new FetchClient(opts.endpoint ?? this.DEFAULT_ENDPOINT ).withAuthCallback(async () => `Bearer ${opts.apiKey}`);
+        });
+        this.xai_service = new FetchClient(opts.endpoint ?? this.DEFAULT_ENDPOINT).withAuthCallback(async () => `Bearer ${opts.apiKey}`);
         this.provider = "xai";
         //this.formatPrompt = this._formatPrompt; //TODO: fix xai prompt formatting
     }
@@ -43,7 +43,7 @@ export class xAIDriver extends BaseOpenAIDriver {
             useToolForFormatting: false,
         }
 
-        const p = await formatOpenAILikeMultimodalPrompt(segments, {...options, ...opts}) as OpenAI.Chat.Completions.ChatCompletionMessageParam[];
+        const p = await formatOpenAILikeMultimodalPrompt(segments, { ...options, ...opts }) as OpenAI.Chat.Completions.ChatCompletionMessageParam[];
 
         return p;
 
@@ -51,7 +51,7 @@ export class xAIDriver extends BaseOpenAIDriver {
 
     extractDataFromResponse(_options: ExecutionOptions, result: OpenAI.Chat.Completions.ChatCompletion): Completion {
         return {
-            result: result.choices[0].message.content,
+            result: result.choices[0].message.content ? [{ type: "text", value: result.choices[0].message.content }] : [],
             finish_reason: result.choices[0].finish_reason,
             token_usage: {
                 prompt: result.usage?.prompt_tokens,
@@ -63,7 +63,7 @@ export class xAIDriver extends BaseOpenAIDriver {
 
     async listModels(): Promise<AIModel[]> {
         const [lm, em] = await Promise.all([
-            this.xai_service.get("/language-models") ,
+            this.xai_service.get("/language-models"),
             this.xai_service.get("/embedding-models")
         ]) as [xAIModelResponse, xAIModelResponse];
 
@@ -93,9 +93,9 @@ export class xAIDriver extends BaseOpenAIDriver {
 
 interface xAIModelResponse {
     models: xAIModel[];
-  }
-  
-  interface xAIModel {
+}
+
+interface xAIModel {
     completion_text_token_price: number;
     created: number;
     id: string;
@@ -105,5 +105,4 @@ interface xAIModelResponse {
     owned_by: string;
     prompt_image_token_price: number;
     prompt_text_token_price: number;
-  }
-  
+}

--- a/drivers/test/all-models.test.ts
+++ b/drivers/test/all-models.test.ts
@@ -27,7 +27,7 @@ if (process.env.GOOGLE_PROJECT_ID && process.env.GOOGLE_REGION) {
             region: process.env.GOOGLE_REGION as string,
         }),
         models: [
-            "publishers/google/models/gemini-2.0-flash-lite-001",
+            "publishers/google/models/gemini-2.0-flash-lite",
            // "gemini-1.5-flash", //legacy id format
             "publishers/anthropic/models/claude-3-7-sonnet",
             "publishers/meta/models/llama-4-scout-17b-16e-instruct-maas"
@@ -117,7 +117,7 @@ if (process.env.BEDROCK_REGION) {
         }),
         //Use foundation models and inference profiles to test the driver
         models: [
-            "anthropic.claude-3-5-sonnet-20240620-v1:0",
+            "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
             "us.meta.llama3-3-70b-instruct-v1:0",
             "us.amazon.nova-micro-v1:0",
             "ai21.jamba-1-5-mini-v1:0",

--- a/drivers/test/all-models.test.ts
+++ b/drivers/test/all-models.test.ts
@@ -27,7 +27,7 @@ if (process.env.GOOGLE_PROJECT_ID && process.env.GOOGLE_REGION) {
             region: process.env.GOOGLE_REGION as string,
         }),
         models: [
-            "publishers/google/models/gemini-2.0-flash-lite",
+            "publishers/google/models/gemini-2.0-flash-lite-001",
            // "gemini-1.5-flash", //legacy id format
             "publishers/anthropic/models/claude-3-7-sonnet",
             "publishers/meta/models/llama-4-scout-17b-16e-instruct-maas"

--- a/drivers/test/all-models.test.ts
+++ b/drivers/test/all-models.test.ts
@@ -27,8 +27,7 @@ if (process.env.GOOGLE_PROJECT_ID && process.env.GOOGLE_REGION) {
             region: process.env.GOOGLE_REGION as string,
         }),
         models: [
-            "publishers/google/models/gemini-2.0-flash-lite-001",
-           // "gemini-1.5-flash", //legacy id format
+            "publishers/google/models/gemini-2.5-flash-lite",
             "publishers/anthropic/models/claude-3-7-sonnet",
             "publishers/meta/models/llama-4-scout-17b-16e-instruct-maas"
         ]

--- a/drivers/test/assertions.ts
+++ b/drivers/test/assertions.ts
@@ -15,7 +15,7 @@ export function assertCompletionOk(r: ExecutionResponse, model?: string, driver?
     }
     expect(r.finish_reason).toBeTruthy();
     //if r.result is string, it should be longer than 2
-    const stringResult = r.result.map(resultAsString).join();
+    const stringResult = r.result.map(resultAsString).join("");
     expect(stringResult.length).toBeGreaterThan(2);
 }
 
@@ -26,9 +26,9 @@ export async function assertStreamingCompletionOk(stream: CompletionStream, json
         out.push(chunk)
         console.log(chunk)
     }
-    console.log(out.join());
+    console.log(out.join(""));
     const r = stream.completion as ExecutionResponse;
-    const jsonObject = jsonMode ? extractAndParseJSON(out.join()) : undefined;
+    const jsonObject = jsonMode ? extractAndParseJSON(out.join("")) : undefined;
     const jsonResult = jsonMode ? parseResultAsJson(r.result) : undefined;
     console.log(jsonObject);
     console.log(jsonResult);
@@ -40,7 +40,7 @@ export async function assertStreamingCompletionOk(stream: CompletionStream, json
     expect(r.prompt).toBeTruthy();
     expect(r.token_usage).toBeTruthy();
     expect(r.finish_reason).toBeTruthy();
-    const stringResult = r.result.map(resultAsString).join();
+    const stringResult = r.result.map(resultAsString).join("");
     expect(stringResult.length).toBeGreaterThan(2);
 
     return out;

--- a/drivers/test/assertions.ts
+++ b/drivers/test/assertions.ts
@@ -1,6 +1,6 @@
 
 import { Bedrock } from '@aws-sdk/client-bedrock';
-import { AbstractDriver, CompletionStream, ExecutionResponse, extractAndParseJSON, resultAsString } from '@llumiverse/core';
+import { AbstractDriver, CompletionStream, ExecutionResponse, extractAndParseJSON, parseResultAsJson, resultAsString } from '@llumiverse/core';
 import { expect } from "vitest";
 import { BedrockDriver } from '../src';
 
@@ -28,8 +28,10 @@ export async function assertStreamingCompletionOk(stream: CompletionStream, json
 
     const r = stream.completion as ExecutionResponse;
     const jsonObject = jsonMode ? extractAndParseJSON(out.join('')) : undefined;
-
-    if (jsonMode) expect(r.result).toStrictEqual(jsonObject);
+    const jsonResult = jsonMode ? parseResultAsJson(r.result) : undefined;
+    if (jsonMode) {
+        expect(jsonResult).toStrictEqual(jsonObject);
+    }
     
     expect(r.error).toBeFalsy();
     expect(r.prompt).toBeTruthy();

--- a/drivers/test/assertions.ts
+++ b/drivers/test/assertions.ts
@@ -24,11 +24,14 @@ export async function assertStreamingCompletionOk(stream: CompletionStream, json
     const out: string[] = []
     for await (const chunk of stream) {
         out.push(chunk)
+        console.log(chunk)
     }
-
+    console.log(out.join());
     const r = stream.completion as ExecutionResponse;
-    const jsonObject = jsonMode ? extractAndParseJSON(out.join('')) : undefined;
+    const jsonObject = jsonMode ? extractAndParseJSON(out.join()) : undefined;
     const jsonResult = jsonMode ? parseResultAsJson(r.result) : undefined;
+    console.log(jsonObject);
+    console.log(jsonResult);
     if (jsonMode) {
         expect(jsonResult).toStrictEqual(jsonObject);
     }

--- a/drivers/test/assertions.ts
+++ b/drivers/test/assertions.ts
@@ -1,6 +1,6 @@
 
 import { Bedrock } from '@aws-sdk/client-bedrock';
-import { AbstractDriver, CompletionStream, ExecutionResponse, extractAndParseJSON, parseResultAsJson, resultAsString } from '@llumiverse/core';
+import { AbstractDriver, CompletionStream, ExecutionResponse, extractAndParseJSON, parseCompletionResultsToJson, completionResultToString } from '@llumiverse/core';
 import { expect } from "vitest";
 import { BedrockDriver } from '../src';
 
@@ -15,7 +15,7 @@ export function assertCompletionOk(r: ExecutionResponse, model?: string, driver?
     }
     expect(r.finish_reason).toBeTruthy();
     //if r.result is string, it should be longer than 2
-    const stringResult = r.result.map(resultAsString).join("");
+    const stringResult = r.result.map(completionResultToString).join("");
     expect(stringResult.length).toBeGreaterThan(2);
 }
 
@@ -29,7 +29,7 @@ export async function assertStreamingCompletionOk(stream: CompletionStream, json
     console.log(out.join(""));
     const r = stream.completion as ExecutionResponse;
     const jsonObject = jsonMode ? extractAndParseJSON(out.join("")) : undefined;
-    const jsonResult = jsonMode ? parseResultAsJson(r.result) : undefined;
+    const jsonResult = jsonMode ? parseCompletionResultsToJson(r.result) : undefined;
     console.log(jsonObject);
     console.log(jsonResult);
     if (jsonMode) {
@@ -40,7 +40,7 @@ export async function assertStreamingCompletionOk(stream: CompletionStream, json
     expect(r.prompt).toBeTruthy();
     expect(r.token_usage).toBeTruthy();
     expect(r.finish_reason).toBeTruthy();
-    const stringResult = r.result.map(resultAsString).join("");
+    const stringResult = r.result.map(completionResultToString).join("");
     expect(stringResult.length).toBeGreaterThan(2);
 
     return out;

--- a/drivers/test/assertions.ts
+++ b/drivers/test/assertions.ts
@@ -1,10 +1,10 @@
 
 import { Bedrock } from '@aws-sdk/client-bedrock';
-import { CompletionStream, ExecutionResponse, extractAndParseJSON } from '@llumiverse/core';
+import { AbstractDriver, CompletionStream, ExecutionResponse, extractAndParseJSON, resultAsString } from '@llumiverse/core';
 import { expect } from "vitest";
 import { BedrockDriver } from '../src';
 
-export function assertCompletionOk(r: ExecutionResponse, model?: string, driver?) {
+export function assertCompletionOk(r: ExecutionResponse, model?: string, driver?: AbstractDriver) {
     expect(r.error).toBeFalsy();
     expect(r.prompt).toBeTruthy();
     //TODO: This just checks for existence of the object,
@@ -15,13 +15,8 @@ export function assertCompletionOk(r: ExecutionResponse, model?: string, driver?
     }
     expect(r.finish_reason).toBeTruthy();
     //if r.result is string, it should be longer than 2
-    if (typeof r.result === 'string') {
-        expect(r.result.length).toBeGreaterThan(2);
-    } else {
-        //if r.result is object, it should have at least 1 property
-        expect(Object.keys(r.result).length).toBeGreaterThan(0);
-    }
-
+    const stringResult = r.result.map(resultAsString).join();
+    expect(stringResult.length).toBeGreaterThan(2);
 }
 
 export async function assertStreamingCompletionOk(stream: CompletionStream, jsonMode: boolean=false) {
@@ -40,7 +35,8 @@ export async function assertStreamingCompletionOk(stream: CompletionStream, json
     expect(r.prompt).toBeTruthy();
     expect(r.token_usage).toBeTruthy();
     expect(r.finish_reason).toBeTruthy();
-    if (typeof r.result === "string")  expect(r.result?.length).toBeGreaterThan(2);
+    const stringResult = r.result.map(resultAsString).join();
+    expect(stringResult.length).toBeGreaterThan(2);
 
     return out;
 }

--- a/drivers/test/image-gen.test.ts
+++ b/drivers/test/image-gen.test.ts
@@ -68,9 +68,9 @@ describe.concurrent.each(drivers)("Driver $name", ({ name, driver, models }) => 
 
         const res = await driver.requestImageGeneration(testPrompt_textToImage, options);
         expect(res).toBeDefined();
-        expect(res.result).toHaveProperty("images");
-        expect(res.result.images).toHaveLength(1);
-        saveImagesToOutput(res.result.images, `text-to-image-${model}`);
+        expect(res.result).toHaveLength(1);
+        expect(res.result[0]).toHaveProperty("value");
+        saveImagesToOutput(res.result.filter(r => r.type === "image").map(r => r.value), `text-to-image-${model}`);
     });
 
     test.each(models)(`${name}: text to image guidance`, {timeout: 300*1000}, async (model) => {
@@ -88,9 +88,9 @@ describe.concurrent.each(drivers)("Driver $name", ({ name, driver, models }) => 
 
         const res = await driver.requestImageGeneration(testPrompt_textToImageGuidance, options);
         expect(res).toBeDefined();
-        expect(res.result).toHaveProperty("images");
-        expect(res.result.images).toHaveLength(1);
-        saveImagesToOutput(res.result.images, `text-to-image-guidance-${model}`);
+        expect(res.result).toHaveLength(1);
+        expect(res.result[0]).toHaveProperty("value");
+        saveImagesToOutput(res.result.filter(r => r.type === "image").map(r => r.value), `text-to-image-guidance-${model}`);
     });
 
 
@@ -107,10 +107,9 @@ describe.concurrent.each(drivers)("Driver $name", ({ name, driver, models }) => 
 
         const res = await driver.requestImageGeneration(testPrompt_imageVariations, options);
         expect(res).toBeDefined();
-        expect(res.result).toHaveProperty("images");
-        expect(res.result.images).toHaveLength(1);
-        saveImagesToOutput(res.result.images, `text-to-image-variation-${model}`);
-
+        expect(res.result).toHaveLength(1);
+        expect(res.result[0]).toHaveProperty("value");
+        saveImagesToOutput(res.result.filter(r => r.type === "image").map(r => r.value), `text-to-image-variation-${model}`);
     });
 
 });

--- a/drivers/test/samples.ts
+++ b/drivers/test/samples.ts
@@ -24,7 +24,7 @@ export const testSchema_color: JSONSchema = {
 
 class ImageSource implements DataSource {
     file: string;
-    mime_type: "image/jpeg";
+    mime_type: "image/jpeg" = "image/jpeg";
     constructor(file: string) {
         this.file = resolve(file);
     }

--- a/drivers/test/tools.test.ts
+++ b/drivers/test/tools.test.ts
@@ -240,7 +240,7 @@ describe.concurrent.each(drivers)("Driver $name", ({ name, driver, models }) => 
             tool_use_id: tool_use[0].id,
             content: "15 degrees"
         } satisfies PromptSegment], { ...options, conversation: r.conversation });
-        const stringResult = r.result.map(resultAsString).join();
+        const stringResult = r.result.map(resultAsString).join("");
         expect(stringResult.includes("15 degrees")).toBeTruthy();
         //console.log("#######Result:", r.result, model);
     });

--- a/drivers/test/tools.test.ts
+++ b/drivers/test/tools.test.ts
@@ -27,7 +27,7 @@ if (process.env.GOOGLE_PROJECT_ID && process.env.GOOGLE_REGION) {
             region: process.env.GOOGLE_REGION as string,
         }),
         models: [
-            "gemini-1.5-pro",
+            "publishers/google/models/gemini-2.5-flash",
             "publishers/anthropic/models/claude-3-7-sonnet",
         ]
     })
@@ -112,7 +112,7 @@ if (process.env.BEDROCK_REGION) {
         }),
         //Use foundation models and inference profiles to test the driver
         models: [
-            "anthropic.claude-3-5-sonnet-20240620-v1:0",
+            "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
             //"us.writer.palmyra-x5-v1:0" // Only in us-west-2
         ],
     });

--- a/drivers/test/tools.test.ts
+++ b/drivers/test/tools.test.ts
@@ -1,4 +1,4 @@
-import { AIModel, AbstractDriver, ExecutionOptions, Modalities, PromptRole, PromptSegment, resultAsString } from '@llumiverse/core';
+import { AIModel, AbstractDriver, ExecutionOptions, Modalities, PromptRole, PromptSegment, completionResultToString } from '@llumiverse/core';
 import 'dotenv/config';
 import { GoogleAuth } from 'google-auth-library';
 import { describe, expect, test } from "vitest";
@@ -240,7 +240,7 @@ describe.concurrent.each(drivers)("Driver $name", ({ name, driver, models }) => 
             tool_use_id: tool_use[0].id,
             content: "15 degrees"
         } satisfies PromptSegment], { ...options, conversation: r.conversation });
-        const stringResult = r.result.map(resultAsString).join("");
+        const stringResult = r.result.map(completionResultToString).join("");
         expect(stringResult.includes("15 degrees")).toBeTruthy();
         //console.log("#######Result:", r.result, model);
     });

--- a/drivers/test/tools.test.ts
+++ b/drivers/test/tools.test.ts
@@ -1,4 +1,4 @@
-import { AIModel, AbstractDriver, ExecutionOptions, Modalities, PromptRole, PromptSegment } from '@llumiverse/core';
+import { AIModel, AbstractDriver, ExecutionOptions, Modalities, PromptRole, PromptSegment, resultAsString } from '@llumiverse/core';
 import 'dotenv/config';
 import { GoogleAuth } from 'google-auth-library';
 import { describe, expect, test } from "vitest";
@@ -240,7 +240,8 @@ describe.concurrent.each(drivers)("Driver $name", ({ name, driver, models }) => 
             tool_use_id: tool_use[0].id,
             content: "15 degrees"
         } satisfies PromptSegment], { ...options, conversation: r.conversation });
-        expect(r.result.includes("15 degrees")).toBeTruthy();
+        const stringResult = r.result.map(resultAsString).join();
+        expect(stringResult.includes("15 degrees")).toBeTruthy();
         //console.log("#######Result:", r.result, model);
     });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,8 +136,8 @@ importers:
         specifier: ^3.35.0
         version: 3.35.0
       '@google/genai':
-        specifier: ^1.17.0
-        version: 1.17.0(@modelcontextprotocol/sdk@1.12.0)
+        specifier: ^1.20.0
+        version: 1.20.0(@modelcontextprotocol/sdk@1.12.0)
       '@huggingface/inference':
         specifier: 2.6.7
         version: 2.6.7
@@ -698,8 +698,8 @@ packages:
     resolution: {integrity: sha512-Eo+ckr1KbTxAOew9P+MeeR0aQXeW5PeOzrSM1JyGny/SGKejwX/RcGWSFpeapnlegTfI9N9xJeUeo3M+XBOeFg==}
     engines: {node: '>=14.0.0'}
 
-  '@google/genai@1.17.0':
-    resolution: {integrity: sha512-r/OZWN9D8WvYrte3bcKPoLODrZ+2TjfxHm5OOyVHUbdFYIp1C4yJaXX4+sCS8I/+CbN9PxLjU5zm1cgmS7qz+A==}
+  '@google/genai@1.20.0':
+    resolution: {integrity: sha512-QdShxO9LX35jFogy3iKprQNqgKKveux4H2QjOnyIvyHRuGi6PHiz3fjNf8Y0VPY8o5V2fHqR2XqiSVoz7yZs0w==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.11.4
@@ -3679,7 +3679,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@google/genai@1.17.0(@modelcontextprotocol/sdk@1.12.0)':
+  '@google/genai@1.20.0(@modelcontextprotocol/sdk@1.12.0)':
     dependencies:
       google-auth-library: 9.15.1
       ws: 8.18.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,8 +136,8 @@ importers:
         specifier: ^3.35.0
         version: 3.35.0
       '@google/genai':
-        specifier: ^1.7.0
-        version: 1.7.0(@modelcontextprotocol/sdk@1.12.0)
+        specifier: ^1.17.0
+        version: 1.17.0(@modelcontextprotocol/sdk@1.12.0)
       '@huggingface/inference':
         specifier: 2.6.7
         version: 2.6.7
@@ -698,11 +698,11 @@ packages:
     resolution: {integrity: sha512-Eo+ckr1KbTxAOew9P+MeeR0aQXeW5PeOzrSM1JyGny/SGKejwX/RcGWSFpeapnlegTfI9N9xJeUeo3M+XBOeFg==}
     engines: {node: '>=14.0.0'}
 
-  '@google/genai@1.7.0':
-    resolution: {integrity: sha512-s/OZLkrIfBwc+SFFaZoKdEogkw4in0YRTGc4Q483jnfchNBWzrNe560eZEfGJHQRPn6YfzJgECCx0sqEOMWvYw==}
+  '@google/genai@1.17.0':
+    resolution: {integrity: sha512-r/OZWN9D8WvYrte3bcKPoLODrZ+2TjfxHm5OOyVHUbdFYIp1C4yJaXX4+sCS8I/+CbN9PxLjU5zm1cgmS7qz+A==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
-      '@modelcontextprotocol/sdk': ^1.11.0
+      '@modelcontextprotocol/sdk': ^1.11.4
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
         optional: true
@@ -3679,12 +3679,10 @@ snapshots:
       - encoding
       - supports-color
 
-  '@google/genai@1.7.0(@modelcontextprotocol/sdk@1.12.0)':
+  '@google/genai@1.17.0(@modelcontextprotocol/sdk@1.12.0)':
     dependencies:
       google-auth-library: 9.15.1
       ws: 8.18.2
-      zod: 3.25.63
-      zod-to-json-schema: 3.24.6(zod@3.25.63)
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.12.0
     transitivePeerDependencies:
@@ -5929,5 +5927,7 @@ snapshots:
   zod-to-json-schema@3.24.6(zod@3.25.63):
     dependencies:
       zod: 3.25.63
+    optional: true
 
-  zod@3.25.63: {}
+  zod@3.25.63:
+    optional: true


### PR DESCRIPTION
This is a major change, moving to structured output for Completion.result, the main output of llumiverse.
Previously this was any, but was in essence either a string or a JSON object.

See type definition:
https://github.com/vertesia/llumiverse/blob/feat-multimodal-output/common/src/types.ts

Example
`[{type: "text", value: "hello world"},{type: "image", value: <image binary data as string>}]`

There are some helper functions to make the transition easier.


Other changes:
Support for global endpoints on google models in vertexai, exposed in listing and available regardless of default region.
Nano-banana support.