### PR TITLE
feat(batch): async batch inference for OpenAI, Vertex, and Bedrock

### DIFF
--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -954,10 +954,25 @@ export interface BatchInferenceRequestItem {
  * provided, the driver falls back to a bucket configured in its driver options
  * (e.g. `batch_bucket` for Vertex/Bedrock).
  */
+/**
+ * Blob I/O for batch staging, injected by the caller so the driver does not need its own
+ * cloud-storage credentials. When provided, the driver delegates input upload + output read
+ * to it (e.g. a host that stages through its own storage service / tenant bucket) instead of
+ * writing/reading the object store directly. If absent, the driver uses its native staging
+ * (its own GCS/S3 client + configured bucket).
+ */
+export interface BatchBlobStore {
+    /** Write `content` at bucket-relative `path`; return the absolute URI written (gs://… or s3://…). */
+    putText(path: string, content: string): Promise<string>;
+    /** List objects under `outputUri` and return each output object's text content. */
+    readOutput(outputUri: string): Promise<string[]>;
+}
+
 export interface BatchInferenceOptions {
     name?: string; // display name / job-name prefix
     input_uri?: string; // pre-staged input JSONL location (gs://… or s3://…) — overrides driver staging
     output_uri?: string; // output location (gs://… or s3://…) — overrides driver default
+    blobStore?: BatchBlobStore; // inject blob I/O so the driver never needs its own storage credentials
 }
 
 export interface BatchInferenceJob {

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -926,6 +926,58 @@ export interface TrainingJob {
     model?: string; // the name of the fine tuned model which is created
 }
 
+// ============== batch inference =====================
+
+export enum BatchInferenceJobStatus {
+    queued = 'queued',
+    running = 'running',
+    succeeded = 'succeeded',
+    failed = 'failed',
+    cancelled = 'cancelled',
+}
+
+/**
+ * A single request in a batch. `custom_id` is echoed back on the matching result
+ * so callers can map a result to their own unit of work (e.g. a document page).
+ * `segments`/`options` are the SAME inputs the synchronous `execute()` takes, so the
+ * batch request is formatted by the driver's existing `createPrompt` — guaranteeing
+ * batch output matches interactive output for the same model.
+ */
+export interface BatchInferenceRequestItem {
+    custom_id: string;
+    segments: PromptSegment[];
+    options: ExecutionOptions;
+}
+
+/**
+ * Options controlling where the driver stages the batch input/output. If not
+ * provided, the driver falls back to a bucket configured in its driver options
+ * (e.g. `batch_bucket` for Vertex/Bedrock).
+ */
+export interface BatchInferenceOptions {
+    name?: string; // display name / job-name prefix
+    input_uri?: string; // pre-staged input JSONL location (gs://… or s3://…) — overrides driver staging
+    output_uri?: string; // output location (gs://… or s3://…) — overrides driver default
+}
+
+export interface BatchInferenceJob {
+    id: string; // provider job resource name / id
+    status: BatchInferenceJobStatus;
+    details?: string; // status detail or error message
+    output_uri?: string; // location of the results once available (gs://… or s3://…)
+    request_count?: number; // number of requests submitted, when known
+    start_time?: number; // epoch millis
+    end_time?: number; // epoch millis
+}
+
+export interface BatchInferenceResultItem {
+    custom_id: string;
+    result?: CompletionResult[];
+    token_usage?: ExecutionTokenUsage;
+    finish_reason?: string;
+    error?: string;
+}
+
 export type JSONPrimitive = string | number | boolean | null;
 export type JSONArray = JSONValue[];
 export type JSONObject = { [key: string]: JSONValue };

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -873,6 +873,58 @@ export interface TrainingJob {
     model?: string; // the name of the fine tuned model which is created
 }
 
+// ============== batch inference =====================
+
+export enum BatchInferenceJobStatus {
+    queued = 'queued',
+    running = 'running',
+    succeeded = 'succeeded',
+    failed = 'failed',
+    cancelled = 'cancelled',
+}
+
+/**
+ * A single request in a batch. `custom_id` is echoed back on the matching result
+ * so callers can map a result to their own unit of work (e.g. a document page).
+ * `segments`/`options` are the SAME inputs the synchronous `execute()` takes, so the
+ * batch request is formatted by the driver's existing `createPrompt` — guaranteeing
+ * batch output matches interactive output for the same model.
+ */
+export interface BatchInferenceRequestItem {
+    custom_id: string;
+    segments: PromptSegment[];
+    options: ExecutionOptions;
+}
+
+/**
+ * Options controlling where the driver stages the batch input/output. If not
+ * provided, the driver falls back to a bucket configured in its driver options
+ * (e.g. `batch_bucket` for Vertex/Bedrock).
+ */
+export interface BatchInferenceOptions {
+    name?: string; // display name / job-name prefix
+    input_uri?: string; // pre-staged input JSONL location (gs://… or s3://…) — overrides driver staging
+    output_uri?: string; // output location (gs://… or s3://…) — overrides driver default
+}
+
+export interface BatchInferenceJob {
+    id: string; // provider job resource name / id
+    status: BatchInferenceJobStatus;
+    details?: string; // status detail or error message
+    output_uri?: string; // location of the results once available (gs://… or s3://…)
+    request_count?: number; // number of requests submitted, when known
+    start_time?: number; // epoch millis
+    end_time?: number; // epoch millis
+}
+
+export interface BatchInferenceResultItem {
+    custom_id: string;
+    result?: CompletionResult[];
+    token_usage?: ExecutionTokenUsage;
+    finish_reason?: string;
+    error?: string;
+}
+
 export type JSONPrimitive = string | number | boolean | null;
 export type JSONArray = JSONValue[];
 export type JSONObject = { [key: string]: JSONValue };

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -901,10 +901,25 @@ export interface BatchInferenceRequestItem {
  * provided, the driver falls back to a bucket configured in its driver options
  * (e.g. `batch_bucket` for Vertex/Bedrock).
  */
+/**
+ * Blob I/O for batch staging, injected by the caller so the driver does not need its own
+ * cloud-storage credentials. When provided, the driver delegates input upload + output read
+ * to it (e.g. a host that stages through its own storage service / tenant bucket) instead of
+ * writing/reading the object store directly. If absent, the driver uses its native staging
+ * (its own GCS/S3 client + configured bucket).
+ */
+export interface BatchBlobStore {
+    /** Write `content` at bucket-relative `path`; return the absolute URI written (gs://… or s3://…). */
+    putText(path: string, content: string): Promise<string>;
+    /** List objects under `outputUri` and return each output object's text content. */
+    readOutput(outputUri: string): Promise<string[]>;
+}
+
 export interface BatchInferenceOptions {
     name?: string; // display name / job-name prefix
     input_uri?: string; // pre-staged input JSONL location (gs://… or s3://…) — overrides driver staging
     output_uri?: string; // output location (gs://… or s3://…) — overrides driver default
+    blobStore?: BatchBlobStore; // inject blob I/O so the driver never needs its own storage credentials
 }
 
 export interface BatchInferenceJob {

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -897,11 +897,6 @@ export interface BatchInferenceRequestItem {
 }
 
 /**
- * Options controlling where the driver stages the batch input/output. If not
- * provided, the driver falls back to a bucket configured in its driver options
- * (e.g. `batch_bucket` for Vertex/Bedrock).
- */
-/**
  * Blob I/O for batch staging, injected by the caller so the driver does not need its own
  * cloud-storage credentials. When provided, the driver delegates input upload + output read
  * to it (e.g. a host that stages through its own storage service / tenant bucket) instead of
@@ -915,11 +910,36 @@ export interface BatchBlobStore {
     readOutput(outputUri: string): Promise<string[]>;
 }
 
+/**
+ * Options controlling where the driver stages the batch input/output. If neither
+ * `input_uri` nor `blobStore` is provided, the driver falls back to a bucket configured
+ * in its driver options (e.g. `batch_bucket` for Vertex/Bedrock).
+ */
 export interface BatchInferenceOptions {
     name?: string; // display name / job-name prefix
-    input_uri?: string; // pre-staged input JSONL location (gs://… or s3://…) — overrides driver staging
-    output_uri?: string; // output location (gs://… or s3://…) — overrides driver default
+    /**
+     * Staging bucket/prefix spec (`gs://bucket/prefix`, `s3://bucket/prefix`, `bucket/prefix`
+     * or bare `bucket`) under which the driver stages a fresh `input.jsonl` (and the job's
+     * output directory) for this run. Takes precedence over the driver-level `batch_bucket`
+     * option. Ignored when a `blobStore` is injected.
+     */
+    input_uri?: string;
     blobStore?: BatchBlobStore; // inject blob I/O so the driver never needs its own storage credentials
+}
+
+/**
+ * Provider-enforced sizing limits for a single batch-inference job, surfaced so a host
+ * can split an oversized request pool into several provider jobs before submitting.
+ */
+export interface BatchInferenceLimits {
+    /** maximum requests per batch job */
+    max_requests_per_job: number;
+    /** maximum serialized input size per job in bytes, if the provider enforces one */
+    max_input_bytes?: number;
+    /** provider-enforced minimum requests per job, if any */
+    min_requests_per_job?: number;
+    /** maximum concurrently running batch jobs, if the provider documents one */
+    max_concurrent_jobs?: number;
 }
 
 export interface BatchInferenceJob {

--- a/core/src/Driver.ts
+++ b/core/src/Driver.ts
@@ -6,6 +6,10 @@
 
 import {
     type AIModel,
+    type BatchInferenceJob,
+    type BatchInferenceOptions,
+    type BatchInferenceRequestItem,
+    type BatchInferenceResultItem,
     type Completion,
     type CompletionChunkObject,
     type CompletionStream,
@@ -69,6 +73,31 @@ export interface Driver<PromptT = unknown> {
     cancelTraining(jobId: string): Promise<TrainingJob>;
 
     getTrainingJob(jobId: string): Promise<TrainingJob>;
+
+    /**
+     * Submit a batch of inference requests to the provider's asynchronous batch API.
+     * Each request is formatted with the driver's `createPrompt`, so batch output
+     * matches interactive output for the same model. Returns a job handle to poll.
+     * Only supported by drivers whose provider offers a batch API (Vertex, Bedrock, …).
+     */
+    startBatchInference(
+        requests: BatchInferenceRequestItem[],
+        options?: BatchInferenceOptions,
+    ): Promise<BatchInferenceJob>;
+
+    getBatchInferenceJob(jobId: string): Promise<BatchInferenceJob>;
+
+    cancelBatchInference(jobId: string): Promise<BatchInferenceJob>;
+
+    /** Fetch the results of a completed batch job, mapped back by `custom_id`. */
+    getBatchInferenceResults(jobId: string): Promise<BatchInferenceResultItem[]>;
+
+    /**
+     * Whether this driver's provider offers a batch-inference API that this driver
+     * implements. Callers query this to decide whether to route work to the batch
+     * path or fall back to synchronous execution. Optionally refined per model.
+     */
+    supportsBatchInference(model?: string): boolean;
 
     //list models available for this environment
     listModels(params?: ModelSearchPayload): Promise<AIModel[]>;
@@ -170,6 +199,29 @@ export abstract class AbstractDriver<OptionsT extends DriverOptions = DriverOpti
 
     getTrainingJob(_jobId: string): Promise<TrainingJob> {
         throw new Error('Method not implemented.');
+    }
+
+    startBatchInference(
+        _requests: BatchInferenceRequestItem[],
+        _options?: BatchInferenceOptions,
+    ): Promise<BatchInferenceJob> {
+        throw new Error(`[${this.provider}] Batch inference is not supported by this driver.`);
+    }
+
+    getBatchInferenceJob(_jobId: string): Promise<BatchInferenceJob> {
+        throw new Error(`[${this.provider}] Batch inference is not supported by this driver.`);
+    }
+
+    cancelBatchInference(_jobId: string): Promise<BatchInferenceJob> {
+        throw new Error(`[${this.provider}] Batch inference is not supported by this driver.`);
+    }
+
+    getBatchInferenceResults(_jobId: string): Promise<BatchInferenceResultItem[]> {
+        throw new Error(`[${this.provider}] Batch inference is not supported by this driver.`);
+    }
+
+    supportsBatchInference(_model?: string): boolean {
+        return false;
     }
 
     validateResult(result: Completion, options: ExecutionOptions) {

--- a/core/src/Driver.ts
+++ b/core/src/Driver.ts
@@ -6,6 +6,7 @@
 
 import {
     type AIModel,
+    type BatchBlobStore,
     type BatchInferenceJob,
     type BatchInferenceOptions,
     type BatchInferenceRequestItem,
@@ -89,8 +90,14 @@ export interface Driver<PromptT = unknown> {
 
     cancelBatchInference(jobId: string): Promise<BatchInferenceJob>;
 
-    /** Fetch the results of a completed batch job, mapped back by `custom_id`. */
-    getBatchInferenceResults(jobId: string): Promise<BatchInferenceResultItem[]>;
+    /**
+     * Fetch the results of a completed batch job, mapped back by `custom_id`.
+     * Pass `blobStore` to read the output through injected blob I/O (mirrors the store used at submit).
+     */
+    getBatchInferenceResults(
+        jobId: string,
+        options?: { blobStore?: BatchBlobStore },
+    ): Promise<BatchInferenceResultItem[]>;
 
     /**
      * Whether this driver's provider offers a batch-inference API that this driver
@@ -216,7 +223,10 @@ export abstract class AbstractDriver<OptionsT extends DriverOptions = DriverOpti
         throw new Error(`[${this.provider}] Batch inference is not supported by this driver.`);
     }
 
-    getBatchInferenceResults(_jobId: string): Promise<BatchInferenceResultItem[]> {
+    getBatchInferenceResults(
+        _jobId: string,
+        _options?: { blobStore?: BatchBlobStore },
+    ): Promise<BatchInferenceResultItem[]> {
         throw new Error(`[${this.provider}] Batch inference is not supported by this driver.`);
     }
 

--- a/core/src/Driver.ts
+++ b/core/src/Driver.ts
@@ -6,6 +6,10 @@
 
 import {
     type AIModel,
+    type BatchInferenceJob,
+    type BatchInferenceOptions,
+    type BatchInferenceRequestItem,
+    type BatchInferenceResultItem,
     type Completion,
     type CompletionStream,
     type DataSource,
@@ -69,6 +73,31 @@ export interface Driver<PromptT = unknown> {
     cancelTraining(jobId: string): Promise<TrainingJob>;
 
     getTrainingJob(jobId: string): Promise<TrainingJob>;
+
+    /**
+     * Submit a batch of inference requests to the provider's asynchronous batch API.
+     * Each request is formatted with the driver's `createPrompt`, so batch output
+     * matches interactive output for the same model. Returns a job handle to poll.
+     * Only supported by drivers whose provider offers a batch API (Vertex, Bedrock, …).
+     */
+    startBatchInference(
+        requests: BatchInferenceRequestItem[],
+        options?: BatchInferenceOptions,
+    ): Promise<BatchInferenceJob>;
+
+    getBatchInferenceJob(jobId: string): Promise<BatchInferenceJob>;
+
+    cancelBatchInference(jobId: string): Promise<BatchInferenceJob>;
+
+    /** Fetch the results of a completed batch job, mapped back by `custom_id`. */
+    getBatchInferenceResults(jobId: string): Promise<BatchInferenceResultItem[]>;
+
+    /**
+     * Whether this driver's provider offers a batch-inference API that this driver
+     * implements. Callers query this to decide whether to route work to the batch
+     * path or fall back to synchronous execution. Optionally refined per model.
+     */
+    supportsBatchInference(model?: string): boolean;
 
     //list models available for this environment
     listModels(params?: ModelSearchPayload): Promise<AIModel[]>;
@@ -170,6 +199,29 @@ export abstract class AbstractDriver<OptionsT extends DriverOptions = DriverOpti
 
     getTrainingJob(_jobId: string): Promise<TrainingJob> {
         throw new Error('Method not implemented.');
+    }
+
+    startBatchInference(
+        _requests: BatchInferenceRequestItem[],
+        _options?: BatchInferenceOptions,
+    ): Promise<BatchInferenceJob> {
+        throw new Error(`[${this.provider}] Batch inference is not supported by this driver.`);
+    }
+
+    getBatchInferenceJob(_jobId: string): Promise<BatchInferenceJob> {
+        throw new Error(`[${this.provider}] Batch inference is not supported by this driver.`);
+    }
+
+    cancelBatchInference(_jobId: string): Promise<BatchInferenceJob> {
+        throw new Error(`[${this.provider}] Batch inference is not supported by this driver.`);
+    }
+
+    getBatchInferenceResults(_jobId: string): Promise<BatchInferenceResultItem[]> {
+        throw new Error(`[${this.provider}] Batch inference is not supported by this driver.`);
+    }
+
+    supportsBatchInference(_model?: string): boolean {
+        return false;
     }
 
     validateResult(result: Completion, options: ExecutionOptions) {

--- a/core/src/Driver.ts
+++ b/core/src/Driver.ts
@@ -8,6 +8,7 @@ import {
     type AIModel,
     type BatchBlobStore,
     type BatchInferenceJob,
+    type BatchInferenceLimits,
     type BatchInferenceOptions,
     type BatchInferenceRequestItem,
     type BatchInferenceResultItem,
@@ -93,6 +94,10 @@ export interface Driver<PromptT = unknown> {
     /**
      * Fetch the results of a completed batch job, mapped back by `custom_id`.
      * Pass `blobStore` to read the output through injected blob I/O (mirrors the store used at submit).
+     *
+     * NOTE: batch results are text-only today — every provider parser returns `text`
+     * completion results (plus token usage / finish reason). Function/tool calls and
+     * images produced by a batch request are not surfaced through this path.
      */
     getBatchInferenceResults(
         jobId: string,
@@ -105,6 +110,13 @@ export interface Driver<PromptT = unknown> {
      * path or fall back to synchronous execution. Optionally refined per model.
      */
     supportsBatchInference(model?: string): boolean;
+
+    /**
+     * Provider-enforced sizing limits for a single batch job (request count, input
+     * bytes, …). Hosts use this to split an oversized request pool into several
+     * provider jobs before calling `startBatchInference`. Optionally refined per model.
+     */
+    getBatchInferenceLimits(model?: string): BatchInferenceLimits;
 
     //list models available for this environment
     listModels(params?: ModelSearchPayload): Promise<AIModel[]>;
@@ -232,6 +244,14 @@ export abstract class AbstractDriver<OptionsT extends DriverOptions = DriverOpti
 
     supportsBatchInference(_model?: string): boolean {
         return false;
+    }
+
+    /**
+     * Conservative default batch-job limits. Drivers that implement batch inference
+     * override this with their provider's documented quotas.
+     */
+    getBatchInferenceLimits(_model?: string): BatchInferenceLimits {
+        return { max_requests_per_job: 10_000 };
     }
 
     validateResult(result: Completion, options: ExecutionOptions) {

--- a/drivers/src/batch-location.ts
+++ b/drivers/src/batch-location.ts
@@ -1,0 +1,26 @@
+export interface BatchBucketLocation {
+    bucket: string;
+    prefix: string;
+}
+
+export function parseBatchBucketLocation(spec: string, scheme: 'gs' | 's3'): BatchBucketLocation {
+    let value = spec.trim();
+    const schemePrefix = `${scheme}://`;
+    if (value.startsWith(schemePrefix)) {
+        value = value.slice(schemePrefix.length);
+    }
+
+    const slash = value.indexOf('/');
+    if (slash === -1) {
+        return { bucket: value, prefix: '' };
+    }
+
+    let prefixEnd = value.length;
+    while (prefixEnd > slash + 1 && value[prefixEnd - 1] === '/') {
+        prefixEnd--;
+    }
+    return {
+        bucket: value.slice(0, slash),
+        prefix: value.slice(slash + 1, prefixEnd),
+    };
+}

--- a/drivers/src/bedrock/batch.ts
+++ b/drivers/src/bedrock/batch.ts
@@ -1,0 +1,169 @@
+/**
+ * Batch-inference helpers for the Bedrock driver.
+ *
+ * Uses Bedrock's asynchronous batch inference (`CreateModelInvocationJob`) with
+ * S3-staged JSONL input/output. Each line is `{ recordId, modelInput }`; the output
+ * is `{ recordId, modelOutput }`, so `recordId` carries the caller's `custom_id`.
+ *
+ * NOTE: Bedrock batch uses the model-native **InvokeModel** body for `modelInput`
+ * (NOT the Converse API shape the driver uses for synchronous calls). This module
+ * parses the common native response shapes (Anthropic Messages, Amazon Nova). Full
+ * parity for every model family (Converse → native request mapping) is a follow-up.
+ * Bedrock batch also requires a minimum number of records per job and an IAM role
+ * with S3 access — see the driver methods.
+ */
+
+import { GetObjectCommand, ListObjectsV2Command, PutObjectCommand, type S3Client } from '@aws-sdk/client-s3';
+import {
+    BatchInferenceJobStatus,
+    type BatchInferenceResultItem,
+    type CompletionResult,
+    type ExecutionTokenUsage,
+} from '@llumiverse/common';
+
+// ---------------------------------------------------------------------------
+// S3 text I/O
+// ---------------------------------------------------------------------------
+
+export interface S3Location {
+    bucket: string;
+    prefix: string;
+}
+
+/** Parse "s3://bucket/prefix", "bucket/prefix" or "bucket" into {bucket, prefix}. */
+export function parseS3Bucket(spec: string): S3Location {
+    let s = spec.trim();
+    if (s.startsWith('s3://')) {
+        s = s.slice('s3://'.length);
+    }
+    const slash = s.indexOf('/');
+    if (slash === -1) {
+        return { bucket: s, prefix: '' };
+    }
+    return { bucket: s.slice(0, slash), prefix: s.slice(slash + 1).replace(/\/+$/, '') };
+}
+
+export async function s3UploadText(s3: S3Client, bucket: string, key: string, text: string): Promise<string> {
+    await s3.send(new PutObjectCommand({ Bucket: bucket, Key: key, Body: text, ContentType: 'application/jsonl' }));
+    return `s3://${bucket}/${key}`;
+}
+
+export async function s3DownloadText(s3: S3Client, bucket: string, key: string): Promise<string> {
+    const res = await s3.send(new GetObjectCommand({ Bucket: bucket, Key: key }));
+    return (await res.Body?.transformToString()) ?? '';
+}
+
+export async function s3List(s3: S3Client, bucket: string, prefix: string): Promise<string[]> {
+    const res = await s3.send(new ListObjectsV2Command({ Bucket: bucket, Prefix: prefix }));
+    return (res.Contents ?? []).map((o) => o.Key ?? '').filter(Boolean);
+}
+
+// ---------------------------------------------------------------------------
+// Status + response mapping
+// ---------------------------------------------------------------------------
+
+/** Map a Bedrock ModelInvocationJobStatus to our provider-agnostic batch status. */
+export function mapModelInvocationJobStatus(status: string | undefined): BatchInferenceJobStatus {
+    switch (status) {
+        case 'Completed':
+            return BatchInferenceJobStatus.succeeded;
+        case 'PartiallyCompleted':
+            return BatchInferenceJobStatus.succeeded;
+        case 'Failed':
+        case 'Expired':
+            return BatchInferenceJobStatus.failed;
+        case 'Stopped':
+        case 'Stopping':
+            return BatchInferenceJobStatus.cancelled;
+        case 'Submitted':
+        case 'Validating':
+        case 'Scheduled':
+            return BatchInferenceJobStatus.queued;
+        default:
+            // InProgress or anything new
+            return BatchInferenceJobStatus.running;
+    }
+}
+
+interface NativeModelOutput {
+    // Anthropic Messages
+    content?: Array<{ type?: string; text?: string }>;
+    usage?: {
+        input_tokens?: number;
+        output_tokens?: number;
+        inputTokens?: number;
+        outputTokens?: number;
+        totalTokens?: number;
+    };
+    stop_reason?: string;
+    // Amazon Nova / Converse-style
+    output?: { message?: { content?: Array<{ text?: string }> } };
+    stopReason?: string;
+    // Amazon Titan
+    results?: Array<{ outputText?: string; completionReason?: string }>;
+}
+
+/** Extract text + token usage from a native Bedrock modelOutput (Anthropic / Nova / Titan shapes). */
+export function parseNativeModelOutput(modelOutput: NativeModelOutput | undefined): {
+    result: CompletionResult[];
+    token_usage?: ExecutionTokenUsage;
+    finish_reason?: string;
+} {
+    const result: CompletionResult[] = [];
+    let finish_reason: string | undefined;
+
+    if (Array.isArray(modelOutput?.content)) {
+        // Anthropic Messages
+        for (const c of modelOutput.content) {
+            if (typeof c.text === 'string' && c.text.length > 0) {
+                result.push({ type: 'text', value: c.text });
+            }
+        }
+        finish_reason = modelOutput.stop_reason;
+    } else if (modelOutput?.output?.message?.content) {
+        // Amazon Nova / Converse-style native output
+        for (const c of modelOutput.output.message.content) {
+            if (typeof c.text === 'string' && c.text.length > 0) {
+                result.push({ type: 'text', value: c.text });
+            }
+        }
+        finish_reason = modelOutput.stopReason;
+    } else if (Array.isArray(modelOutput?.results)) {
+        // Amazon Titan
+        for (const r of modelOutput.results) {
+            if (typeof r.outputText === 'string' && r.outputText.length > 0) {
+                result.push({ type: 'text', value: r.outputText });
+            }
+        }
+        finish_reason = modelOutput.results[0]?.completionReason;
+    }
+
+    const u = modelOutput?.usage;
+    const prompt = u?.input_tokens ?? u?.inputTokens;
+    const output = u?.output_tokens ?? u?.outputTokens;
+    const token_usage: ExecutionTokenUsage | undefined =
+        prompt == null && output == null
+            ? undefined
+            : { prompt, result: output, total: u?.totalTokens ?? (prompt ?? 0) + (output ?? 0) };
+
+    return { result, token_usage, finish_reason };
+}
+
+/** Parse a single Bedrock batch output JSONL line (`{ recordId, modelOutput }`). */
+export function parseBedrockBatchOutputLine(line: string, index: number): BatchInferenceResultItem | undefined {
+    const trimmed = line.trim();
+    if (!trimmed) {
+        return undefined;
+    }
+    let obj: { recordId?: string; modelOutput?: NativeModelOutput; error?: unknown };
+    try {
+        obj = JSON.parse(trimmed);
+    } catch {
+        return undefined;
+    }
+    const custom_id = obj.recordId ?? String(index);
+    if (obj.modelOutput) {
+        return { custom_id, ...parseNativeModelOutput(obj.modelOutput) };
+    }
+    return { custom_id, error: obj.error ? JSON.stringify(obj.error) : 'no modelOutput in batch record' };
+}

--- a/drivers/src/bedrock/batch.ts
+++ b/drivers/src/bedrock/batch.ts
@@ -47,8 +47,34 @@ export async function s3DownloadText(s3: S3Client, bucket: string, key: string):
 }
 
 export async function s3List(s3: S3Client, bucket: string, prefix: string): Promise<string[]> {
-    const res = await s3.send(new ListObjectsV2Command({ Bucket: bucket, Prefix: prefix }));
-    return (res.Contents ?? []).map((o) => o.Key ?? '').filter(Boolean);
+    const keys: string[] = [];
+    let continuationToken: string | undefined;
+    do {
+        const res = await s3.send(
+            new ListObjectsV2Command({ Bucket: bucket, Prefix: prefix, ContinuationToken: continuationToken }),
+        );
+        for (const o of res.Contents ?? []) {
+            if (o.Key) {
+                keys.push(o.Key);
+            }
+        }
+        continuationToken = res.IsTruncated ? res.NextContinuationToken : undefined;
+    } while (continuationToken);
+    return keys;
+}
+
+/**
+ * Whether an S3 key under the job's output prefix is a record-output file to parse.
+ * Bedrock writes per-record output as `<input-file>.jsonl.out` plus a job-summary
+ * `manifest.json.out` — the manifest is NOT a record file and must be excluded, or it
+ * is ingested as a phantom failed record.
+ */
+export function isBedrockBatchOutputKey(key: string): boolean {
+    const name = key.split('/').pop() ?? key;
+    if (name.startsWith('manifest.')) {
+        return false;
+    }
+    return name.endsWith('.jsonl') || name.endsWith('.out');
 }
 
 // ---------------------------------------------------------------------------

--- a/drivers/src/bedrock/batch.ts
+++ b/drivers/src/bedrock/batch.ts
@@ -20,6 +20,7 @@ import {
     type CompletionResult,
     type ExecutionTokenUsage,
 } from '@llumiverse/common';
+import { parseBatchBucketLocation } from '../batch-location.js';
 
 // ---------------------------------------------------------------------------
 // S3 text I/O
@@ -32,15 +33,7 @@ export interface S3Location {
 
 /** Parse "s3://bucket/prefix", "bucket/prefix" or "bucket" into {bucket, prefix}. */
 export function parseS3Bucket(spec: string): S3Location {
-    let s = spec.trim();
-    if (s.startsWith('s3://')) {
-        s = s.slice('s3://'.length);
-    }
-    const slash = s.indexOf('/');
-    if (slash === -1) {
-        return { bucket: s, prefix: '' };
-    }
-    return { bucket: s.slice(0, slash), prefix: s.slice(slash + 1).replace(/\/+$/, '') };
+    return parseBatchBucketLocation(spec, 's3');
 }
 
 export async function s3UploadText(s3: S3Client, bucket: string, key: string, text: string): Promise<string> {

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -1,12 +1,15 @@
 import {
     Bedrock,
     CreateModelCustomizationJobCommand,
+    CreateModelInvocationJobCommand,
     type FoundationModelSummary,
     GetModelCustomizationJobCommand,
     type GetModelCustomizationJobCommandOutput,
+    GetModelInvocationJobCommand,
     ModelCustomizationJobStatus,
     ModelModality,
     StopModelCustomizationJobCommand,
+    StopModelInvocationJobCommand,
 } from '@aws-sdk/client-bedrock';
 import {
     BedrockRuntime,
@@ -24,6 +27,11 @@ import { S3Client } from '@aws-sdk/client-s3';
 import type { AwsCredentialIdentity, Provider } from '@aws-sdk/types';
 import {
     type AIModel,
+    type BatchInferenceJob,
+    BatchInferenceJobStatus,
+    type BatchInferenceOptions,
+    type BatchInferenceRequestItem,
+    type BatchInferenceResultItem,
     type BedrockClaudeOptions,
     type BedrockGptOssOptions,
     type BedrockPalmyraOptions,
@@ -68,6 +76,14 @@ import { LRUCache } from 'mnemonist';
 import { resolveClaudeThinking } from '../shared/claude-thinking.js';
 import { truncateBinaryForDebug, uint8ArrayToBase64ForDebug } from '../shared/debug-prompt.js';
 import {
+    mapModelInvocationJobStatus,
+    parseBedrockBatchOutputLine,
+    parseS3Bucket,
+    s3DownloadText,
+    s3List,
+    s3UploadText,
+} from './batch.js';
+import {
     converseConcatMessages,
     converseJSONprefill,
     converseSystemToMessages,
@@ -75,7 +91,7 @@ import {
 } from './converse.js';
 import { generateBedrockEmbeddings } from './embeddings.js';
 import { formatNovaImageGenerationPayload, NovaImageGenerationTaskType } from './nova-image-payload.js';
-import { forceUploadFile } from './s3.js';
+import { forceUploadFile, tryCreateBucket } from './s3.js';
 import { formatTwelvelabsPegasusPrompt, type TwelvelabsPegasusRequest } from './twelvelabs.js';
 
 const supportStreamingCache = new LRUCache<string, boolean>(4096);
@@ -152,6 +168,17 @@ export interface BedrockDriverOptions extends DriverOptions {
      * The role ARN to be used for training
      */
     training_role_arn?: string;
+
+    /**
+     * S3 bucket used to stage batch-inference input/output (falls back to training_bucket).
+     * Created if it does not already exist.
+     */
+    batch_bucket?: string;
+
+    /**
+     * The IAM role ARN Bedrock assumes to read/write the batch S3 data (falls back to training_role_arn).
+     */
+    batch_role_arn?: string;
 
     /**
      * The credentials to use to access AWS (IAM access key + secret)
@@ -1558,6 +1585,105 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
         );
 
         return jobInfo(job, jobId);
+    }
+
+    // ===================== Batch inference (Bedrock S3) =====================
+
+    supportsBatchInference(_model?: string): boolean {
+        return true;
+    }
+
+    async startBatchInference(
+        requests: BatchInferenceRequestItem[],
+        options?: BatchInferenceOptions,
+    ): Promise<BatchInferenceJob> {
+        if (requests.length === 0) {
+            throw new Error('[bedrock] startBatchInference called with no requests');
+        }
+        const model = requests[0].options.model;
+        const bucketSpec = options?.input_uri ?? this.options.batch_bucket ?? this.options.training_bucket;
+        const roleArn = this.options.batch_role_arn ?? this.options.training_role_arn;
+        if (!bucketSpec) {
+            throw new Error("[bedrock] Batch inference requires an S3 bucket: set 'batch_bucket' in driver options");
+        }
+        if (!roleArn) {
+            throw new Error("[bedrock] Batch inference requires 'batch_role_arn' in driver options");
+        }
+        const { bucket, prefix } = parseS3Bucket(bucketSpec);
+        const s3 = new S3Client({ region: this.options.region, credentials: this.options.credentials });
+        await tryCreateBucket(s3, bucket);
+
+        // Build JSONL: one { recordId, modelInput } per request. `recordId` carries the
+        // caller's custom_id. NOTE: modelInput must be the model-native InvokeModel body;
+        // see batch.ts for the Converse→native caveat for some model families.
+        const lines: string[] = [];
+        for (const item of requests) {
+            const prompt = await this.createPrompt(item.segments, item.options);
+            lines.push(JSON.stringify({ recordId: item.custom_id, modelInput: prompt }));
+        }
+
+        const runId = options?.name ? `${options.name}-${Date.now()}` : `llumiverse-batch-${Date.now()}`;
+        const base = prefix ? `${prefix}/${runId}` : runId;
+        const inputUri = await s3UploadText(s3, bucket, `${base}/input.jsonl`, lines.join('\n'));
+        const outputUri = `s3://${bucket}/${base}/output/`;
+
+        const service = this.getService();
+        const res = await service.send(
+            new CreateModelInvocationJobCommand({
+                jobName: runId,
+                roleArn,
+                modelId: model,
+                inputDataConfig: { s3InputDataConfig: { s3Uri: inputUri, s3InputFormat: 'JSONL' } },
+                outputDataConfig: { s3OutputDataConfig: { s3Uri: outputUri } },
+            }),
+        );
+
+        return {
+            id: res.jobArn ?? '',
+            status: BatchInferenceJobStatus.queued,
+            output_uri: outputUri,
+            request_count: requests.length,
+        };
+    }
+
+    async getBatchInferenceJob(jobId: string): Promise<BatchInferenceJob> {
+        const service = this.getService();
+        const job = await service.send(new GetModelInvocationJobCommand({ jobIdentifier: jobId }));
+        return {
+            id: jobId,
+            status: mapModelInvocationJobStatus(job.status),
+            details: job.message ?? undefined,
+            output_uri: job.outputDataConfig?.s3OutputDataConfig?.s3Uri,
+        };
+    }
+
+    async cancelBatchInference(jobId: string): Promise<BatchInferenceJob> {
+        const service = this.getService();
+        await service.send(new StopModelInvocationJobCommand({ jobIdentifier: jobId }));
+        return this.getBatchInferenceJob(jobId);
+    }
+
+    async getBatchInferenceResults(jobId: string): Promise<BatchInferenceResultItem[]> {
+        const service = this.getService();
+        const job = await service.send(new GetModelInvocationJobCommand({ jobIdentifier: jobId }));
+        const outputUri = job.outputDataConfig?.s3OutputDataConfig?.s3Uri;
+        if (!outputUri) {
+            throw new Error('[bedrock] batch job has no S3 output destination');
+        }
+        const { bucket, prefix } = parseS3Bucket(outputUri);
+        const s3 = new S3Client({ region: this.options.region, credentials: this.options.credentials });
+        const keys = (await s3List(s3, bucket, prefix)).filter((k) => k.endsWith('.jsonl') || k.endsWith('.out'));
+        const items: BatchInferenceResultItem[] = [];
+        for (const key of keys) {
+            const text = await s3DownloadText(s3, bucket, key);
+            for (const line of text.split('\n')) {
+                const parsed = parseBedrockBatchOutputLine(line, items.length);
+                if (parsed) {
+                    items.push(parsed);
+                }
+            }
+        }
+        return items;
     }
 
     // ===================== management API ==================

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -27,8 +27,10 @@ import { S3Client } from '@aws-sdk/client-s3';
 import type { AwsCredentialIdentity, Provider } from '@aws-sdk/types';
 import {
     type AIModel,
+    type BatchBlobStore,
     type BatchInferenceJob,
     BatchInferenceJobStatus,
+    type BatchInferenceLimits,
     type BatchInferenceOptions,
     type BatchInferenceRequestItem,
     type BatchInferenceResultItem,
@@ -78,6 +80,7 @@ import { logClaudeTruncation } from '../shared/claude-stop-reason.js';
 import { resolveClaudeThinking } from '../shared/claude-thinking.js';
 import { truncateBinaryForDebug, uint8ArrayToBase64ForDebug } from '../shared/debug-prompt.js';
 import {
+    isBedrockBatchOutputKey,
     mapModelInvocationJobStatus,
     parseBedrockBatchOutputLine,
     parseS3Bucket,
@@ -1777,7 +1780,19 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
     // ===================== Batch inference (Bedrock S3) =====================
 
     supportsBatchInference(_model?: string): boolean {
-        return true;
+        // Disabled: startBatchInference currently submits the Converse-shaped prompt as
+        // `modelInput`, but Bedrock batch requires the model-native InvokeModel body
+        // (e.g. Claude rejects records missing max_tokens/anthropic_version). The batch
+        // methods below stay callable for testing; mapping Converse → native request
+        // bodies is the follow-up that re-enables this.
+        return false;
+    }
+
+    getBatchInferenceLimits(_model?: string): BatchInferenceLimits {
+        // Bedrock batch inference quotas: up to 50,000 records per job (default quota)
+        // and a minimum of 100 records per job. See
+        // https://docs.aws.amazon.com/bedrock/latest/userguide/quotas.html (as of 2026-08).
+        return { max_requests_per_job: 50_000, min_requests_per_job: 100 };
     }
 
     async startBatchInference(
@@ -1787,7 +1802,20 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
         if (requests.length === 0) {
             throw new Error('[bedrock] startBatchInference called with no requests');
         }
+        if (options?.blobStore) {
+            // The methods below build their own S3 client from driver options; silently
+            // ignoring an injected blobStore would bypass the host's staging expectations.
+            throw new Error(
+                '[bedrock] injected blobStore staging is not supported yet — configure batch_bucket instead',
+            );
+        }
         const model = requests[0].options.model;
+        const mismatch = requests.find((r) => r.options.model !== model);
+        if (mismatch) {
+            throw new Error(
+                `[bedrock] all requests in a batch must target the same model: got '${mismatch.options.model}' and '${model}'`,
+            );
+        }
         const bucketSpec = options?.input_uri ?? this.options.batch_bucket ?? this.options.training_bucket;
         const roleArn = this.options.batch_role_arn ?? this.options.training_role_arn;
         if (!bucketSpec) {
@@ -1841,6 +1869,8 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
             status: mapModelInvocationJobStatus(job.status),
             details: job.message ?? undefined,
             output_uri: job.outputDataConfig?.s3OutputDataConfig?.s3Uri,
+            start_time: job.submitTime?.getTime(),
+            end_time: job.endTime?.getTime(),
         };
     }
 
@@ -1850,7 +1880,16 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
         return this.getBatchInferenceJob(jobId);
     }
 
-    async getBatchInferenceResults(jobId: string): Promise<BatchInferenceResultItem[]> {
+    async getBatchInferenceResults(
+        jobId: string,
+        options?: { blobStore?: BatchBlobStore },
+    ): Promise<BatchInferenceResultItem[]> {
+        if (options?.blobStore) {
+            // Same rationale as startBatchInference: this method reads S3 directly.
+            throw new Error(
+                '[bedrock] injected blobStore staging is not supported yet — configure batch_bucket instead',
+            );
+        }
         const service = this.getService();
         const job = await service.send(new GetModelInvocationJobCommand({ jobIdentifier: jobId }));
         const outputUri = job.outputDataConfig?.s3OutputDataConfig?.s3Uri;
@@ -1859,7 +1898,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
         }
         const { bucket, prefix } = parseS3Bucket(outputUri);
         const s3 = new S3Client({ region: this.options.region, credentials: this.options.credentials });
-        const keys = (await s3List(s3, bucket, prefix)).filter((k) => k.endsWith('.jsonl') || k.endsWith('.out'));
+        const keys = (await s3List(s3, bucket, prefix)).filter(isBedrockBatchOutputKey);
         const items: BatchInferenceResultItem[] = [];
         for (const key of keys) {
             const text = await s3DownloadText(s3, bucket, key);

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -1,12 +1,15 @@
 import {
     Bedrock,
     CreateModelCustomizationJobCommand,
+    CreateModelInvocationJobCommand,
     type FoundationModelSummary,
     GetModelCustomizationJobCommand,
     type GetModelCustomizationJobCommandOutput,
+    GetModelInvocationJobCommand,
     ModelCustomizationJobStatus,
     ModelModality,
     StopModelCustomizationJobCommand,
+    StopModelInvocationJobCommand,
 } from '@aws-sdk/client-bedrock';
 import {
     BedrockRuntime,
@@ -24,6 +27,11 @@ import { S3Client } from '@aws-sdk/client-s3';
 import type { AwsCredentialIdentity, Provider } from '@aws-sdk/types';
 import {
     type AIModel,
+    type BatchInferenceJob,
+    BatchInferenceJobStatus,
+    type BatchInferenceOptions,
+    type BatchInferenceRequestItem,
+    type BatchInferenceResultItem,
     type BedrockClaudeOptions,
     type BedrockGptOssOptions,
     type BedrockPalmyraOptions,
@@ -70,6 +78,14 @@ import { logClaudeTruncation } from '../shared/claude-stop-reason.js';
 import { resolveClaudeThinking } from '../shared/claude-thinking.js';
 import { truncateBinaryForDebug, uint8ArrayToBase64ForDebug } from '../shared/debug-prompt.js';
 import {
+    mapModelInvocationJobStatus,
+    parseBedrockBatchOutputLine,
+    parseS3Bucket,
+    s3DownloadText,
+    s3List,
+    s3UploadText,
+} from './batch.js';
+import {
     converseConcatMessages,
     converseJSONprefill,
     converseSystemToMessages,
@@ -79,7 +95,7 @@ import {
 } from './converse.js';
 import { generateBedrockEmbeddings } from './embeddings.js';
 import { formatNovaImageGenerationPayload, NovaImageGenerationTaskType } from './nova-image-payload.js';
-import { forceUploadFile } from './s3.js';
+import { forceUploadFile, tryCreateBucket } from './s3.js';
 import { formatTwelvelabsPegasusPrompt, type TwelvelabsPegasusRequest } from './twelvelabs.js';
 
 const supportStreamingCache = new LRUCache<string, boolean>(4096);
@@ -308,6 +324,17 @@ export interface BedrockDriverOptions extends DriverOptions {
      * The role ARN to be used for training
      */
     training_role_arn?: string;
+
+    /**
+     * S3 bucket used to stage batch-inference input/output (falls back to training_bucket).
+     * Created if it does not already exist.
+     */
+    batch_bucket?: string;
+
+    /**
+     * The IAM role ARN Bedrock assumes to read/write the batch S3 data (falls back to training_role_arn).
+     */
+    batch_role_arn?: string;
 
     /**
      * The credentials to use to access AWS (IAM access key + secret)
@@ -1745,6 +1772,105 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
         );
 
         return jobInfo(job, jobId);
+    }
+
+    // ===================== Batch inference (Bedrock S3) =====================
+
+    supportsBatchInference(_model?: string): boolean {
+        return true;
+    }
+
+    async startBatchInference(
+        requests: BatchInferenceRequestItem[],
+        options?: BatchInferenceOptions,
+    ): Promise<BatchInferenceJob> {
+        if (requests.length === 0) {
+            throw new Error('[bedrock] startBatchInference called with no requests');
+        }
+        const model = requests[0].options.model;
+        const bucketSpec = options?.input_uri ?? this.options.batch_bucket ?? this.options.training_bucket;
+        const roleArn = this.options.batch_role_arn ?? this.options.training_role_arn;
+        if (!bucketSpec) {
+            throw new Error("[bedrock] Batch inference requires an S3 bucket: set 'batch_bucket' in driver options");
+        }
+        if (!roleArn) {
+            throw new Error("[bedrock] Batch inference requires 'batch_role_arn' in driver options");
+        }
+        const { bucket, prefix } = parseS3Bucket(bucketSpec);
+        const s3 = new S3Client({ region: this.options.region, credentials: this.options.credentials });
+        await tryCreateBucket(s3, bucket);
+
+        // Build JSONL: one { recordId, modelInput } per request. `recordId` carries the
+        // caller's custom_id. NOTE: modelInput must be the model-native InvokeModel body;
+        // see batch.ts for the Converse→native caveat for some model families.
+        const lines: string[] = [];
+        for (const item of requests) {
+            const prompt = await this.createPrompt(item.segments, item.options);
+            lines.push(JSON.stringify({ recordId: item.custom_id, modelInput: prompt }));
+        }
+
+        const runId = options?.name ? `${options.name}-${Date.now()}` : `llumiverse-batch-${Date.now()}`;
+        const base = prefix ? `${prefix}/${runId}` : runId;
+        const inputUri = await s3UploadText(s3, bucket, `${base}/input.jsonl`, lines.join('\n'));
+        const outputUri = `s3://${bucket}/${base}/output/`;
+
+        const service = this.getService();
+        const res = await service.send(
+            new CreateModelInvocationJobCommand({
+                jobName: runId,
+                roleArn,
+                modelId: model,
+                inputDataConfig: { s3InputDataConfig: { s3Uri: inputUri, s3InputFormat: 'JSONL' } },
+                outputDataConfig: { s3OutputDataConfig: { s3Uri: outputUri } },
+            }),
+        );
+
+        return {
+            id: res.jobArn ?? '',
+            status: BatchInferenceJobStatus.queued,
+            output_uri: outputUri,
+            request_count: requests.length,
+        };
+    }
+
+    async getBatchInferenceJob(jobId: string): Promise<BatchInferenceJob> {
+        const service = this.getService();
+        const job = await service.send(new GetModelInvocationJobCommand({ jobIdentifier: jobId }));
+        return {
+            id: jobId,
+            status: mapModelInvocationJobStatus(job.status),
+            details: job.message ?? undefined,
+            output_uri: job.outputDataConfig?.s3OutputDataConfig?.s3Uri,
+        };
+    }
+
+    async cancelBatchInference(jobId: string): Promise<BatchInferenceJob> {
+        const service = this.getService();
+        await service.send(new StopModelInvocationJobCommand({ jobIdentifier: jobId }));
+        return this.getBatchInferenceJob(jobId);
+    }
+
+    async getBatchInferenceResults(jobId: string): Promise<BatchInferenceResultItem[]> {
+        const service = this.getService();
+        const job = await service.send(new GetModelInvocationJobCommand({ jobIdentifier: jobId }));
+        const outputUri = job.outputDataConfig?.s3OutputDataConfig?.s3Uri;
+        if (!outputUri) {
+            throw new Error('[bedrock] batch job has no S3 output destination');
+        }
+        const { bucket, prefix } = parseS3Bucket(outputUri);
+        const s3 = new S3Client({ region: this.options.region, credentials: this.options.credentials });
+        const keys = (await s3List(s3, bucket, prefix)).filter((k) => k.endsWith('.jsonl') || k.endsWith('.out'));
+        const items: BatchInferenceResultItem[] = [];
+        for (const key of keys) {
+            const text = await s3DownloadText(s3, bucket, key);
+            for (const line of text.split('\n')) {
+                const parsed = parseBedrockBatchOutputLine(line, items.length);
+                if (parsed) {
+                    items.push(parsed);
+                }
+            }
+        }
+        return items;
     }
 
     // ===================== management API ==================

--- a/drivers/src/openai/batch-input.test.ts
+++ b/drivers/src/openai/batch-input.test.ts
@@ -1,0 +1,101 @@
+import {
+    type BatchInferenceRequestItem,
+    type DataSource,
+    type ExecutionOptions,
+    PromptRole,
+    type PromptSegment,
+} from '@llumiverse/core';
+import type OpenAI from 'openai';
+import { describe, expect, it, vi } from 'vitest';
+import { OpenAIDriver } from './openai.js';
+
+interface BatchInputLine {
+    body: {
+        input: Array<{
+            role?: string;
+            content?: Array<{ type: string; image_url?: string }>;
+        }>;
+    };
+}
+
+const options: ExecutionOptions = {
+    model: 'gpt-5.2',
+    model_options: { _option_id: 'text-fallback', max_tokens: 100 },
+};
+
+function imageDataSource() {
+    const getStream = vi.fn().mockResolvedValue(
+        new ReadableStream<Uint8Array>({
+            start(controller) {
+                controller.enqueue(new Uint8Array([1, 2, 3]));
+                controller.close();
+            },
+        }),
+    );
+    const getURL = vi.fn().mockResolvedValue('https://signed.example/image.png?signature=redacted');
+    const source: DataSource = {
+        name: 'image.png',
+        mime_type: 'image/png',
+        getStream,
+        getURL,
+        getURI: vi.fn().mockResolvedValue('gs://bucket/image.png'),
+    };
+    return { source, getStream, getURL };
+}
+
+function request(source: DataSource): BatchInferenceRequestItem {
+    const segments: PromptSegment[] = [{ role: PromptRole.user, content: 'Describe the image.', files: [source] }];
+    return { custom_id: 'image-1', segments, options };
+}
+
+describe('OpenAI batch image inputs', () => {
+    it('places signed image URLs in the batch JSONL without reading the image bytes', async () => {
+        const driver = new OpenAIDriver({ apiKey: 'test-key' });
+        const { source, getStream, getURL } = imageDataSource();
+        let inputJsonl = '';
+        const createFile = vi.fn().mockImplementation(async ({ file }: { file: File }) => {
+            inputJsonl = await file.text();
+            return { id: 'file-batch-input' };
+        });
+        const createBatch = vi.fn().mockResolvedValue({ id: 'batch-1', status: 'validating' });
+        driver.service = {
+            files: { create: createFile },
+            batches: { create: createBatch },
+        } as unknown as OpenAI;
+
+        await driver.startBatchInference([request(source)], { name: 'signed-image-batch' });
+
+        expect(getURL).toHaveBeenCalledOnce();
+        expect(getStream).not.toHaveBeenCalled();
+        const line = JSON.parse(inputJsonl) as BatchInputLine;
+        const userMessage = line.body.input.find((item) => item.role === 'user');
+        expect(userMessage?.content).toContainEqual({
+            type: 'input_image',
+            image_url: 'https://signed.example/image.png?signature=redacted',
+            detail: 'auto',
+        });
+        expect(createBatch).toHaveBeenCalledWith({
+            input_file_id: 'file-batch-input',
+            endpoint: '/v1/responses',
+            completion_window: '24h',
+        });
+    });
+
+    it('keeps synchronous prompt images inline', async () => {
+        const driver = new OpenAIDriver({ apiKey: 'test-key' });
+        const { source, getStream, getURL } = imageDataSource();
+
+        const prompt = await driver.createPrompt(request(source).segments, options);
+
+        expect(getStream).toHaveBeenCalledOnce();
+        expect(getURL).not.toHaveBeenCalled();
+        const userMessage = prompt.find(
+            (item): item is OpenAI.Responses.EasyInputMessage => 'role' in item && item.role === 'user',
+        );
+        expect(userMessage?.content).toContainEqual({
+            type: 'input_image',
+            image_url: 'data:image/png;base64,AQID',
+            detail: 'auto',
+        });
+    });
+});

--- a/drivers/src/openai/batch-results.test.ts
+++ b/drivers/src/openai/batch-results.test.ts
@@ -1,0 +1,122 @@
+import type OpenAI from 'openai';
+import { describe, expect, it, vi } from 'vitest';
+import { parseOpenAIBatchErrorLine } from './batch.js';
+import { OpenAIDriver } from './openai.js';
+
+function outputLine(custom_id: string, text: string): string {
+    return JSON.stringify({ custom_id, response: { status_code: 200, body: { output_text: text } } });
+}
+
+function errorLine(custom_id: string, message: string): string {
+    return JSON.stringify({
+        custom_id,
+        response: { status_code: 400, body: { error: { message, type: 'invalid_request_error' } } },
+        error: null,
+    });
+}
+
+function mockDriver(job: {
+    output_file_id?: string | null;
+    error_file_id?: string | null;
+    files?: Record<string, string>;
+}): OpenAIDriver {
+    const driver = new OpenAIDriver({ apiKey: 'test-key' });
+    const retrieve = vi.fn().mockResolvedValue({
+        id: 'batch-1',
+        status: 'completed',
+        output_file_id: job.output_file_id ?? null,
+        error_file_id: job.error_file_id ?? null,
+    });
+    const content = vi.fn().mockImplementation(async (fileId: string) => ({
+        text: async () => job.files?.[fileId] ?? '',
+    }));
+    driver.service = {
+        batches: { retrieve },
+        files: { content },
+    } as unknown as OpenAI;
+    return driver;
+}
+
+describe('parseOpenAIBatchErrorLine', () => {
+    it('extracts the response body error message', () => {
+        const item = parseOpenAIBatchErrorLine(errorLine('doc-1', 'model overloaded'), 0);
+        expect(item).toEqual({ custom_id: 'doc-1', error: 'model overloaded' });
+    });
+
+    it('falls back to the top-level error object', () => {
+        const item = parseOpenAIBatchErrorLine(
+            JSON.stringify({ custom_id: 'doc-2', error: { code: 'server_error', message: 'boom' } }),
+            0,
+        );
+        expect(item?.custom_id).toBe('doc-2');
+        expect(item?.error).toContain('boom');
+    });
+
+    it('reports the status code when no error payload is present', () => {
+        const item = parseOpenAIBatchErrorLine(
+            JSON.stringify({ custom_id: 'doc-3', response: { status_code: 500 } }),
+            0,
+        );
+        expect(item).toEqual({ custom_id: 'doc-3', error: 'request failed with status 500' });
+    });
+
+    it('ignores blank and invalid lines', () => {
+        expect(parseOpenAIBatchErrorLine('   ', 0)).toBeUndefined();
+        expect(parseOpenAIBatchErrorLine('not json', 0)).toBeUndefined();
+    });
+});
+
+describe('OpenAI getBatchInferenceResults', () => {
+    it('merges error-file items with output-file items', async () => {
+        const driver = mockDriver({
+            output_file_id: 'file-out',
+            error_file_id: 'file-err',
+            files: {
+                'file-out': [outputLine('doc-1', 'first'), outputLine('doc-2', 'second')].join('\n'),
+                'file-err': errorLine('doc-3', 'schema validation failed'),
+            },
+        });
+        const items = await driver.getBatchInferenceResults('batch-1');
+        expect(items).toHaveLength(3);
+        expect(items.find((i) => i.custom_id === 'doc-1')?.result).toEqual([{ type: 'text', value: 'first' }]);
+        expect(items.find((i) => i.custom_id === 'doc-3')).toEqual({
+            custom_id: 'doc-3',
+            error: 'schema validation failed',
+        });
+    });
+
+    it('returns error items when all requests failed (no output file)', async () => {
+        const driver = mockDriver({
+            output_file_id: null,
+            error_file_id: 'file-err',
+            files: { 'file-err': [errorLine('doc-1', 'bad request'), errorLine('doc-2', 'too long')].join('\n') },
+        });
+        const items = await driver.getBatchInferenceResults('batch-1');
+        expect(items).toEqual([
+            { custom_id: 'doc-1', error: 'bad request' },
+            { custom_id: 'doc-2', error: 'too long' },
+        ]);
+    });
+
+    it('prefers the output-file item when a custom_id appears in both files', async () => {
+        const driver = mockDriver({
+            output_file_id: 'file-out',
+            error_file_id: 'file-err',
+            files: {
+                'file-out': outputLine('doc-1', 'kept'),
+                'file-err': errorLine('doc-1', 'stale duplicate'),
+            },
+        });
+        const items = await driver.getBatchInferenceResults('batch-1');
+        expect(items).toEqual([
+            { custom_id: 'doc-1', result: [{ type: 'text', value: 'kept' }], token_usage: undefined },
+        ]);
+    });
+
+    it('throws only when the job has neither output nor error file', async () => {
+        const driver = mockDriver({ output_file_id: null, error_file_id: null });
+        await expect(driver.getBatchInferenceResults('batch-1')).rejects.toThrow(
+            '[openai] batch job has no output or error file',
+        );
+    });
+});

--- a/drivers/src/openai/batch.ts
+++ b/drivers/src/openai/batch.ts
@@ -1,0 +1,88 @@
+/**
+ * Batch-inference helpers for the OpenAI (Responses API) driver.
+ *
+ * Uses the OpenAI Batch API: a JSONL of `{ custom_id, method, url, body }` lines is
+ * uploaded via the Files API, submitted with `batches.create`, polled, and the output
+ * file is downloaded and parsed. Each `body` is built by the driver's shared
+ * `buildResponsesBody`, so a batch request is identical to the synchronous request.
+ */
+
+import {
+    BatchInferenceJobStatus,
+    type BatchInferenceResultItem,
+    type CompletionResult,
+    type ExecutionTokenUsage,
+} from '@llumiverse/common';
+
+/** Map an OpenAI batch status to our provider-agnostic batch status. */
+export function mapOpenAIBatchStatus(status: string | undefined): BatchInferenceJobStatus {
+    switch (status) {
+        case 'completed':
+            return BatchInferenceJobStatus.succeeded;
+        case 'failed':
+        case 'expired':
+            return BatchInferenceJobStatus.failed;
+        case 'cancelled':
+        case 'cancelling':
+            return BatchInferenceJobStatus.cancelled;
+        case 'validating':
+            return BatchInferenceJobStatus.queued;
+        default:
+            // in_progress, finalizing, or anything new
+            return BatchInferenceJobStatus.running;
+    }
+}
+
+interface ResponsesBody {
+    output?: Array<{ type?: string; content?: Array<{ type?: string; text?: string }> }>;
+    output_text?: string;
+    usage?: { input_tokens?: number; output_tokens?: number; total_tokens?: number };
+}
+
+/** Extract text + token usage from a Responses API output body. */
+export function parseResponsesBody(body: ResponsesBody | undefined): {
+    result: CompletionResult[];
+    token_usage?: ExecutionTokenUsage;
+} {
+    const result: CompletionResult[] = [];
+    if (typeof body?.output_text === 'string' && body.output_text.length > 0) {
+        result.push({ type: 'text', value: body.output_text });
+    } else if (Array.isArray(body?.output)) {
+        for (const item of body.output) {
+            if (item.type === 'message' && Array.isArray(item.content)) {
+                for (const c of item.content) {
+                    if (c.type === 'output_text' && typeof c.text === 'string' && c.text.length > 0) {
+                        result.push({ type: 'text', value: c.text });
+                    }
+                }
+            }
+        }
+    }
+    const u = body?.usage;
+    const token_usage: ExecutionTokenUsage | undefined = u
+        ? { prompt: u.input_tokens, result: u.output_tokens, total: u.total_tokens }
+        : undefined;
+    return { result, token_usage };
+}
+
+/** Parse a single OpenAI batch output JSONL line (`{ custom_id, response: { body }, error }`). */
+export function parseOpenAIBatchOutputLine(line: string, index: number): BatchInferenceResultItem | undefined {
+    const trimmed = line.trim();
+    if (!trimmed) {
+        return undefined;
+    }
+    let obj: { custom_id?: string; response?: { status_code?: number; body?: ResponsesBody }; error?: unknown };
+    try {
+        obj = JSON.parse(trimmed);
+    } catch {
+        return undefined;
+    }
+    const custom_id = obj.custom_id ?? String(index);
+    if (obj.error) {
+        return { custom_id, error: typeof obj.error === 'string' ? obj.error : JSON.stringify(obj.error) };
+    }
+    if (obj.response?.body) {
+        return { custom_id, ...parseResponsesBody(obj.response.body) };
+    }
+    return { custom_id, error: 'no response body in batch output' };
+}

--- a/drivers/src/openai/batch.ts
+++ b/drivers/src/openai/batch.ts
@@ -65,6 +65,37 @@ export function parseResponsesBody(body: ResponsesBody | undefined): {
     return { result, token_usage };
 }
 
+/**
+ * Parse a single line of an OpenAI batch **error file** (`Batch.error_file_id`) into a
+ * failed result item. Error-file lines carry the failure either as a top-level `error`
+ * object or as a non-2xx `response` whose body is `{ error: { message } }`.
+ */
+export function parseOpenAIBatchErrorLine(line: string, index: number): BatchInferenceResultItem | undefined {
+    const trimmed = line.trim();
+    if (!trimmed) {
+        return undefined;
+    }
+    let obj: {
+        custom_id?: string;
+        error?: unknown;
+        response?: { status_code?: number; body?: { error?: { message?: string } } };
+    };
+    try {
+        obj = JSON.parse(trimmed);
+    } catch {
+        return undefined;
+    }
+    const custom_id = obj.custom_id ?? String(index);
+    const bodyErrorMessage = obj.response?.body?.error?.message;
+    if (typeof bodyErrorMessage === 'string' && bodyErrorMessage.length > 0) {
+        return { custom_id, error: bodyErrorMessage };
+    }
+    if (obj.error) {
+        return { custom_id, error: typeof obj.error === 'string' ? obj.error : JSON.stringify(obj.error) };
+    }
+    return { custom_id, error: `request failed with status ${obj.response?.status_code ?? 'unknown'}` };
+}
+
 /** Parse a single OpenAI batch output JSONL line (`{ custom_id, response: { body }, error }`). */
 export function parseOpenAIBatchOutputLine(line: string, index: number): BatchInferenceResultItem | undefined {
     const trimmed = line.trim();

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -1,5 +1,9 @@
 import {
     type AIModel,
+    type BatchInferenceJob,
+    type BatchInferenceOptions,
+    type BatchInferenceRequestItem,
+    type BatchInferenceResultItem,
     type Completion,
     type CompletionChunkObject,
     type CompletionResult,
@@ -39,6 +43,7 @@ import {
 import { AbstractDriver } from '@llumiverse/core/driver';
 import type OpenAI from 'openai';
 import type { AzureOpenAI } from 'openai';
+import { toFile } from 'openai';
 import {
     APIConnectionError,
     APIConnectionTimeoutError,
@@ -55,6 +60,7 @@ import {
     RateLimitError,
     UnprocessableEntityError,
 } from 'openai/error';
+import { mapOpenAIBatchStatus, parseOpenAIBatchOutputLine } from './batch.js';
 import { formatOpenAILikeMultimodalPrompt } from './openai_format.js';
 import { formatOpenAISchema } from './schema.js';
 
@@ -231,16 +237,16 @@ export abstract class OpenAIResponsesDriverBase extends AbstractDriver<
         return mapResponseStream(stream);
     }
 
-    async requestTextCompletion(prompt: ResponseInputItem[], options: ExecutionOptions): Promise<Completion> {
-        if (
-            options.model_options?._option_id !== undefined &&
-            options.model_options?._option_id !== 'openai-text' &&
-            options.model_options?._option_id !== 'openai-thinking' &&
-            options.model_options?._option_id !== 'text-fallback'
-        ) {
-            this.logger.debug({ options: options.model_options }, 'Unexpected option id');
-        }
-
+    /**
+     * Build the Responses API request body from a prompt + options. Shared by the
+     * synchronous `requestTextCompletion` and the batch path so that a batch line is
+     * byte-identical to the synchronous request for the same model (output parity).
+     * NOTE: mutates `prompt` (convertRoles / insert_image_detail), matching the sync path.
+     */
+    protected buildResponsesBody(
+        prompt: ResponseInputItem[],
+        options: ExecutionOptions,
+    ): OpenAI.Responses.ResponseCreateParamsNonStreaming {
         convertRoles(prompt, options.model);
 
         const model_options = options.model_options as OpenAIRequestOptions | undefined;
@@ -270,9 +276,7 @@ export abstract class OpenAIResponsesDriverBase extends AbstractDriver<
         const effort = openAIReasoningEffort(options.model, model_options?.effort ?? model_options?.reasoning_effort);
         const reasoning = effort ? { effort } : undefined;
 
-        let completion: Completion;
-
-        const res = await this.service.responses.create({
+        return {
             stream: false,
             model: options.model,
             input: conversation,
@@ -291,7 +295,25 @@ export abstract class OpenAIResponsesDriverBase extends AbstractDriver<
                       },
                   }
                 : undefined,
-        });
+        };
+    }
+
+    async requestTextCompletion(prompt: ResponseInputItem[], options: ExecutionOptions): Promise<Completion> {
+        if (
+            options.model_options?._option_id !== undefined &&
+            options.model_options?._option_id !== 'openai-text' &&
+            options.model_options?._option_id !== 'openai-thinking' &&
+            options.model_options?._option_id !== 'text-fallback'
+        ) {
+            this.logger.debug({ options: options.model_options }, 'Unexpected option id');
+        }
+
+        const params = this.buildResponsesBody(prompt, options);
+        let conversation = params.input as ResponseInputItem[];
+
+        let completion: Completion;
+
+        const res = await this.service.responses.create(params);
 
         completion = this.extractDataFromResponse(options, res);
         if (options.include_original_response) {
@@ -410,6 +432,75 @@ export abstract class OpenAIResponsesDriverBase extends AbstractDriver<
             // babbage, davinci not yet implemented
             throw new Error(`Unsupported model for training: ${options.model}`);
         }
+    }
+
+    // ===================== Batch inference (OpenAI Batch API) =====================
+
+    supportsBatchInference(_model?: string): boolean {
+        return true;
+    }
+
+    async startBatchInference(
+        requests: BatchInferenceRequestItem[],
+        options?: BatchInferenceOptions,
+    ): Promise<BatchInferenceJob> {
+        if (requests.length === 0) {
+            throw new Error('[openai] startBatchInference called with no requests');
+        }
+        const lines: string[] = [];
+        for (const item of requests) {
+            const prompt = await this.createPrompt(item.segments, item.options);
+            const { stream: _stream, ...body } = this.buildResponsesBody(prompt, item.options);
+            lines.push(JSON.stringify({ custom_id: item.custom_id, method: 'POST', url: '/v1/responses', body }));
+        }
+        const file = await this.service.files.create({
+            file: await toFile(Buffer.from(lines.join('\n')), `${options?.name ?? 'llumiverse-batch'}.jsonl`, {
+                type: 'application/jsonl',
+            }),
+            purpose: 'batch',
+        });
+        const job = await this.service.batches.create({
+            input_file_id: file.id,
+            endpoint: '/v1/responses',
+            completion_window: '24h',
+        });
+        return {
+            id: job.id,
+            status: mapOpenAIBatchStatus(job.status),
+            request_count: requests.length,
+        };
+    }
+
+    async getBatchInferenceJob(jobId: string): Promise<BatchInferenceJob> {
+        const job = await this.service.batches.retrieve(jobId);
+        return {
+            id: job.id,
+            status: mapOpenAIBatchStatus(job.status),
+            details: job.errors ? JSON.stringify(job.errors) : undefined,
+            output_uri: job.output_file_id ?? undefined,
+        };
+    }
+
+    async cancelBatchInference(jobId: string): Promise<BatchInferenceJob> {
+        await this.service.batches.cancel(jobId);
+        return this.getBatchInferenceJob(jobId);
+    }
+
+    async getBatchInferenceResults(jobId: string): Promise<BatchInferenceResultItem[]> {
+        const job = await this.service.batches.retrieve(jobId);
+        if (!job.output_file_id) {
+            throw new Error('[openai] batch job has no output file');
+        }
+        const content = await this.service.files.content(job.output_file_id);
+        const text = await content.text();
+        const items: BatchInferenceResultItem[] = [];
+        for (const line of text.split('\n')) {
+            const parsed = parseOpenAIBatchOutputLine(line, items.length);
+            if (parsed) {
+                items.push(parsed);
+            }
+        }
+        return items;
     }
 
     async startTraining(dataset: DataSource, options: TrainingOptions): Promise<TrainingJob> {

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -1,6 +1,7 @@
 import {
     type AIModel,
     type BatchInferenceJob,
+    type BatchInferenceLimits,
     type BatchInferenceOptions,
     type BatchInferenceRequestItem,
     type BatchInferenceResultItem,
@@ -46,7 +47,7 @@ import {
 import type OpenAI from 'openai';
 import type { AzureOpenAI } from 'openai';
 import { toFile } from 'openai';
-import { mapOpenAIBatchStatus, parseOpenAIBatchOutputLine } from './batch.js';
+import { mapOpenAIBatchStatus, parseOpenAIBatchErrorLine, parseOpenAIBatchOutputLine } from './batch.js';
 import { OpenAICompatibleDriverBase } from './openai_compatible.js';
 import { formatOpenAILikeMultimodalPrompt } from './openai_format.js';
 import { formatOpenAISchema } from './schema.js';
@@ -560,12 +561,25 @@ export abstract class OpenAIResponsesDriverBase extends OpenAICompatibleDriverBa
         return true;
     }
 
+    getBatchInferenceLimits(_model?: string): BatchInferenceLimits {
+        // OpenAI Batch API: up to 50,000 requests per batch and a 200 MB input file.
+        // See https://platform.openai.com/docs/guides/batch (as of 2026-08).
+        return { max_requests_per_job: 50_000, max_input_bytes: 200 * 1024 * 1024 };
+    }
+
     async startBatchInference(
         requests: BatchInferenceRequestItem[],
         options?: BatchInferenceOptions,
     ): Promise<BatchInferenceJob> {
         if (requests.length === 0) {
             throw new Error('[openai] startBatchInference called with no requests');
+        }
+        const batchModel = requests[0].options.model;
+        const mismatch = requests.find((r) => r.options.model !== batchModel);
+        if (mismatch) {
+            throw new Error(
+                `[openai] all requests in a batch must target the same model: got '${mismatch.options.model}' and '${batchModel}'`,
+            );
         }
         const lines: string[] = [];
         for (const item of requests) {
@@ -608,16 +622,31 @@ export abstract class OpenAIResponsesDriverBase extends OpenAICompatibleDriverBa
 
     async getBatchInferenceResults(jobId: string): Promise<BatchInferenceResultItem[]> {
         const job = await this.service.batches.retrieve(jobId);
-        if (!job.output_file_id) {
-            throw new Error('[openai] batch job has no output file');
+        // Successful requests land in `output_file_id`; failed ones in a separate
+        // `error_file_id`. When every request failed, only the error file exists.
+        if (!job.output_file_id && !job.error_file_id) {
+            throw new Error('[openai] batch job has no output or error file');
         }
-        const content = await this.service.files.content(job.output_file_id);
-        const text = await content.text();
         const items: BatchInferenceResultItem[] = [];
-        for (const line of text.split('\n')) {
-            const parsed = parseOpenAIBatchOutputLine(line, items.length);
-            if (parsed) {
-                items.push(parsed);
+        if (job.output_file_id) {
+            const content = await this.service.files.content(job.output_file_id);
+            const text = await content.text();
+            for (const line of text.split('\n')) {
+                const parsed = parseOpenAIBatchOutputLine(line, items.length);
+                if (parsed) {
+                    items.push(parsed);
+                }
+            }
+        }
+        if (job.error_file_id) {
+            const seen = new Set(items.map((item) => item.custom_id));
+            const content = await this.service.files.content(job.error_file_id);
+            const text = await content.text();
+            for (const line of text.split('\n')) {
+                const parsed = parseOpenAIBatchErrorLine(line, items.length);
+                if (parsed && !seen.has(parsed.custom_id)) {
+                    items.push(parsed);
+                }
             }
         }
         return items;

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -403,6 +403,14 @@ export abstract class OpenAIResponsesDriverBase extends OpenAICompatibleDriverBa
     }
 
     protected async formatPrompt(segments: PromptSegment[], options: PromptOptions): Promise<ResponseInputItem[]> {
+        return this.formatResponsesPrompt(segments, options);
+    }
+
+    private async formatResponsesPrompt(
+        segments: PromptSegment[],
+        options: PromptOptions,
+        imageInputTransport: 'inline' | 'url' = 'inline',
+    ): Promise<ResponseInputItem[]> {
         const schemaSuffix = options.prompt_cache_schema_suffix === true && !!options.result_schema;
         const resultSchema =
             supportsSchema(options.model, this.provider) && !schemaSuffix ? undefined : options.result_schema;
@@ -410,6 +418,7 @@ export abstract class OpenAIResponsesDriverBase extends OpenAICompatibleDriverBa
             ...options,
             result_schema: resultSchema,
             resultSchemaPosition: schemaSuffix ? 'suffix' : undefined,
+            imageInputTransport,
         });
     }
 
@@ -560,7 +569,7 @@ export abstract class OpenAIResponsesDriverBase extends OpenAICompatibleDriverBa
         }
         const lines: string[] = [];
         for (const item of requests) {
-            const prompt = await this.createPrompt(item.segments, item.options);
+            const prompt = await this.formatResponsesPrompt(item.segments, item.options, 'url');
             const { stream: _stream, ...body } = this.buildResponsesBody(prompt, item.options);
             lines.push(JSON.stringify({ custom_id: item.custom_id, method: 'POST', url: '/v1/responses', body }));
         }

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -1,5 +1,9 @@
 import {
     type AIModel,
+    type BatchInferenceJob,
+    type BatchInferenceOptions,
+    type BatchInferenceRequestItem,
+    type BatchInferenceResultItem,
     type Completion,
     type CompletionChunkObject,
     type CompletionResult,
@@ -41,6 +45,8 @@ import {
 } from '@llumiverse/core';
 import type OpenAI from 'openai';
 import type { AzureOpenAI } from 'openai';
+import { toFile } from 'openai';
+import { mapOpenAIBatchStatus, parseOpenAIBatchOutputLine } from './batch.js';
 import { OpenAICompatibleDriverBase } from './openai_compatible.js';
 import { formatOpenAILikeMultimodalPrompt } from './openai_format.js';
 import { formatOpenAISchema } from './schema.js';
@@ -271,21 +277,11 @@ export class OpenAIResponsesProtocol {
         );
     }
 
-    async requestTextCompletion(
+    buildTextCompletionRequest(
         driver: OpenAIResponsesDriverBase,
         prompt: ResponseInputItem[],
         options: ExecutionOptions,
-    ): Promise<Completion> {
-        if (
-            options.model_options?._option_id !== undefined &&
-            options.model_options?._option_id !== 'openai-text' &&
-            options.model_options?._option_id !== 'openai-thinking' &&
-            options.model_options?._option_id !== 'bedrock-mantle-responses' &&
-            options.model_options?._option_id !== 'text-fallback'
-        ) {
-            driver.logger.debug({ options: options.model_options }, 'Unexpected option id');
-        }
-
+    ): { body: OpenAI.Responses.ResponseCreateParamsNonStreaming; conversation: ResponseInputItem[] } {
         convertRoles(prompt, options.model);
 
         const model_options = options.model_options as OpenAIRequestOptions | undefined;
@@ -330,26 +326,48 @@ export class OpenAIResponsesProtocol {
             driver.getResponsesRequestModel(options.model),
             promptCacheKey,
         );
-        const res = await driver.service.responses.create({
-            stream: false,
-            model: driver.getResponsesRequestModel(options.model),
-            prompt_cache_key: promptCacheKey,
-            prompt_cache_retention: promptCacheRetention,
-            prompt_cache_options: promptCache.options,
-            input: promptCache.input,
-            reasoning,
-            include: reasoning ? ['reasoning.encrypted_content'] : undefined,
-            temperature: isReasoningModel ? undefined : model_options?.temperature,
-            top_p: isReasoningModel ? undefined : model_options?.top_p,
-            max_output_tokens: model_options?.max_tokens, //TODO: use max_tokens for older models, currently relying on OpenAI to handle it
-            tools: useTools ? toolDefs : undefined,
-            text: buildResponseTextConfig(
-                parsedSchema,
-                strictMode,
-                model_options?.verbosity,
-                options.prompt_cache_schema_suffix === true && !!options.result_schema,
-            ),
-        });
+        return {
+            body: {
+                stream: false,
+                model: driver.getResponsesRequestModel(options.model),
+                prompt_cache_key: promptCacheKey,
+                prompt_cache_retention: promptCacheRetention,
+                prompt_cache_options: promptCache.options,
+                input: promptCache.input,
+                reasoning,
+                include: reasoning ? ['reasoning.encrypted_content'] : undefined,
+                temperature: isReasoningModel ? undefined : model_options?.temperature,
+                top_p: isReasoningModel ? undefined : model_options?.top_p,
+                max_output_tokens: model_options?.max_tokens,
+                tools: useTools ? toolDefs : undefined,
+                text: buildResponseTextConfig(
+                    parsedSchema,
+                    strictMode,
+                    model_options?.verbosity,
+                    options.prompt_cache_schema_suffix === true && !!options.result_schema,
+                ),
+            },
+            conversation,
+        };
+    }
+
+    async requestTextCompletion(
+        driver: OpenAIResponsesDriverBase,
+        prompt: ResponseInputItem[],
+        options: ExecutionOptions,
+    ): Promise<Completion> {
+        if (
+            options.model_options?._option_id !== undefined &&
+            options.model_options?._option_id !== 'openai-text' &&
+            options.model_options?._option_id !== 'openai-thinking' &&
+            options.model_options?._option_id !== 'bedrock-mantle-responses' &&
+            options.model_options?._option_id !== 'text-fallback'
+        ) {
+            driver.logger.debug({ options: options.model_options }, 'Unexpected option id');
+        }
+
+        const { body, conversation } = this.buildTextCompletionRequest(driver, prompt, options);
+        const res = await driver.service.responses.create(body);
 
         const completion = driver.extractDataFromResponse(options, res);
         if (options.include_original_response) {
@@ -431,6 +449,14 @@ export abstract class OpenAIResponsesDriverBase extends OpenAICompatibleDriverBa
 
     requestTextCompletion(prompt: ResponseInputItem[], options: ExecutionOptions): Promise<Completion> {
         return this.responsesProtocol.requestTextCompletion(this, prompt, options);
+    }
+
+    /** Build the same non-streaming request body used by direct execution for a provider batch line. */
+    protected buildResponsesBody(
+        prompt: ResponseInputItem[],
+        options: ExecutionOptions,
+    ): OpenAI.Responses.ResponseCreateParamsNonStreaming {
+        return this.responsesProtocol.buildTextCompletionRequest(this, prompt, options).body;
     }
 
     protected canStream(_options: ExecutionOptions): Promise<boolean> {
@@ -517,6 +543,75 @@ export abstract class OpenAIResponsesDriverBase extends OpenAICompatibleDriverBa
             // babbage, davinci not yet implemented
             throw new Error(`Unsupported model for training: ${options.model}`);
         }
+    }
+
+    // ===================== Batch inference (OpenAI Batch API) =====================
+
+    supportsBatchInference(_model?: string): boolean {
+        return true;
+    }
+
+    async startBatchInference(
+        requests: BatchInferenceRequestItem[],
+        options?: BatchInferenceOptions,
+    ): Promise<BatchInferenceJob> {
+        if (requests.length === 0) {
+            throw new Error('[openai] startBatchInference called with no requests');
+        }
+        const lines: string[] = [];
+        for (const item of requests) {
+            const prompt = await this.createPrompt(item.segments, item.options);
+            const { stream: _stream, ...body } = this.buildResponsesBody(prompt, item.options);
+            lines.push(JSON.stringify({ custom_id: item.custom_id, method: 'POST', url: '/v1/responses', body }));
+        }
+        const file = await this.service.files.create({
+            file: await toFile(Buffer.from(lines.join('\n')), `${options?.name ?? 'llumiverse-batch'}.jsonl`, {
+                type: 'application/jsonl',
+            }),
+            purpose: 'batch',
+        });
+        const job = await this.service.batches.create({
+            input_file_id: file.id,
+            endpoint: '/v1/responses',
+            completion_window: '24h',
+        });
+        return {
+            id: job.id,
+            status: mapOpenAIBatchStatus(job.status),
+            request_count: requests.length,
+        };
+    }
+
+    async getBatchInferenceJob(jobId: string): Promise<BatchInferenceJob> {
+        const job = await this.service.batches.retrieve(jobId);
+        return {
+            id: job.id,
+            status: mapOpenAIBatchStatus(job.status),
+            details: job.errors ? JSON.stringify(job.errors) : undefined,
+            output_uri: job.output_file_id ?? undefined,
+        };
+    }
+
+    async cancelBatchInference(jobId: string): Promise<BatchInferenceJob> {
+        await this.service.batches.cancel(jobId);
+        return this.getBatchInferenceJob(jobId);
+    }
+
+    async getBatchInferenceResults(jobId: string): Promise<BatchInferenceResultItem[]> {
+        const job = await this.service.batches.retrieve(jobId);
+        if (!job.output_file_id) {
+            throw new Error('[openai] batch job has no output file');
+        }
+        const content = await this.service.files.content(job.output_file_id);
+        const text = await content.text();
+        const items: BatchInferenceResultItem[] = [];
+        for (const line of text.split('\n')) {
+            const parsed = parseOpenAIBatchOutputLine(line, items.length);
+            if (parsed) {
+                items.push(parsed);
+            }
+        }
+        return items;
     }
 
     async startTraining(dataset: DataSource, options: TrainingOptions): Promise<TrainingJob> {

--- a/drivers/src/openai/openai_format.ts
+++ b/drivers/src/openai/openai_format.ts
@@ -99,11 +99,15 @@ export async function formatOpenAILikeMultimodalPrompt(
         //generate the parts based on PromptSegment
         if (msg.files) {
             for (const file of msg.files) {
-                const stream = await file.getStream();
-                const data = await readStreamAsBase64(stream);
+                const imageUrl =
+                    opts.imageInputTransport === 'url'
+                        ? await file.getURL()
+                        : `data:${file.mime_type || 'image/jpeg'};base64,${await readStreamAsBase64(
+                              await file.getStream(),
+                          )}`;
                 parts.push({
                     type: 'input_image',
-                    image_url: `data:${file.mime_type || 'image/jpeg'};base64,${data}`,
+                    image_url: imageUrl,
                     detail: 'auto',
                 });
             }
@@ -208,6 +212,7 @@ export interface OpenAIPromptFormatterOptions {
     useToolForFormatting?: boolean;
     schema?: object;
     resultSchemaPosition?: 'system' | 'suffix';
+    imageInputTransport?: 'inline' | 'url';
 }
 
 // Chat Completions API types

--- a/drivers/src/test-driver/index.ts
+++ b/drivers/src/test-driver/index.ts
@@ -1,6 +1,8 @@
 import {
     type AIModel,
     AIModelStatus,
+    type BatchInferenceJob,
+    type BatchInferenceResultItem,
     type CompletionStream,
     type Driver,
     type EmbeddingsResult,
@@ -39,6 +41,26 @@ export class TestDriver implements Driver<PromptSegment[]> {
 
     getTrainingJob(_jobId: string): Promise<TrainingJob> {
         throw new Error('Method not implemented.');
+    }
+
+    startBatchInference(): Promise<BatchInferenceJob> {
+        throw new Error('Method not implemented.');
+    }
+
+    getBatchInferenceJob(_jobId: string): Promise<BatchInferenceJob> {
+        throw new Error('Method not implemented.');
+    }
+
+    cancelBatchInference(_jobId: string): Promise<BatchInferenceJob> {
+        throw new Error('Method not implemented.');
+    }
+
+    getBatchInferenceResults(_jobId: string): Promise<BatchInferenceResultItem[]> {
+        throw new Error('Method not implemented.');
+    }
+
+    supportsBatchInference(): boolean {
+        return false;
     }
 
     async createPrompt(segments: PromptSegment[], _opts: ExecutionOptions): Promise<PromptSegment[]> {

--- a/drivers/src/test-driver/index.ts
+++ b/drivers/src/test-driver/index.ts
@@ -2,6 +2,7 @@ import {
     type AIModel,
     AIModelStatus,
     type BatchInferenceJob,
+    type BatchInferenceLimits,
     type BatchInferenceResultItem,
     type CompletionStream,
     type Driver,
@@ -61,6 +62,10 @@ export class TestDriver implements Driver<PromptSegment[]> {
 
     supportsBatchInference(): boolean {
         return false;
+    }
+
+    getBatchInferenceLimits(): BatchInferenceLimits {
+        return { max_requests_per_job: 10_000 };
     }
 
     async createPrompt(segments: PromptSegment[], _opts: ExecutionOptions): Promise<PromptSegment[]> {

--- a/drivers/src/vertexai/batch.test.ts
+++ b/drivers/src/vertexai/batch.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { parseVertexModelTarget, parseVertexResourceLocation } from './batch.js';
+
+describe('Vertex batch resource normalization', () => {
+    it('moves a catalog model location onto the client target', () => {
+        expect(parseVertexModelTarget('locations/global/publishers/google/models/gemini-3.5-flash-lite')).toEqual({
+            model: 'gemini-3.5-flash-lite',
+            location: 'global',
+        });
+    });
+
+    it('accepts partial and bare Gemini model ids', () => {
+        expect(parseVertexModelTarget('publishers/google/models/gemini-2.5-flash')).toEqual({
+            model: 'gemini-2.5-flash',
+            location: undefined,
+        });
+        expect(parseVertexModelTarget('gemini-2.5-flash')).toEqual({
+            model: 'gemini-2.5-flash',
+            location: undefined,
+        });
+    });
+
+    it('recovers the location from a batch job resource name', () => {
+        expect(parseVertexResourceLocation('projects/test/locations/global/batchPredictionJobs/123')).toBe('global');
+    });
+});

--- a/drivers/src/vertexai/batch.ts
+++ b/drivers/src/vertexai/batch.ts
@@ -1,0 +1,190 @@
+/**
+ * Batch-inference helpers for the Vertex AI driver.
+ *
+ * Uses Vertex's asynchronous batch prediction for Gemini (via the `@google/genai`
+ * `batches` API) with GCS-staged input/output. Each request is formatted with the
+ * driver's normal `createPrompt` + `getGeminiPayload`, so a batch line is identical
+ * to the synchronous request for the same model — batch output matches interactive
+ * output. GCS I/O goes through the driver's existing GoogleAuth client, so no extra
+ * dependency (`@google-cloud/storage`) is required.
+ */
+
+import type { GenerateContentParameters, GenerateContentResponse } from '@google/genai';
+import {
+    BatchInferenceJobStatus,
+    type BatchInferenceResultItem,
+    type CompletionResult,
+    type ExecutionTokenUsage,
+} from '@llumiverse/common';
+import type { AuthClient } from 'google-auth-library';
+
+// ---------------------------------------------------------------------------
+// GCS location parsing + I/O via the auth client (no @google-cloud/storage dep)
+// ---------------------------------------------------------------------------
+
+export interface GcsLocation {
+    bucket: string;
+    prefix: string;
+}
+
+/** Parse "gs://bucket/prefix", "bucket/prefix" or "bucket" into {bucket, prefix}. */
+export function parseGcsBucket(spec: string): GcsLocation {
+    let s = spec.trim();
+    if (s.startsWith('gs://')) {
+        s = s.slice('gs://'.length);
+    }
+    const slash = s.indexOf('/');
+    if (slash === -1) {
+        return { bucket: s, prefix: '' };
+    }
+    return { bucket: s.slice(0, slash), prefix: s.slice(slash + 1).replace(/\/+$/, '') };
+}
+
+export async function gcsUploadText(
+    auth: AuthClient,
+    bucket: string,
+    name: string,
+    text: string,
+    contentType = 'application/x-ndjson',
+): Promise<string> {
+    const url = `https://storage.googleapis.com/upload/storage/v1/b/${encodeURIComponent(
+        bucket,
+    )}/o?uploadType=media&name=${encodeURIComponent(name)}`;
+    await auth.request({ url, method: 'POST', headers: { 'Content-Type': contentType }, data: text });
+    return `gs://${bucket}/${name}`;
+}
+
+export async function gcsDownloadText(auth: AuthClient, bucket: string, name: string): Promise<string> {
+    const url = `https://storage.googleapis.com/storage/v1/b/${encodeURIComponent(bucket)}/o/${encodeURIComponent(
+        name,
+    )}?alt=media`;
+    const res = await auth.request({ url, method: 'GET', responseType: 'text' });
+    return typeof res.data === 'string' ? res.data : JSON.stringify(res.data);
+}
+
+export async function gcsList(auth: AuthClient, bucket: string, prefix: string): Promise<string[]> {
+    const url = `https://storage.googleapis.com/storage/v1/b/${encodeURIComponent(
+        bucket,
+    )}/o?prefix=${encodeURIComponent(prefix)}`;
+    const res = await auth.request({ url, method: 'GET' });
+    const data = res.data as { items?: Array<{ name: string }> };
+    return (data.items ?? []).map((i) => i.name);
+}
+
+// ---------------------------------------------------------------------------
+// Request / response mapping
+// ---------------------------------------------------------------------------
+
+/** Map a Vertex JobState string to our provider-agnostic batch status. */
+export function mapBatchJobState(state: string | undefined): BatchInferenceJobStatus {
+    switch (state) {
+        case 'JOB_STATE_SUCCEEDED':
+            return BatchInferenceJobStatus.succeeded;
+        case 'JOB_STATE_FAILED':
+        case 'JOB_STATE_EXPIRED':
+            return BatchInferenceJobStatus.failed;
+        case 'JOB_STATE_CANCELLED':
+        case 'JOB_STATE_CANCELLING':
+            return BatchInferenceJobStatus.cancelled;
+        case 'JOB_STATE_PENDING':
+        case 'JOB_STATE_QUEUED':
+            return BatchInferenceJobStatus.queued;
+        default:
+            // RUNNING, PAUSED, UPDATING, UNSPECIFIED, or anything new
+            return BatchInferenceJobStatus.running;
+    }
+}
+
+function pruneUndefined<T extends Record<string, unknown>>(obj: T): T {
+    for (const k of Object.keys(obj)) {
+        if (obj[k] === undefined) {
+            delete obj[k];
+        }
+    }
+    return obj;
+}
+
+/**
+ * Convert the SDK `GenerateContentParameters` ({ model, contents, config }) into the
+ * Vertex REST `GenerateContentRequest` used for GCS batch JSONL input — generation
+ * params are nested under `generationConfig`, everything else stays at the top level.
+ */
+export function toRestGenerateContentRequest(params: GenerateContentParameters): Record<string, unknown> {
+    const config = (params.config ?? {}) as Record<string, unknown>;
+    const generationConfig = pruneUndefined({
+        temperature: config.temperature,
+        topP: config.topP,
+        topK: config.topK,
+        candidateCount: config.candidateCount,
+        maxOutputTokens: config.maxOutputTokens,
+        stopSequences: config.stopSequences,
+        presencePenalty: config.presencePenalty,
+        frequencyPenalty: config.frequencyPenalty,
+        seed: config.seed,
+        responseMimeType: config.responseMimeType,
+        responseJsonSchema: config.responseJsonSchema,
+        responseModalities: config.responseModalities,
+        thinkingConfig: config.thinkingConfig,
+    });
+    return pruneUndefined({
+        contents: params.contents,
+        systemInstruction: config.systemInstruction,
+        safetySettings: config.safetySettings,
+        tools: config.tools,
+        toolConfig: config.toolConfig,
+        labels: config.labels,
+        generationConfig,
+    });
+}
+
+/** Parse a Gemini batch output line's `response` into llumiverse result + token usage. */
+export function parseGeminiBatchResponse(response: GenerateContentResponse | undefined): {
+    result: CompletionResult[];
+    token_usage?: ExecutionTokenUsage;
+    finish_reason?: string;
+} {
+    const candidate = response?.candidates?.[0];
+    const parts = candidate?.content?.parts ?? [];
+    const result: CompletionResult[] = [];
+    for (const p of parts) {
+        if (typeof p.text === 'string' && p.text.length > 0) {
+            result.push({ type: 'text', value: p.text });
+        }
+    }
+    const um = response?.usageMetadata;
+    const token_usage: ExecutionTokenUsage | undefined =
+        um?.totalTokenCount == null
+            ? undefined
+            : {
+                  total: um.totalTokenCount,
+                  prompt: um.promptTokenCount,
+                  result: (um.candidatesTokenCount ?? 0) + (um.thoughtsTokenCount ?? 0),
+              };
+    return { result, token_usage, finish_reason: candidate?.finishReason };
+}
+
+/**
+ * Parse a single output JSONL line from a Vertex Gemini batch prediction file.
+ * Handles the `{ custom_id?, request, response|status }` shape; `custom_id` falls back
+ * to the provided index when not echoed by the backend.
+ */
+export function parseBatchOutputLine(line: string, index: number): BatchInferenceResultItem | undefined {
+    const trimmed = line.trim();
+    if (!trimmed) {
+        return undefined;
+    }
+    let obj: Record<string, unknown>;
+    try {
+        obj = JSON.parse(trimmed);
+    } catch {
+        return undefined;
+    }
+    const request = obj.request as { labels?: Record<string, string> } | undefined;
+    const custom_id = (obj.custom_id as string | undefined) ?? request?.labels?.custom_id ?? String(index);
+    const response = obj.response as GenerateContentResponse | undefined;
+    if (response) {
+        return { custom_id, ...parseGeminiBatchResponse(response) };
+    }
+    const status = obj.status ?? (obj.error as { message?: string } | undefined)?.message;
+    return { custom_id, error: typeof status === 'string' ? status : 'no response in batch output' };
+}

--- a/drivers/src/vertexai/batch.ts
+++ b/drivers/src/vertexai/batch.ts
@@ -27,6 +27,35 @@ export interface GcsLocation {
     prefix: string;
 }
 
+export interface VertexModelTarget {
+    model: string;
+    location?: string;
+}
+
+/**
+ * Convert a catalog/resource model id into the form expected by the Google Gen AI
+ * batch client. Unlike generateContent, batches.create does not reliably accept the
+ * Vertesia catalog form (`locations/<region>/publishers/google/models/<model>`).
+ * The location belongs on the client and the request receives the bare model id.
+ */
+export function parseVertexModelTarget(resourceName: string): VertexModelTarget {
+    const parts = resourceName.split('/').filter(Boolean);
+    const modelIndex = parts.lastIndexOf('models');
+    const locationIndex = parts.lastIndexOf('locations');
+    return {
+        model:
+            modelIndex >= 0 && modelIndex + 1 < parts.length ? parts[modelIndex + 1] : (parts.at(-1) ?? resourceName),
+        location: locationIndex >= 0 && locationIndex + 1 < parts.length ? parts[locationIndex + 1] : undefined,
+    };
+}
+
+/** Extract the location embedded in a Vertex resource name such as a batch job id. */
+export function parseVertexResourceLocation(resourceName: string): string | undefined {
+    const parts = resourceName.split('/').filter(Boolean);
+    const locationIndex = parts.lastIndexOf('locations');
+    return locationIndex >= 0 && locationIndex + 1 < parts.length ? parts[locationIndex + 1] : undefined;
+}
+
 /** Parse "gs://bucket/prefix", "bucket/prefix" or "bucket" into {bucket, prefix}. */
 export function parseGcsBucket(spec: string): GcsLocation {
     let s = spec.trim();

--- a/drivers/src/vertexai/batch.ts
+++ b/drivers/src/vertexai/batch.ts
@@ -17,6 +17,7 @@ import {
     type ExecutionTokenUsage,
 } from '@llumiverse/common';
 import type { AuthClient } from 'google-auth-library';
+import { parseBatchBucketLocation } from '../batch-location.js';
 
 // ---------------------------------------------------------------------------
 // GCS location parsing + I/O via the auth client (no @google-cloud/storage dep)
@@ -58,15 +59,7 @@ export function parseVertexResourceLocation(resourceName: string): string | unde
 
 /** Parse "gs://bucket/prefix", "bucket/prefix" or "bucket" into {bucket, prefix}. */
 export function parseGcsBucket(spec: string): GcsLocation {
-    let s = spec.trim();
-    if (s.startsWith('gs://')) {
-        s = s.slice('gs://'.length);
-    }
-    const slash = s.indexOf('/');
-    if (slash === -1) {
-        return { bucket: s, prefix: '' };
-    }
-    return { bucket: s.slice(0, slash), prefix: s.slice(slash + 1).replace(/\/+$/, '') };
+    return parseBatchBucketLocation(spec, 'gs');
 }
 
 export async function gcsUploadText(

--- a/drivers/src/vertexai/batch.ts
+++ b/drivers/src/vertexai/batch.ts
@@ -203,10 +203,28 @@ export function parseBatchOutputLine(line: string, index: number): BatchInferenc
     }
     const request = obj.request as { labels?: Record<string, string> } | undefined;
     const custom_id = (obj.custom_id as string | undefined) ?? request?.labels?.custom_id ?? String(index);
+    const status = obj.status ?? (obj.error as { message?: string } | undefined)?.message;
+    const hasErrorStatus = typeof status === 'string' ? status.trim().length > 0 : status != null;
+    if (hasErrorStatus) {
+        let message = typeof status === 'string' ? status : JSON.stringify(status);
+        try {
+            const parsedStatus = typeof status === 'string' ? (JSON.parse(status) as { message?: unknown }) : status;
+            if (
+                parsedStatus &&
+                typeof parsedStatus === 'object' &&
+                'message' in parsedStatus &&
+                typeof parsedStatus.message === 'string'
+            ) {
+                message = parsedStatus.message;
+            }
+        } catch {
+            // Plain-text provider statuses are already useful as-is.
+        }
+        return { custom_id, error: message };
+    }
     const response = obj.response as GenerateContentResponse | undefined;
     if (response) {
         return { custom_id, ...parseGeminiBatchResponse(response) };
     }
-    const status = obj.status ?? (obj.error as { message?: string } | undefined)?.message;
-    return { custom_id, error: typeof status === 'string' ? status : 'no response in batch output' };
+    return { custom_id, error: 'no response in batch output' };
 }

--- a/drivers/src/vertexai/batch.ts
+++ b/drivers/src/vertexai/batch.ts
@@ -85,12 +85,20 @@ export async function gcsDownloadText(auth: AuthClient, bucket: string, name: st
 }
 
 export async function gcsList(auth: AuthClient, bucket: string, prefix: string): Promise<string[]> {
-    const url = `https://storage.googleapis.com/storage/v1/b/${encodeURIComponent(
-        bucket,
-    )}/o?prefix=${encodeURIComponent(prefix)}`;
-    const res = await auth.request({ url, method: 'GET' });
-    const data = res.data as { items?: Array<{ name: string }> };
-    return (data.items ?? []).map((i) => i.name);
+    const names: string[] = [];
+    let pageToken: string | undefined;
+    do {
+        const url = `https://storage.googleapis.com/storage/v1/b/${encodeURIComponent(
+            bucket,
+        )}/o?prefix=${encodeURIComponent(prefix)}${pageToken ? `&pageToken=${encodeURIComponent(pageToken)}` : ''}`;
+        const res = await auth.request({ url, method: 'GET' });
+        const data = res.data as { items?: Array<{ name: string }>; nextPageToken?: string };
+        for (const i of data.items ?? []) {
+            names.push(i.name);
+        }
+        pageToken = data.nextPageToken;
+    } while (pageToken);
+    return names;
 }
 
 // ---------------------------------------------------------------------------
@@ -101,6 +109,11 @@ export async function gcsList(auth: AuthClient, bucket: string, prefix: string):
 export function mapBatchJobState(state: string | undefined): BatchInferenceJobStatus {
     switch (state) {
         case 'JOB_STATE_SUCCEEDED':
+            return BatchInferenceJobStatus.succeeded;
+        case 'JOB_STATE_PARTIALLY_SUCCEEDED':
+            // Terminal: some records failed but the partial results are retrievable —
+            // item-level errors surface per-record in the output. Mapping it to
+            // 'running' would make pollers loop forever.
             return BatchInferenceJobStatus.succeeded;
         case 'JOB_STATE_FAILED':
         case 'JOB_STATE_EXPIRED':

--- a/drivers/src/vertexai/index.ts
+++ b/drivers/src/vertexai/index.ts
@@ -3,6 +3,7 @@ import { type Content, GoogleGenAI, type Model } from '@google/genai';
 import { PredictionServiceClient, v1beta1 } from '@google-cloud/aiplatform';
 import {
     type AIModel,
+    type BatchBlobStore,
     type BatchInferenceJob,
     type BatchInferenceOptions,
     type BatchInferenceRequestItem,
@@ -396,14 +397,6 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
             throw new Error('[vertexai] startBatchInference called with no requests');
         }
         const model = requests[0].options.model;
-        const bucketSpec = options?.input_uri ?? this.options.batch_bucket;
-        if (!bucketSpec) {
-            throw new Error(
-                "[vertexai] Batch inference requires a GCS bucket: set 'batch_bucket' in driver options or 'input_uri' in batch options",
-            );
-        }
-        const { bucket, prefix } = parseGcsBucket(bucketSpec);
-        const auth = await this.getAuthClient();
 
         const lines: string[] = [];
         for (const item of requests) {
@@ -417,9 +410,28 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
         }
 
         const runId = options?.name ? `${options.name}-${Date.now()}` : `llumiverse-batch-${Date.now()}`;
-        const base = prefix ? `${prefix}/${runId}` : runId;
-        const inputUri = await gcsUploadText(auth, bucket, `${base}/input.jsonl`, lines.join('\n'));
-        const destUri = `gs://${bucket}/${base}/output`;
+
+        // Staging: prefer injected blob I/O (host stages via its own storage — no driver GCS creds
+        // needed); otherwise use the driver's own GCS client + configured bucket.
+        let inputUri: string;
+        let destUri: string;
+        if (options?.blobStore) {
+            const base = `batch-staging/${runId}`;
+            inputUri = await options.blobStore.putText(`${base}/input.jsonl`, lines.join('\n'));
+            destUri = inputUri.replace(/input\.jsonl$/, 'output');
+        } else {
+            const bucketSpec = options?.input_uri ?? this.options.batch_bucket;
+            if (!bucketSpec) {
+                throw new Error(
+                    "[vertexai] Batch inference requires a GCS bucket: set 'batch_bucket' in driver options, 'input_uri' in batch options, or pass a blobStore",
+                );
+            }
+            const { bucket, prefix } = parseGcsBucket(bucketSpec);
+            const auth = await this.getAuthClient();
+            const base = prefix ? `${prefix}/${runId}` : runId;
+            inputUri = await gcsUploadText(auth, bucket, `${base}/input.jsonl`, lines.join('\n'));
+            destUri = `gs://${bucket}/${base}/output`;
+        }
 
         const genai = this.getGoogleGenAIClient();
         const job = await genai.batches.create({
@@ -454,26 +466,38 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
         return this.getBatchInferenceJob(jobId);
     }
 
-    async getBatchInferenceResults(jobId: string): Promise<BatchInferenceResultItem[]> {
+    async getBatchInferenceResults(
+        jobId: string,
+        options?: { blobStore?: BatchBlobStore },
+    ): Promise<BatchInferenceResultItem[]> {
         const genai = this.getGoogleGenAIClient();
         const job = await genai.batches.get({ name: jobId });
         const destUri = typeof job.dest === 'string' ? job.dest : (job.dest?.gcsUri ?? undefined);
         if (!destUri) {
             throw new Error('[vertexai] batch job has no GCS output destination');
         }
-        const { bucket, prefix } = parseGcsBucket(destUri);
-        const auth = await this.getAuthClient();
-        const names = (await gcsList(auth, bucket, prefix)).filter(
-            (n) => n.endsWith('.jsonl') || n.includes('prediction'),
-        );
         const items: BatchInferenceResultItem[] = [];
-        for (const name of names) {
-            const text = await gcsDownloadText(auth, bucket, name);
+        const collect = (text: string) => {
             for (const line of text.split('\n')) {
                 const parsed = parseBatchOutputLine(line, items.length);
                 if (parsed) {
                     items.push(parsed);
                 }
+            }
+        };
+        if (options?.blobStore) {
+            // Host reads the output through its own storage (mirrors the injected submit staging).
+            for (const text of await options.blobStore.readOutput(destUri)) {
+                collect(text);
+            }
+        } else {
+            const { bucket, prefix } = parseGcsBucket(destUri);
+            const auth = await this.getAuthClient();
+            const names = (await gcsList(auth, bucket, prefix)).filter(
+                (n) => n.endsWith('.jsonl') || n.includes('prediction'),
+            );
+            for (const name of names) {
+                collect(await gcsDownloadText(auth, bucket, name));
             }
         }
         return items;

--- a/drivers/src/vertexai/index.ts
+++ b/drivers/src/vertexai/index.ts
@@ -3,6 +3,10 @@ import { type Content, GoogleGenAI, type Model } from '@google/genai';
 import { PredictionServiceClient, v1beta1 } from '@google-cloud/aiplatform';
 import {
     type AIModel,
+    type BatchInferenceJob,
+    type BatchInferenceOptions,
+    type BatchInferenceRequestItem,
+    type BatchInferenceResultItem,
     type Completion,
     type CompletionChunkObject,
     type CompletionResult,
@@ -33,9 +37,18 @@ import {
     type OpenAIChatCompletionsPrompt,
 } from '../openai/openai_chat_completions.js';
 import { type ClaudePrompt, formatClaudeDebugPrompt } from '../shared/claude-messages.js';
+import {
+    gcsDownloadText,
+    gcsList,
+    gcsUploadText,
+    mapBatchJobState,
+    parseBatchOutputLine,
+    parseGcsBucket,
+    toRestGenerateContentRequest,
+} from './batch.js';
 import { generateVertexAiEmbeddings } from './embeddings/embed.js';
 import { ANTHROPIC_REGIONS, NON_GLOBAL_ANTHROPIC_MODELS } from './models/claude.js';
-import { formatGeminiDebugPrompt } from './models/gemini.js';
+import { formatGeminiDebugPrompt, getGeminiPayload } from './models/gemini.js';
 import { formatImagenDebugPrompt, ImagenModelDefinition, type ImagenPrompt } from './models/imagen.js';
 import { getModelDefinition, trimModelName } from './models.js';
 import { getListedVertexOpenMaaSModels } from './open-maas-models.js';
@@ -44,6 +57,8 @@ export interface VertexAIDriverOptions extends DriverOptions {
     project: string;
     region: string;
     googleAuthOptions?: GoogleAuthOptions;
+    /** GCS bucket (name or gs://bucket/prefix) used to stage batch-inference input/output. Required to use batch inference. */
+    batch_bucket?: string;
 }
 
 export interface GenerateContentPrompt {
@@ -359,6 +374,109 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
         options: ExecutionOptions,
     ): Promise<AsyncIterable<CompletionChunkObject>> {
         return getModelDefinition(options.model).requestTextCompletionStream(this, prompt, options);
+    }
+
+    // ===================== Batch inference (Vertex GCS) =====================
+
+    supportsBatchInference(model?: string): boolean {
+        // Vertex batch prediction is available for Gemini generateContent models.
+        // Anthropic/Imagen/OpenAI-MaaS models on Vertex are not handled by this path.
+        if (!model) {
+            return true;
+        }
+        const m = model.toLowerCase();
+        return m.includes('gemini');
+    }
+
+    async startBatchInference(
+        requests: BatchInferenceRequestItem[],
+        options?: BatchInferenceOptions,
+    ): Promise<BatchInferenceJob> {
+        if (requests.length === 0) {
+            throw new Error('[vertexai] startBatchInference called with no requests');
+        }
+        const model = requests[0].options.model;
+        const bucketSpec = options?.input_uri ?? this.options.batch_bucket;
+        if (!bucketSpec) {
+            throw new Error(
+                "[vertexai] Batch inference requires a GCS bucket: set 'batch_bucket' in driver options or 'input_uri' in batch options",
+            );
+        }
+        const { bucket, prefix } = parseGcsBucket(bucketSpec);
+        const auth = await this.getAuthClient();
+
+        const lines: string[] = [];
+        for (const item of requests) {
+            const prompt = await this.createPrompt(item.segments, item.options);
+            if (!('contents' in prompt)) {
+                throw new Error('[vertexai] Batch inference currently supports Gemini (generateContent) models only');
+            }
+            const params = getGeminiPayload(item.options, prompt as GenerateContentPrompt);
+            const request = toRestGenerateContentRequest(params);
+            lines.push(JSON.stringify({ custom_id: item.custom_id, request }));
+        }
+
+        const runId = options?.name ? `${options.name}-${Date.now()}` : `llumiverse-batch-${Date.now()}`;
+        const base = prefix ? `${prefix}/${runId}` : runId;
+        const inputUri = await gcsUploadText(auth, bucket, `${base}/input.jsonl`, lines.join('\n'));
+        const destUri = `gs://${bucket}/${base}/output`;
+
+        const genai = this.getGoogleGenAIClient();
+        const job = await genai.batches.create({
+            model,
+            src: inputUri,
+            config: { displayName: runId, dest: destUri },
+        });
+
+        return {
+            id: job.name ?? '',
+            status: mapBatchJobState(job.state as string | undefined),
+            output_uri: destUri,
+            request_count: requests.length,
+        };
+    }
+
+    async getBatchInferenceJob(jobId: string): Promise<BatchInferenceJob> {
+        const genai = this.getGoogleGenAIClient();
+        const job = await genai.batches.get({ name: jobId });
+        const destUri = typeof job.dest === 'string' ? job.dest : (job.dest?.gcsUri ?? undefined);
+        return {
+            id: job.name ?? jobId,
+            status: mapBatchJobState(job.state as string | undefined),
+            details: (job as { error?: { message?: string } }).error?.message ?? undefined,
+            output_uri: destUri,
+        };
+    }
+
+    async cancelBatchInference(jobId: string): Promise<BatchInferenceJob> {
+        const genai = this.getGoogleGenAIClient();
+        await genai.batches.cancel({ name: jobId });
+        return this.getBatchInferenceJob(jobId);
+    }
+
+    async getBatchInferenceResults(jobId: string): Promise<BatchInferenceResultItem[]> {
+        const genai = this.getGoogleGenAIClient();
+        const job = await genai.batches.get({ name: jobId });
+        const destUri = typeof job.dest === 'string' ? job.dest : (job.dest?.gcsUri ?? undefined);
+        if (!destUri) {
+            throw new Error('[vertexai] batch job has no GCS output destination');
+        }
+        const { bucket, prefix } = parseGcsBucket(destUri);
+        const auth = await this.getAuthClient();
+        const names = (await gcsList(auth, bucket, prefix)).filter(
+            (n) => n.endsWith('.jsonl') || n.includes('prediction'),
+        );
+        const items: BatchInferenceResultItem[] = [];
+        for (const name of names) {
+            const text = await gcsDownloadText(auth, bucket, name);
+            for (const line of text.split('\n')) {
+                const parsed = parseBatchOutputLine(line, items.length);
+                if (parsed) {
+                    items.push(parsed);
+                }
+            }
+        }
+        return items;
     }
 
     /**

--- a/drivers/src/vertexai/index.ts
+++ b/drivers/src/vertexai/index.ts
@@ -3,6 +3,10 @@ import { type Content, GoogleGenAI, type Model } from '@google/genai';
 import { PredictionServiceClient, v1beta1 } from '@google-cloud/aiplatform';
 import {
     type AIModel,
+    type BatchInferenceJob,
+    type BatchInferenceOptions,
+    type BatchInferenceRequestItem,
+    type BatchInferenceResultItem,
     type Completion,
     type CompletionResult,
     type DriverCompletionStream,
@@ -33,9 +37,18 @@ import {
     type OpenAIChatCompletionsPrompt,
 } from '../openai/openai_chat_completions.js';
 import { type ClaudePrompt, formatClaudeDebugPrompt } from '../shared/claude-messages.js';
+import {
+    gcsDownloadText,
+    gcsList,
+    gcsUploadText,
+    mapBatchJobState,
+    parseBatchOutputLine,
+    parseGcsBucket,
+    toRestGenerateContentRequest,
+} from './batch.js';
 import { generateVertexAiEmbeddings } from './embeddings/embed.js';
 import { ANTHROPIC_REGIONS, NON_GLOBAL_ANTHROPIC_MODELS } from './models/claude.js';
-import { formatGeminiDebugPrompt } from './models/gemini.js';
+import { formatGeminiDebugPrompt, getGeminiPayload } from './models/gemini.js';
 import { formatImagenDebugPrompt, ImagenModelDefinition, type ImagenPrompt } from './models/imagen.js';
 import { getModelDefinition, trimModelName } from './models.js';
 import { getListedVertexOpenMaaSModels } from './open-maas-models.js';
@@ -46,6 +59,8 @@ export interface VertexAIDriverOptions extends DriverOptions {
     project: string;
     region: string;
     googleAuthOptions?: GoogleAuthOptions;
+    /** GCS bucket (name or gs://bucket/prefix) used to stage batch-inference input/output. Required to use batch inference. */
+    batch_bucket?: string;
 }
 
 export interface GenerateContentPrompt {
@@ -364,6 +379,109 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
         options: ExecutionOptions,
     ): Promise<DriverCompletionStream> {
         return getModelDefinition(options.model).requestTextCompletionStream(this, prompt, options);
+    }
+
+    // ===================== Batch inference (Vertex GCS) =====================
+
+    supportsBatchInference(model?: string): boolean {
+        // Vertex batch prediction is available for Gemini generateContent models.
+        // Anthropic/Imagen/OpenAI-MaaS models on Vertex are not handled by this path.
+        if (!model) {
+            return true;
+        }
+        const m = model.toLowerCase();
+        return m.includes('gemini');
+    }
+
+    async startBatchInference(
+        requests: BatchInferenceRequestItem[],
+        options?: BatchInferenceOptions,
+    ): Promise<BatchInferenceJob> {
+        if (requests.length === 0) {
+            throw new Error('[vertexai] startBatchInference called with no requests');
+        }
+        const model = requests[0].options.model;
+        const bucketSpec = options?.input_uri ?? this.options.batch_bucket;
+        if (!bucketSpec) {
+            throw new Error(
+                "[vertexai] Batch inference requires a GCS bucket: set 'batch_bucket' in driver options or 'input_uri' in batch options",
+            );
+        }
+        const { bucket, prefix } = parseGcsBucket(bucketSpec);
+        const auth = await this.getAuthClient();
+
+        const lines: string[] = [];
+        for (const item of requests) {
+            const prompt = await this.createPrompt(item.segments, item.options);
+            if (!('contents' in prompt)) {
+                throw new Error('[vertexai] Batch inference currently supports Gemini (generateContent) models only');
+            }
+            const params = getGeminiPayload(item.options, prompt as GenerateContentPrompt);
+            const request = toRestGenerateContentRequest(params);
+            lines.push(JSON.stringify({ custom_id: item.custom_id, request }));
+        }
+
+        const runId = options?.name ? `${options.name}-${Date.now()}` : `llumiverse-batch-${Date.now()}`;
+        const base = prefix ? `${prefix}/${runId}` : runId;
+        const inputUri = await gcsUploadText(auth, bucket, `${base}/input.jsonl`, lines.join('\n'));
+        const destUri = `gs://${bucket}/${base}/output`;
+
+        const genai = this.getGoogleGenAIClient();
+        const job = await genai.batches.create({
+            model,
+            src: inputUri,
+            config: { displayName: runId, dest: destUri },
+        });
+
+        return {
+            id: job.name ?? '',
+            status: mapBatchJobState(job.state as string | undefined),
+            output_uri: destUri,
+            request_count: requests.length,
+        };
+    }
+
+    async getBatchInferenceJob(jobId: string): Promise<BatchInferenceJob> {
+        const genai = this.getGoogleGenAIClient();
+        const job = await genai.batches.get({ name: jobId });
+        const destUri = typeof job.dest === 'string' ? job.dest : (job.dest?.gcsUri ?? undefined);
+        return {
+            id: job.name ?? jobId,
+            status: mapBatchJobState(job.state as string | undefined),
+            details: (job as { error?: { message?: string } }).error?.message ?? undefined,
+            output_uri: destUri,
+        };
+    }
+
+    async cancelBatchInference(jobId: string): Promise<BatchInferenceJob> {
+        const genai = this.getGoogleGenAIClient();
+        await genai.batches.cancel({ name: jobId });
+        return this.getBatchInferenceJob(jobId);
+    }
+
+    async getBatchInferenceResults(jobId: string): Promise<BatchInferenceResultItem[]> {
+        const genai = this.getGoogleGenAIClient();
+        const job = await genai.batches.get({ name: jobId });
+        const destUri = typeof job.dest === 'string' ? job.dest : (job.dest?.gcsUri ?? undefined);
+        if (!destUri) {
+            throw new Error('[vertexai] batch job has no GCS output destination');
+        }
+        const { bucket, prefix } = parseGcsBucket(destUri);
+        const auth = await this.getAuthClient();
+        const names = (await gcsList(auth, bucket, prefix)).filter(
+            (n) => n.endsWith('.jsonl') || n.includes('prediction'),
+        );
+        const items: BatchInferenceResultItem[] = [];
+        for (const name of names) {
+            const text = await gcsDownloadText(auth, bucket, name);
+            for (const line of text.split('\n')) {
+                const parsed = parseBatchOutputLine(line, items.length);
+                if (parsed) {
+                    items.push(parsed);
+                }
+            }
+        }
+        return items;
     }
 
     /**

--- a/drivers/src/vertexai/index.ts
+++ b/drivers/src/vertexai/index.ts
@@ -45,6 +45,8 @@ import {
     mapBatchJobState,
     parseBatchOutputLine,
     parseGcsBucket,
+    parseVertexModelTarget,
+    parseVertexResourceLocation,
     toRestGenerateContentRequest,
 } from './batch.js';
 import { generateVertexAiEmbeddings } from './embeddings/embed.js';
@@ -401,7 +403,7 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
         if (requests.length === 0) {
             throw new Error('[vertexai] startBatchInference called with no requests');
         }
-        const model = requests[0].options.model;
+        const modelTarget = parseVertexModelTarget(requests[0].options.model);
 
         const lines: string[] = [];
         for (const item of requests) {
@@ -438,9 +440,9 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
             destUri = `gs://${bucket}/${base}/output`;
         }
 
-        const genai = this.getGoogleGenAIClient();
+        const genai = this.getGoogleGenAIClient(modelTarget.location ?? this.options.region);
         const job = await genai.batches.create({
-            model,
+            model: modelTarget.model,
             src: inputUri,
             config: { displayName: runId, dest: destUri },
         });
@@ -454,7 +456,7 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
     }
 
     async getBatchInferenceJob(jobId: string): Promise<BatchInferenceJob> {
-        const genai = this.getGoogleGenAIClient();
+        const genai = this.getGoogleGenAIClient(parseVertexResourceLocation(jobId) ?? this.options.region);
         const job = await genai.batches.get({ name: jobId });
         const destUri = typeof job.dest === 'string' ? job.dest : (job.dest?.gcsUri ?? undefined);
         return {
@@ -466,7 +468,7 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
     }
 
     async cancelBatchInference(jobId: string): Promise<BatchInferenceJob> {
-        const genai = this.getGoogleGenAIClient();
+        const genai = this.getGoogleGenAIClient(parseVertexResourceLocation(jobId) ?? this.options.region);
         await genai.batches.cancel({ name: jobId });
         return this.getBatchInferenceJob(jobId);
     }
@@ -475,7 +477,7 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
         jobId: string,
         options?: { blobStore?: BatchBlobStore },
     ): Promise<BatchInferenceResultItem[]> {
-        const genai = this.getGoogleGenAIClient();
+        const genai = this.getGoogleGenAIClient(parseVertexResourceLocation(jobId) ?? this.options.region);
         const job = await genai.batches.get({ name: jobId });
         const destUri = typeof job.dest === 'string' ? job.dest : (job.dest?.gcsUri ?? undefined);
         if (!destUri) {

--- a/drivers/src/vertexai/index.ts
+++ b/drivers/src/vertexai/index.ts
@@ -3,6 +3,7 @@ import { type Content, GoogleGenAI, type Model } from '@google/genai';
 import { PredictionServiceClient, v1beta1 } from '@google-cloud/aiplatform';
 import {
     type AIModel,
+    type BatchBlobStore,
     type BatchInferenceJob,
     type BatchInferenceOptions,
     type BatchInferenceRequestItem,
@@ -401,14 +402,6 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
             throw new Error('[vertexai] startBatchInference called with no requests');
         }
         const model = requests[0].options.model;
-        const bucketSpec = options?.input_uri ?? this.options.batch_bucket;
-        if (!bucketSpec) {
-            throw new Error(
-                "[vertexai] Batch inference requires a GCS bucket: set 'batch_bucket' in driver options or 'input_uri' in batch options",
-            );
-        }
-        const { bucket, prefix } = parseGcsBucket(bucketSpec);
-        const auth = await this.getAuthClient();
 
         const lines: string[] = [];
         for (const item of requests) {
@@ -422,9 +415,28 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
         }
 
         const runId = options?.name ? `${options.name}-${Date.now()}` : `llumiverse-batch-${Date.now()}`;
-        const base = prefix ? `${prefix}/${runId}` : runId;
-        const inputUri = await gcsUploadText(auth, bucket, `${base}/input.jsonl`, lines.join('\n'));
-        const destUri = `gs://${bucket}/${base}/output`;
+
+        // Staging: prefer injected blob I/O (host stages via its own storage — no driver GCS creds
+        // needed); otherwise use the driver's own GCS client + configured bucket.
+        let inputUri: string;
+        let destUri: string;
+        if (options?.blobStore) {
+            const base = `batch-staging/${runId}`;
+            inputUri = await options.blobStore.putText(`${base}/input.jsonl`, lines.join('\n'));
+            destUri = inputUri.replace(/input\.jsonl$/, 'output');
+        } else {
+            const bucketSpec = options?.input_uri ?? this.options.batch_bucket;
+            if (!bucketSpec) {
+                throw new Error(
+                    "[vertexai] Batch inference requires a GCS bucket: set 'batch_bucket' in driver options, 'input_uri' in batch options, or pass a blobStore",
+                );
+            }
+            const { bucket, prefix } = parseGcsBucket(bucketSpec);
+            const auth = await this.getAuthClient();
+            const base = prefix ? `${prefix}/${runId}` : runId;
+            inputUri = await gcsUploadText(auth, bucket, `${base}/input.jsonl`, lines.join('\n'));
+            destUri = `gs://${bucket}/${base}/output`;
+        }
 
         const genai = this.getGoogleGenAIClient();
         const job = await genai.batches.create({
@@ -459,26 +471,38 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
         return this.getBatchInferenceJob(jobId);
     }
 
-    async getBatchInferenceResults(jobId: string): Promise<BatchInferenceResultItem[]> {
+    async getBatchInferenceResults(
+        jobId: string,
+        options?: { blobStore?: BatchBlobStore },
+    ): Promise<BatchInferenceResultItem[]> {
         const genai = this.getGoogleGenAIClient();
         const job = await genai.batches.get({ name: jobId });
         const destUri = typeof job.dest === 'string' ? job.dest : (job.dest?.gcsUri ?? undefined);
         if (!destUri) {
             throw new Error('[vertexai] batch job has no GCS output destination');
         }
-        const { bucket, prefix } = parseGcsBucket(destUri);
-        const auth = await this.getAuthClient();
-        const names = (await gcsList(auth, bucket, prefix)).filter(
-            (n) => n.endsWith('.jsonl') || n.includes('prediction'),
-        );
         const items: BatchInferenceResultItem[] = [];
-        for (const name of names) {
-            const text = await gcsDownloadText(auth, bucket, name);
+        const collect = (text: string) => {
             for (const line of text.split('\n')) {
                 const parsed = parseBatchOutputLine(line, items.length);
                 if (parsed) {
                     items.push(parsed);
                 }
+            }
+        };
+        if (options?.blobStore) {
+            // Host reads the output through its own storage (mirrors the injected submit staging).
+            for (const text of await options.blobStore.readOutput(destUri)) {
+                collect(text);
+            }
+        } else {
+            const { bucket, prefix } = parseGcsBucket(destUri);
+            const auth = await this.getAuthClient();
+            const names = (await gcsList(auth, bucket, prefix)).filter(
+                (n) => n.endsWith('.jsonl') || n.includes('prediction'),
+            );
+            for (const name of names) {
+                collect(await gcsDownloadText(auth, bucket, name));
             }
         }
         return items;

--- a/drivers/src/vertexai/index.ts
+++ b/drivers/src/vertexai/index.ts
@@ -5,6 +5,7 @@ import {
     type AIModel,
     type BatchBlobStore,
     type BatchInferenceJob,
+    type BatchInferenceLimits,
     type BatchInferenceOptions,
     type BatchInferenceRequestItem,
     type BatchInferenceResultItem,
@@ -396,6 +397,14 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
         return m.includes('gemini');
     }
 
+    getBatchInferenceLimits(_model?: string): BatchInferenceLimits {
+        // Vertex Gemini batch prediction: up to 200,000 requests per JSONL input job and a
+        // regional quota of 75 concurrent batch prediction jobs. See
+        // https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/batch-prediction-gemini
+        // and https://cloud.google.com/vertex-ai/docs/quotas (as of 2026-08).
+        return { max_requests_per_job: 200_000, max_concurrent_jobs: 75 };
+    }
+
     async startBatchInference(
         requests: BatchInferenceRequestItem[],
         options?: BatchInferenceOptions,
@@ -403,7 +412,14 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
         if (requests.length === 0) {
             throw new Error('[vertexai] startBatchInference called with no requests');
         }
-        const modelTarget = parseVertexModelTarget(requests[0].options.model);
+        const batchModel = requests[0].options.model;
+        const mismatch = requests.find((r) => r.options.model !== batchModel);
+        if (mismatch) {
+            throw new Error(
+                `[vertexai] all requests in a batch must target the same model: got '${mismatch.options.model}' and '${batchModel}'`,
+            );
+        }
+        const modelTarget = parseVertexModelTarget(batchModel);
 
         const lines: string[] = [];
         for (const item of requests) {
@@ -420,6 +436,11 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
             }
             const params = getGeminiPayload(item.options, prompt as GenerateContentPrompt);
             const request = toRestGenerateContentRequest(params);
+            // Mirror custom_id into the per-request labels so the output parser's
+            // `request.labels.custom_id` fallback is real when the backend does not
+            // echo the top-level `custom_id` on the output line.
+            const labels = (request.labels as Record<string, string> | undefined) ?? {};
+            request.labels = { ...labels, custom_id: item.custom_id };
             lines.push(JSON.stringify({ custom_id: item.custom_id, request }));
         }
 
@@ -471,6 +492,8 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
             status: mapBatchJobState(job.state as string | undefined),
             details: (job as { error?: { message?: string } }).error?.message ?? undefined,
             output_uri: destUri,
+            start_time: job.createTime ? Date.parse(job.createTime) : undefined,
+            end_time: job.endTime ? Date.parse(job.endTime) : undefined,
         };
     }
 

--- a/drivers/src/vertexai/index.ts
+++ b/drivers/src/vertexai/index.ts
@@ -407,7 +407,14 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
 
         const lines: string[] = [];
         for (const item of requests) {
-            const prompt = await this.createPrompt(item.segments, item.options);
+            const prompt = await getModelDefinition(item.options.model).createPrompt(
+                this,
+                item.segments,
+                item.options,
+                {
+                    fileInputTransport: 'url',
+                },
+            );
             if (!('contents' in prompt)) {
                 throw new Error('[vertexai] Batch inference currently supports Gemini (generateContent) models only');
             }

--- a/drivers/src/vertexai/models.ts
+++ b/drivers/src/vertexai/models.ts
@@ -18,10 +18,19 @@ export function trimModelName(model: string): string {
     return i > -1 ? model.substring(0, i) : model;
 }
 
+export interface VertexPromptOptions {
+    fileInputTransport?: 'default' | 'url';
+}
+
 export interface ModelDefinition<PromptT = VertexAIPrompt> {
     model: AIModel;
     versions?: string[]; // the versions of the model that are available. ex: ['001', '002']
-    createPrompt(driver: VertexAIDriver, segments: PromptSegment[], options: ExecutionOptions): Promise<PromptT>;
+    createPrompt(
+        driver: VertexAIDriver,
+        segments: PromptSegment[],
+        options: ExecutionOptions,
+        promptOptions?: VertexPromptOptions,
+    ): Promise<PromptT>;
     requestTextCompletion(driver: VertexAIDriver, prompt: PromptT, options: ExecutionOptions): Promise<Completion>;
     requestTextCompletionStream(
         driver: VertexAIDriver,

--- a/drivers/src/vertexai/models/gemini-conversation-mutation.test.ts
+++ b/drivers/src/vertexai/models/gemini-conversation-mutation.test.ts
@@ -487,6 +487,33 @@ describe('GeminiModelDefinition - no conversation mutation', () => {
         });
     });
 
+    it('createPrompt places signed URLs in batch file data without reading bytes', async () => {
+        const modelDef = new GeminiModelDefinition('gemini-2.0-flash');
+        const file: DataSource = {
+            name: 'image.jpg',
+            mime_type: 'image/jpeg',
+            getURI: vi.fn().mockResolvedValue('gs://test-bucket/image.jpg'),
+            getURL: vi.fn().mockResolvedValue('https://signed.example/image.jpg?signature=redacted'),
+            getStream: vi.fn().mockResolvedValue(new ReadableStream()),
+        };
+        const segments: PromptSegment[] = [{ role: PromptRole.user, files: [file] } as PromptSegment];
+        const options: ExecutionOptions = { model: 'publishers/google/models/gemini-2.0-flash' };
+
+        const prompt = await modelDef.createPrompt({} as VertexAIDriver, segments, options, {
+            fileInputTransport: 'url',
+        });
+
+        expect(file.getURL).toHaveBeenCalledTimes(1);
+        expect(file.getURI).not.toHaveBeenCalled();
+        expect(file.getStream).not.toHaveBeenCalled();
+        expect(prompt.contents[0].parts?.[0]).toEqual({
+            fileData: {
+                fileUri: 'https://signed.example/image.jpg?signature=redacted',
+                mimeType: 'image/jpeg',
+            },
+        });
+    });
+
     it('requestTextCompletion: does not mutate prompt.contents when tools=[] and conversation has function parts', async () => {
         const modelDef = new GeminiModelDefinition('gemini-2.0-flash');
         const originalContents = makeContentsWithFunctionParts();

--- a/drivers/src/vertexai/models/gemini.ts
+++ b/drivers/src/vertexai/models/gemini.ts
@@ -47,7 +47,7 @@ import {
 import { asyncMap } from '@llumiverse/core/async';
 import { truncateBinaryForDebug } from '../../shared/debug-prompt.js';
 import type { GenerateContentPrompt, VertexAIDriver } from '../index.js';
-import type { ModelDefinition } from '../models.js';
+import type { ModelDefinition, VertexPromptOptions } from '../models.js';
 
 type GoogleApiErrorLike = Pick<ApiError, 'status' | 'message'>;
 
@@ -478,6 +478,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
         _driver: VertexAIDriver,
         segments: PromptSegment[],
         options: ExecutionOptions,
+        promptOptions?: VertexPromptOptions,
     ): Promise<GenerateContentPrompt> {
         const splits = options.model.split('/');
         const modelName = splits[splits.length - 1];
@@ -534,11 +535,13 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
                 // File content handling
                 if (msg.files) {
                     for (const f of msg.files) {
-                        const fileUri = await f.getURI();
+                        const fileUri =
+                            promptOptions?.fileInputTransport === 'url' ? await f.getURL() : await f.getURI();
                         const isGsUri =
                             fileUri.startsWith('gs://') || fileUri.startsWith('https://storage.googleapis.com/');
+                        const isRemoteUrl = promptOptions?.fileInputTransport === 'url' && /^https?:\/\//.test(fileUri);
 
-                        if (isGsUri) {
+                        if (isGsUri || isRemoteUrl) {
                             parts.push({
                                 fileData: {
                                     fileUri,

--- a/drivers/test/batch-openai.integration.test.ts
+++ b/drivers/test/batch-openai.integration.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Live integration test: OpenAI batch inference vs synchronous execution on a real
+ * document. Renders the first N pages to JPEG, transcribes each to markdown via BOTH
+ * the synchronous path and the async Batch API, and reports the comparison.
+ *
+ * Gated — runs only when set:
+ *   OPENAI_API_KEY
+ *   BATCH_TEST_PDF       path to the PDF (e.g. the Fed report)
+ *   OPENAI_BATCH_MODEL   default gpt-5-mini
+ *   BATCH_TEST_PAGES     default 4
+ *   BATCH_OUT_DIR        default $TMPDIR/batch-compare-openai
+ *
+ * Run: set -a; source ai-intake/.env; set +a; \
+ *   BATCH_TEST_PDF=… pnpm --filter @llumiverse/drivers exec vitest run test/batch-openai.integration.test.ts
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+    Base64DataSource,
+    type BatchInferenceRequestItem,
+    type CompletionResult,
+    type ExecutionOptions,
+    type PromptSegment,
+} from '@llumiverse/core';
+import { describe, expect, it } from 'vitest';
+import { OpenAIDriver } from '../src/index.js';
+
+const API_KEY = process.env.OPENAI_API_KEY;
+const PDF = process.env.BATCH_TEST_PDF;
+const MODEL = process.env.OPENAI_BATCH_MODEL ?? 'gpt-5-mini';
+const PAGES = Number(process.env.BATCH_TEST_PAGES ?? '4');
+const POLL_MS = 30_000;
+const TIMEOUT_MS = 90 * 60 * 1000;
+
+const gated = Boolean(API_KEY && PDF && existsSync(PDF));
+
+function resultText(result: CompletionResult[]): string {
+    return result.map((r) => (r.type === 'text' ? r.value : r.type === 'json' ? JSON.stringify(r.value) : '')).join('');
+}
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe.skipIf(!gated)('OpenAI batch vs sync — document transcription', () => {
+    it(
+        'transcribes the same pages via batch and sync and reports the comparison',
+        async () => {
+            const dir = mkdtempSync(join(tmpdir(), 'batchpdf-oai-'));
+            execFileSync('pdftoppm', [
+                '-f',
+                '1',
+                '-l',
+                String(PAGES),
+                '-r',
+                '150',
+                '-jpeg',
+                PDF as string,
+                join(dir, 'p'),
+            ]);
+            const files = readdirSync(dir)
+                .filter((f) => f.endsWith('.jpg'))
+                .sort();
+            expect(files.length).toBeGreaterThan(0);
+
+            const driver = new OpenAIDriver({ apiKey: API_KEY as string });
+            const PROMPT =
+                'Convert this document page image to clean GitHub-flavored Markdown. Output only the markdown, with no preamble.';
+
+            const requests: BatchInferenceRequestItem[] = files.map((f, i) => ({
+                custom_id: `page-${i + 1}`,
+                segments: [
+                    { role: 'system', content: PROMPT },
+                    {
+                        role: 'user',
+                        content: '',
+                        files: [new Base64DataSource(f, 'image/jpeg', readFileSync(join(dir, f)).toString('base64'))],
+                    },
+                ] as PromptSegment[],
+                options: { model: MODEL, model_options: { max_tokens: 4096 } } as ExecutionOptions,
+            }));
+
+            // --- synchronous path (tolerate gpt-5-mini's occasional empty completions) ---
+            const syncStart = Date.now();
+            const sync = new Map<string, string>();
+            let syncErrors = 0;
+            for (const r of requests) {
+                try {
+                    const res = await driver.execute(r.segments, r.options);
+                    sync.set(r.custom_id, resultText(res.result));
+                } catch (e) {
+                    syncErrors++;
+                    sync.set(r.custom_id, '');
+                    // eslint-disable-next-line no-console
+                    console.log(`[openai-sync] ${r.custom_id} failed: ${(e as Error).message}`);
+                }
+            }
+            const syncMs = Date.now() - syncStart;
+
+            // --- batch path ---
+            const submitStart = Date.now();
+            const job = await driver.startBatchInference(requests, { name: 'doc-batch-test' });
+            // eslint-disable-next-line no-console
+            console.log(`[openai-batch] submitted job=${job.id} status=${job.status}`);
+            let status = job;
+            while (status.status === 'queued' || status.status === 'running') {
+                await sleep(POLL_MS);
+                status = await driver.getBatchInferenceJob(job.id);
+                // eslint-disable-next-line no-console
+                console.log(`[openai-batch] status=${status.status}`);
+            }
+            const batchMs = Date.now() - submitStart;
+            expect(status.status).toBe('succeeded');
+
+            const results = await driver.getBatchInferenceResults(job.id);
+            const batch = new Map(results.map((r) => [r.custom_id, resultText(r.result ?? [])]));
+            const batchTokens = new Map(results.map((r) => [r.custom_id, r.token_usage]));
+
+            expect(batch.size).toBe(requests.length);
+            const outDir = process.env.BATCH_OUT_DIR ?? join(tmpdir(), 'batch-compare-openai');
+            mkdirSync(outDir, { recursive: true });
+            const perPage: Array<Record<string, unknown>> = [];
+            let batchNonEmpty = 0;
+            for (const r of requests) {
+                const s = (sync.get(r.custom_id) ?? '').trim();
+                const b = (batch.get(r.custom_id) ?? '').trim();
+                if (b.length > 0) {
+                    batchNonEmpty++;
+                }
+                writeFileSync(join(outDir, `${r.custom_id}.sync.md`), s);
+                writeFileSync(join(outDir, `${r.custom_id}.batch.md`), b);
+                perPage.push({
+                    custom_id: r.custom_id,
+                    sync_chars: s.length,
+                    batch_chars: b.length,
+                    first120_exact: s.slice(0, 120) === b.slice(0, 120),
+                    identical: s === b,
+                    batch_tokens: batchTokens.get(r.custom_id),
+                });
+            }
+            const summary = {
+                model: MODEL,
+                pages: requests.length,
+                sync_ms: syncMs,
+                sync_errors: syncErrors,
+                batch_ms: batchMs,
+                batch_non_empty: batchNonEmpty,
+                batch_job_id: job.id,
+                per_page: perPage,
+            };
+            writeFileSync(join(outDir, 'summary.json'), JSON.stringify(summary, null, 2));
+            // eslint-disable-next-line no-console
+            console.log(`[openai-batch-vs-sync] ${JSON.stringify(summary)}`);
+            expect(results.length).toBe(requests.length);
+        },
+        TIMEOUT_MS,
+    );
+});

--- a/drivers/test/batch-scale.integration.test.ts
+++ b/drivers/test/batch-scale.integration.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Vertex batch SCALE test — batch-only turnaround vs page count, using GCS-referenced
+ * images (the real PdfToMd path: images already in GCS → referenced by gs:// URI, so
+ * the JSONL stays ~1KB/line at any scale). Sync latency is INFERRED from the measured
+ * per-page rate (no need to actually run hours of sync).
+ *
+ * Answers: "at what scale does batch become faster than sync, and by how much?"
+ *
+ * Gated:
+ *   GOOGLE_PROJECT_ID, GOOGLE_REGION (default us-central1)
+ *   BATCH_BUCKET        gs bucket/prefix the caller can write to
+ *   BATCH_TEST_PDF      source PDF (pages are rendered once, uploaded once, then cycled)
+ *   BATCH_SCALE_PAGES   number of batch requests to submit (default 1000)
+ *   BATCH_TEST_MODEL    default gemini-2.5-flash-lite
+ *   SYNC_S_PER_PAGE     measured sync rate for inference (default 3.5)
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+    type BatchInferenceRequestItem,
+    type ExecutionOptions,
+    type PromptSegment,
+    URLDataSource,
+} from '@llumiverse/core';
+import { describe, expect, it } from 'vitest';
+import { VertexAIDriver } from '../src/index.js';
+
+const PROJECT = process.env.GOOGLE_PROJECT_ID;
+const REGION = process.env.GOOGLE_REGION ?? 'us-central1';
+const BUCKET = process.env.BATCH_BUCKET;
+const PDF = process.env.BATCH_TEST_PDF;
+const MODEL = process.env.BATCH_TEST_MODEL ?? 'gemini-2.5-flash-lite';
+const SCALE = Number(process.env.BATCH_SCALE_PAGES ?? '1000');
+const SYNC_S_PER_PAGE = Number(process.env.SYNC_S_PER_PAGE ?? '3.5');
+const POLL_MS = 30_000;
+const TIMEOUT_MS = 4 * 60 * 60 * 1000; // 4h
+
+const gated = Boolean(PROJECT && BUCKET && PDF && existsSync(PDF));
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+function parseBucket(spec: string): { bucket: string; prefix: string } {
+    const s = spec.replace(/^gs:\/\//, '');
+    const slash = s.indexOf('/');
+    return slash === -1
+        ? { bucket: s, prefix: '' }
+        : { bucket: s.slice(0, slash), prefix: s.slice(slash + 1).replace(/\/+$/, '') };
+}
+
+describe.skipIf(!gated)('Vertex batch scale — turnaround vs page count', () => {
+    it(
+        `batch-only at ${SCALE} pages (GCS-referenced images)`,
+        async () => {
+            // 1. render all pages once, 2. upload to GCS once (referenced, not inlined)
+            const dir = mkdtempSync(join(tmpdir(), 'scaleimg-'));
+            execFileSync('pdftoppm', ['-r', '150', '-jpeg', PDF as string, join(dir, 'p')]);
+            const files = readdirSync(dir)
+                .filter((f) => f.endsWith('.jpg'))
+                .sort();
+            expect(files.length).toBeGreaterThan(0);
+
+            const { bucket, prefix } = parseBucket(BUCKET as string);
+            const imgPrefix = `${prefix ? `${prefix}/` : ''}scale-imgs`;
+            execFileSync('gcloud', [
+                'storage',
+                'cp',
+                ...files.map((f) => join(dir, f)),
+                `gs://${bucket}/${imgPrefix}/`,
+                '--project',
+                PROJECT as string,
+            ]);
+            const gsUris = files.map((f) => `gs://${bucket}/${imgPrefix}/${f}`);
+
+            // 3. build SCALE requests cycling the GCS images
+            const PROMPT =
+                'Convert this document page image to clean GitHub-flavored Markdown. Output only the markdown, with no preamble.';
+            const requests: BatchInferenceRequestItem[] = Array.from({ length: SCALE }, (_, i) => ({
+                custom_id: `page-${i + 1}`,
+                segments: [
+                    { role: 'system', content: PROMPT },
+                    {
+                        role: 'user',
+                        content: '',
+                        files: [
+                            new URLDataSource(`img-${i % gsUris.length}.jpg`, 'image/jpeg', gsUris[i % gsUris.length]),
+                        ],
+                    },
+                ] as PromptSegment[],
+                options: { model: MODEL, model_options: { max_tokens: 4096, temperature: 0 } } as ExecutionOptions,
+            }));
+
+            const driver = new VertexAIDriver({ project: PROJECT as string, region: REGION, batch_bucket: BUCKET });
+
+            // 4. batch-only: measure submit → succeeded → results turnaround
+            const t0 = Date.now();
+            const job = await driver.startBatchInference(requests, { name: `scale-${SCALE}` });
+            // eslint-disable-next-line no-console
+            console.log(`[scale ${SCALE}] submitted ${job.id} status=${job.status}`);
+            let status = job;
+            while (status.status === 'queued' || status.status === 'running') {
+                await sleep(POLL_MS);
+                status = await driver.getBatchInferenceJob(job.id);
+                // eslint-disable-next-line no-console
+                console.log(`[scale ${SCALE}] ${new Date().toISOString()} status=${status.status}`);
+            }
+            const batchMs = Date.now() - t0;
+            expect(status.status).toBe('succeeded');
+
+            const results = await driver.getBatchInferenceResults(job.id);
+            const nonEmpty = results.filter((r) => (r.result?.length ?? 0) > 0).length;
+            const syncMs = SCALE * SYNC_S_PER_PAGE * 1000;
+            const summary = {
+                model: MODEL,
+                pages: SCALE,
+                batch_ms: batchMs,
+                batch_min: +(batchMs / 60000).toFixed(1),
+                inferred_sync_min: +(syncMs / 60000).toFixed(1),
+                speedup_vs_sync: +(syncMs / batchMs).toFixed(2),
+                results: results.length,
+                non_empty: nonEmpty,
+                job: job.id,
+            };
+            const outDir = process.env.BATCH_OUT_DIR ?? join(tmpdir(), 'batch-scale');
+            mkdirSync(outDir, { recursive: true });
+            writeFileSync(join(outDir, `scale-${SCALE}.json`), JSON.stringify(summary, null, 2));
+            // eslint-disable-next-line no-console
+            console.log(`[scale-result] ${JSON.stringify(summary)}`);
+            expect(results.length).toBe(SCALE);
+        },
+        TIMEOUT_MS,
+    );
+});

--- a/drivers/test/batch-scale.integration.test.ts
+++ b/drivers/test/batch-scale.integration.test.ts
@@ -27,6 +27,7 @@ import {
 } from '@llumiverse/core';
 import { describe, expect, it } from 'vitest';
 import { VertexAIDriver } from '../src/index.js';
+import { parseGcsBucket } from '../src/vertexai/batch.js';
 
 const PROJECT = process.env.GOOGLE_PROJECT_ID;
 const REGION = process.env.GOOGLE_REGION ?? 'us-central1';
@@ -41,14 +42,6 @@ const TIMEOUT_MS = 4 * 60 * 60 * 1000; // 4h
 const gated = Boolean(PROJECT && BUCKET && PDF && existsSync(PDF));
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
-function parseBucket(spec: string): { bucket: string; prefix: string } {
-    const s = spec.replace(/^gs:\/\//, '');
-    const slash = s.indexOf('/');
-    return slash === -1
-        ? { bucket: s, prefix: '' }
-        : { bucket: s.slice(0, slash), prefix: s.slice(slash + 1).replace(/\/+$/, '') };
-}
-
 describe.skipIf(!gated)('Vertex batch scale — turnaround vs page count', () => {
     it(
         `batch-only at ${SCALE} pages (GCS-referenced images)`,
@@ -61,7 +54,7 @@ describe.skipIf(!gated)('Vertex batch scale — turnaround vs page count', () =>
                 .sort();
             expect(files.length).toBeGreaterThan(0);
 
-            const { bucket, prefix } = parseBucket(BUCKET as string);
+            const { bucket, prefix } = parseGcsBucket(BUCKET as string);
             const imgPrefix = `${prefix ? `${prefix}/` : ''}scale-imgs`;
             execFileSync('gcloud', [
                 'storage',

--- a/drivers/test/batch-vertex.integration.test.ts
+++ b/drivers/test/batch-vertex.integration.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Live integration test: Vertex batch inference vs synchronous execution on a real
+ * document (the Fed report). Renders the first N pages to JPEG, transcribes each to
+ * markdown via BOTH the synchronous path and the async batch path, and reports
+ * per-page output, tokens and wall-clock.
+ *
+ * Gated — runs only when these are set (and GCP ADC is available):
+ *   GOOGLE_PROJECT_ID   e.g. vertesia-dev
+ *   GOOGLE_REGION       default us-central1
+ *   BATCH_BUCKET        a GCS bucket the caller can write to (name or gs://bucket/prefix)
+ *   BATCH_TEST_PDF      path to the PDF (e.g. the Fed report)
+ *   BATCH_TEST_MODEL    default gemini-2.5-flash-lite
+ *   BATCH_TEST_PAGES    default 4
+ *   BATCH_OUT_DIR       where to write the sync/batch outputs + summary.json
+ *
+ * Run: BATCH_TEST_PDF=… BATCH_BUCKET=… pnpm --filter @llumiverse/drivers exec vitest run test/batch-vertex.integration.test.ts
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+    Base64DataSource,
+    type BatchInferenceRequestItem,
+    type CompletionResult,
+    type ExecutionOptions,
+    type PromptSegment,
+} from '@llumiverse/core';
+import { describe, expect, it } from 'vitest';
+import { VertexAIDriver } from '../src/index.js';
+
+const PROJECT = process.env.GOOGLE_PROJECT_ID;
+const REGION = process.env.GOOGLE_REGION ?? 'us-central1';
+const BUCKET = process.env.BATCH_BUCKET;
+const PDF = process.env.BATCH_TEST_PDF;
+const MODEL = process.env.BATCH_TEST_MODEL ?? 'gemini-2.5-flash-lite';
+const PAGES = Number(process.env.BATCH_TEST_PAGES ?? '4');
+const POLL_MS = 20_000;
+const TIMEOUT_MS = 60 * 60 * 1000;
+
+const gated = Boolean(PROJECT && BUCKET && PDF && existsSync(PDF));
+
+function resultText(result: CompletionResult[]): string {
+    return result.map((r) => (r.type === 'text' ? r.value : r.type === 'json' ? JSON.stringify(r.value) : '')).join('');
+}
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe.skipIf(!gated)('Vertex batch vs sync — document transcription', () => {
+    it(
+        'transcribes the same pages via batch and sync and reports the comparison',
+        async () => {
+            const dir = mkdtempSync(join(tmpdir(), 'batchpdf-'));
+            execFileSync('pdftoppm', [
+                '-f',
+                '1',
+                '-l',
+                String(PAGES),
+                '-r',
+                '150',
+                '-jpeg',
+                PDF as string,
+                join(dir, 'p'),
+            ]);
+            const files = readdirSync(dir)
+                .filter((f) => f.endsWith('.jpg'))
+                .sort();
+            expect(files.length).toBeGreaterThan(0);
+
+            const driver = new VertexAIDriver({ project: PROJECT as string, region: REGION, batch_bucket: BUCKET });
+            const PROMPT =
+                'Convert this document page image to clean GitHub-flavored Markdown. Output only the markdown, with no preamble.';
+
+            const requests: BatchInferenceRequestItem[] = files.map((f, i) => ({
+                custom_id: `page-${i + 1}`,
+                segments: [
+                    { role: 'system', content: PROMPT },
+                    {
+                        role: 'user',
+                        content: '',
+                        files: [new Base64DataSource(f, 'image/jpeg', readFileSync(join(dir, f)).toString('base64'))],
+                    },
+                ] as PromptSegment[],
+                options: { model: MODEL, model_options: { max_tokens: 4096, temperature: 0 } } as ExecutionOptions,
+            }));
+
+            // --- synchronous path ---
+            const syncStart = Date.now();
+            const sync = new Map<string, string>();
+            for (const r of requests) {
+                const res = await driver.execute(r.segments, r.options);
+                sync.set(r.custom_id, resultText(res.result));
+            }
+            const syncMs = Date.now() - syncStart;
+
+            // --- batch path ---
+            const submitStart = Date.now();
+            const job = await driver.startBatchInference(requests, { name: 'doc-batch-test' });
+            // eslint-disable-next-line no-console
+            console.log(`[batch] submitted job=${job.id} status=${job.status}`);
+            let status = job;
+            while (status.status === 'queued' || status.status === 'running') {
+                await sleep(POLL_MS);
+                status = await driver.getBatchInferenceJob(job.id);
+                // eslint-disable-next-line no-console
+                console.log(`[batch] status=${status.status}`);
+            }
+            const batchMs = Date.now() - submitStart;
+            expect(status.status).toBe('succeeded');
+
+            const results = await driver.getBatchInferenceResults(job.id);
+            const batch = new Map(results.map((r) => [r.custom_id, resultText(r.result ?? [])]));
+            const batchTokens = new Map(results.map((r) => [r.custom_id, r.token_usage]));
+
+            // --- compare ---
+            expect(batch.size).toBe(requests.length);
+            const outDir = process.env.BATCH_OUT_DIR ?? join(tmpdir(), 'batch-compare');
+            mkdirSync(outDir, { recursive: true });
+            let firstLineMatches = 0;
+            const perPage: Array<Record<string, unknown>> = [];
+            for (const r of requests) {
+                const s = (sync.get(r.custom_id) ?? '').trim();
+                const b = (batch.get(r.custom_id) ?? '').trim();
+                expect(b.length).toBeGreaterThan(0);
+                const exact = s.slice(0, 120) === b.slice(0, 120);
+                if (exact) {
+                    firstLineMatches++;
+                }
+                writeFileSync(join(outDir, `${r.custom_id}.sync.md`), s);
+                writeFileSync(join(outDir, `${r.custom_id}.batch.md`), b);
+                perPage.push({
+                    custom_id: r.custom_id,
+                    sync_chars: s.length,
+                    batch_chars: b.length,
+                    first120_exact: exact,
+                    identical: s === b,
+                    batch_tokens: batchTokens.get(r.custom_id),
+                });
+            }
+            const summary = {
+                model: MODEL,
+                pages: requests.length,
+                sync_ms: syncMs,
+                batch_ms: batchMs,
+                batch_job_id: job.id,
+                first120_exact_matches: `${firstLineMatches}/${requests.length}`,
+                per_page: perPage,
+            };
+            writeFileSync(join(outDir, 'summary.json'), JSON.stringify(summary, null, 2));
+            // eslint-disable-next-line no-console
+            console.log(`[batch-vs-sync] ${JSON.stringify(summary)}`);
+            // Report-only: batch and sync can differ slightly (sampling); we assert both produced output.
+            expect(firstLineMatches).toBeGreaterThanOrEqual(0);
+        },
+        TIMEOUT_MS,
+    );
+});

--- a/drivers/test/batch.test.ts
+++ b/drivers/test/batch.test.ts
@@ -1,0 +1,131 @@
+import { BatchInferenceJobStatus } from '@llumiverse/common';
+import { describe, expect, it } from 'vitest';
+import {
+    mapModelInvocationJobStatus,
+    parseBedrockBatchOutputLine,
+    parseNativeModelOutput,
+    parseS3Bucket,
+} from '../src/bedrock/batch.js';
+import {
+    mapBatchJobState,
+    parseBatchOutputLine,
+    parseGcsBucket,
+    toRestGenerateContentRequest,
+} from '../src/vertexai/batch.js';
+
+describe('vertex batch helpers', () => {
+    it('parseGcsBucket handles gs://, bucket/prefix and bucket-only', () => {
+        expect(parseGcsBucket('gs://my-bucket/pre/fix/')).toEqual({ bucket: 'my-bucket', prefix: 'pre/fix' });
+        expect(parseGcsBucket('my-bucket/pre')).toEqual({ bucket: 'my-bucket', prefix: 'pre' });
+        expect(parseGcsBucket('my-bucket')).toEqual({ bucket: 'my-bucket', prefix: '' });
+    });
+
+    it('mapBatchJobState maps Vertex JobState to provider-agnostic status', () => {
+        expect(mapBatchJobState('JOB_STATE_SUCCEEDED')).toBe(BatchInferenceJobStatus.succeeded);
+        expect(mapBatchJobState('JOB_STATE_FAILED')).toBe(BatchInferenceJobStatus.failed);
+        expect(mapBatchJobState('JOB_STATE_EXPIRED')).toBe(BatchInferenceJobStatus.failed);
+        expect(mapBatchJobState('JOB_STATE_CANCELLED')).toBe(BatchInferenceJobStatus.cancelled);
+        expect(mapBatchJobState('JOB_STATE_PENDING')).toBe(BatchInferenceJobStatus.queued);
+        expect(mapBatchJobState('JOB_STATE_RUNNING')).toBe(BatchInferenceJobStatus.running);
+        expect(mapBatchJobState(undefined)).toBe(BatchInferenceJobStatus.running);
+    });
+
+    it('toRestGenerateContentRequest nests generation params under generationConfig and prunes undefined', () => {
+        const params = {
+            model: 'gemini-3.1-flash-lite',
+            contents: [{ role: 'user', parts: [{ text: 'hi' }] }],
+            config: {
+                systemInstruction: { parts: [{ text: 'sys' }] },
+                temperature: 0.2,
+                maxOutputTokens: 1024,
+                responseMimeType: 'application/json',
+                safetySettings: [{ category: 'X', threshold: 'Y' }],
+            },
+        } as never;
+        const req = toRestGenerateContentRequest(params);
+        expect(req.contents).toEqual([{ role: 'user', parts: [{ text: 'hi' }] }]);
+        expect(req.systemInstruction).toEqual({ parts: [{ text: 'sys' }] });
+        expect(req.safetySettings).toEqual([{ category: 'X', threshold: 'Y' }]);
+        expect(req.generationConfig).toEqual({
+            temperature: 0.2,
+            maxOutputTokens: 1024,
+            responseMimeType: 'application/json',
+        });
+        expect('topK' in (req.generationConfig as object)).toBe(false);
+    });
+
+    it('parseBatchOutputLine extracts custom_id, text and token usage', () => {
+        const line = JSON.stringify({
+            custom_id: 'page-3',
+            request: {},
+            response: {
+                candidates: [{ content: { parts: [{ text: '# Heading\ntext' }] }, finishReason: 'STOP' }],
+                usageMetadata: { promptTokenCount: 100, candidatesTokenCount: 40, totalTokenCount: 140 },
+            },
+        });
+        const item = parseBatchOutputLine(line, 0);
+        expect(item?.custom_id).toBe('page-3');
+        expect(item?.result).toEqual([{ type: 'text', value: '# Heading\ntext' }]);
+        expect(item?.token_usage).toEqual({ total: 140, prompt: 100, result: 40 });
+        expect(item?.finish_reason).toBe('STOP');
+    });
+
+    it('parseBatchOutputLine falls back to index custom_id and reports errors', () => {
+        const item = parseBatchOutputLine(JSON.stringify({ request: {}, status: 'RESOURCE_EXHAUSTED' }), 7);
+        expect(item?.custom_id).toBe('7');
+        expect(item?.error).toBe('RESOURCE_EXHAUSTED');
+    });
+
+    it('parseBatchOutputLine ignores blank/invalid lines', () => {
+        expect(parseBatchOutputLine('   ', 0)).toBeUndefined();
+        expect(parseBatchOutputLine('not json', 0)).toBeUndefined();
+    });
+});
+
+describe('bedrock batch helpers', () => {
+    it('parseS3Bucket handles s3://, bucket/prefix and bucket-only', () => {
+        expect(parseS3Bucket('s3://b/p/q/')).toEqual({ bucket: 'b', prefix: 'p/q' });
+        expect(parseS3Bucket('b/p')).toEqual({ bucket: 'b', prefix: 'p' });
+        expect(parseS3Bucket('b')).toEqual({ bucket: 'b', prefix: '' });
+    });
+
+    it('mapModelInvocationJobStatus maps Bedrock statuses', () => {
+        expect(mapModelInvocationJobStatus('Completed')).toBe(BatchInferenceJobStatus.succeeded);
+        expect(mapModelInvocationJobStatus('PartiallyCompleted')).toBe(BatchInferenceJobStatus.succeeded);
+        expect(mapModelInvocationJobStatus('Failed')).toBe(BatchInferenceJobStatus.failed);
+        expect(mapModelInvocationJobStatus('Stopped')).toBe(BatchInferenceJobStatus.cancelled);
+        expect(mapModelInvocationJobStatus('Submitted')).toBe(BatchInferenceJobStatus.queued);
+        expect(mapModelInvocationJobStatus('InProgress')).toBe(BatchInferenceJobStatus.running);
+    });
+
+    it('parseNativeModelOutput handles the Anthropic Messages shape', () => {
+        const out = parseNativeModelOutput({
+            content: [{ type: 'text', text: 'hello' }],
+            usage: { input_tokens: 12, output_tokens: 5 },
+            stop_reason: 'end_turn',
+        });
+        expect(out.result).toEqual([{ type: 'text', value: 'hello' }]);
+        expect(out.token_usage).toEqual({ prompt: 12, result: 5, total: 17 });
+        expect(out.finish_reason).toBe('end_turn');
+    });
+
+    it('parseNativeModelOutput handles the Amazon Nova shape', () => {
+        const out = parseNativeModelOutput({
+            output: { message: { content: [{ text: 'nova out' }] } },
+            usage: { inputTokens: 20, outputTokens: 8, totalTokens: 28 },
+            stopReason: 'end_turn',
+        });
+        expect(out.result).toEqual([{ type: 'text', value: 'nova out' }]);
+        expect(out.token_usage).toEqual({ prompt: 20, result: 8, total: 28 });
+    });
+
+    it('parseBedrockBatchOutputLine maps recordId to custom_id', () => {
+        const line = JSON.stringify({
+            recordId: 'p1',
+            modelOutput: { content: [{ text: 'x' }], usage: { input_tokens: 1, output_tokens: 1 } },
+        });
+        const item = parseBedrockBatchOutputLine(line, 0);
+        expect(item?.custom_id).toBe('p1');
+        expect(item?.result).toEqual([{ type: 'text', value: 'x' }]);
+    });
+});

--- a/drivers/test/batch.test.ts
+++ b/drivers/test/batch.test.ts
@@ -1,5 +1,12 @@
 import { BatchInferenceJobStatus } from '@llumiverse/common';
-import { describe, expect, it } from 'vitest';
+import {
+    type BatchBlobStore,
+    type BatchInferenceRequestItem,
+    type DataSource,
+    type ExecutionOptions,
+    PromptRole,
+} from '@llumiverse/core';
+import { describe, expect, it, vi } from 'vitest';
 import {
     mapModelInvocationJobStatus,
     parseBedrockBatchOutputLine,
@@ -12,6 +19,7 @@ import {
     parseGcsBucket,
     toRestGenerateContentRequest,
 } from '../src/vertexai/batch.js';
+import { VertexAIDriver } from '../src/vertexai/index.js';
 
 const manyTrailingSlashes = '/'.repeat(100_000);
 
@@ -64,6 +72,7 @@ describe('vertex batch helpers', () => {
         const line = JSON.stringify({
             custom_id: 'page-3',
             request: {},
+            status: '',
             response: {
                 candidates: [{ content: { parts: [{ text: '# Heading\ntext' }] }, finishReason: 'STOP' }],
                 usageMetadata: { promptTokenCount: 100, candidatesTokenCount: 40, totalTokenCount: 140 },
@@ -82,9 +91,65 @@ describe('vertex batch helpers', () => {
         expect(item?.error).toBe('RESOURCE_EXHAUSTED');
     });
 
+    it('parseBatchOutputLine reports a structured item error even when Vertex emits an empty response', () => {
+        const item = parseBatchOutputLine(
+            JSON.stringify({
+                custom_id: 'image-1',
+                response: {},
+                status: JSON.stringify({ code: 7, message: 'storage.objects.get denied' }),
+            }),
+            0,
+        );
+        expect(item).toEqual({ custom_id: 'image-1', error: 'storage.objects.get denied' });
+    });
+
     it('parseBatchOutputLine ignores blank/invalid lines', () => {
         expect(parseBatchOutputLine('   ', 0)).toBeUndefined();
         expect(parseBatchOutputLine('not json', 0)).toBeUndefined();
+    });
+
+    it('startBatchInference serializes signed media URLs without reading their bytes', async () => {
+        const getStream = vi.fn().mockResolvedValue(new ReadableStream());
+        const getURL = vi.fn().mockResolvedValue('https://signed.example/image.jpg?signature=redacted');
+        const source: DataSource = {
+            name: 'image.jpg',
+            mime_type: 'image/jpeg',
+            getStream,
+            getURL,
+            getURI: vi.fn().mockResolvedValue('gs://tenant-bucket/image.jpg'),
+        };
+        const request: BatchInferenceRequestItem = {
+            custom_id: 'image-1',
+            segments: [{ role: PromptRole.user, content: 'Describe it.', files: [source] }],
+            options: {
+                model: 'publishers/google/models/gemini-2.5-flash',
+            } as ExecutionOptions,
+        };
+        const putText = vi.fn().mockResolvedValue('gs://tenant-bucket/batch/input.jsonl');
+        const blobStore: BatchBlobStore = {
+            putText,
+            readOutput: vi.fn().mockResolvedValue([]),
+        };
+        const driver = new VertexAIDriver({ project: 'test-project', region: 'us-central1' });
+        vi.spyOn(driver, 'getGoogleGenAIClient').mockReturnValue({
+            batches: {
+                create: vi.fn().mockResolvedValue({ name: 'batch-1', state: 'JOB_STATE_PENDING' }),
+            },
+        } as unknown as ReturnType<VertexAIDriver['getGoogleGenAIClient']>);
+
+        await driver.startBatchInference([request], { name: 'signed-media', blobStore });
+
+        expect(getURL).toHaveBeenCalledOnce();
+        expect(getStream).not.toHaveBeenCalled();
+        const input = JSON.parse(vi.mocked(putText).mock.calls[0][1]) as {
+            request: { contents: Array<{ parts: Array<{ fileData?: { fileUri: string } }> }> };
+        };
+        expect(input.request.contents[0].parts).toContainEqual({
+            fileData: {
+                fileUri: 'https://signed.example/image.jpg?signature=redacted',
+                mimeType: 'image/jpeg',
+            },
+        });
     });
 });
 

--- a/drivers/test/batch.test.ts
+++ b/drivers/test/batch.test.ts
@@ -13,11 +13,17 @@ import {
     toRestGenerateContentRequest,
 } from '../src/vertexai/batch.js';
 
+const manyTrailingSlashes = '/'.repeat(100_000);
+
 describe('vertex batch helpers', () => {
     it('parseGcsBucket handles gs://, bucket/prefix and bucket-only', () => {
         expect(parseGcsBucket('gs://my-bucket/pre/fix/')).toEqual({ bucket: 'my-bucket', prefix: 'pre/fix' });
         expect(parseGcsBucket('my-bucket/pre')).toEqual({ bucket: 'my-bucket', prefix: 'pre' });
         expect(parseGcsBucket('my-bucket')).toEqual({ bucket: 'my-bucket', prefix: '' });
+        expect(parseGcsBucket(`gs://my-bucket/prefix${manyTrailingSlashes}`)).toEqual({
+            bucket: 'my-bucket',
+            prefix: 'prefix',
+        });
     });
 
     it('mapBatchJobState maps Vertex JobState to provider-agnostic status', () => {
@@ -87,6 +93,10 @@ describe('bedrock batch helpers', () => {
         expect(parseS3Bucket('s3://b/p/q/')).toEqual({ bucket: 'b', prefix: 'p/q' });
         expect(parseS3Bucket('b/p')).toEqual({ bucket: 'b', prefix: 'p' });
         expect(parseS3Bucket('b')).toEqual({ bucket: 'b', prefix: '' });
+        expect(parseS3Bucket(`s3://b/prefix${manyTrailingSlashes}`)).toEqual({
+            bucket: 'b',
+            prefix: 'prefix',
+        });
     });
 
     it('mapModelInvocationJobStatus maps Bedrock statuses', () => {

--- a/drivers/test/batch.test.ts
+++ b/drivers/test/batch.test.ts
@@ -1,3 +1,4 @@
+import type { S3Client } from '@aws-sdk/client-s3';
 import { BatchInferenceJobStatus } from '@llumiverse/common';
 import {
     type BatchBlobStore,
@@ -6,14 +7,21 @@ import {
     type ExecutionOptions,
     PromptRole,
 } from '@llumiverse/core';
+import type { AuthClient } from 'google-auth-library';
 import { describe, expect, it, vi } from 'vitest';
 import {
+    isBedrockBatchOutputKey,
     mapModelInvocationJobStatus,
     parseBedrockBatchOutputLine,
     parseNativeModelOutput,
     parseS3Bucket,
+    s3List,
 } from '../src/bedrock/batch.js';
+import { BedrockDriver } from '../src/bedrock/index.js';
+import { OpenAIDriver } from '../src/openai/openai.js';
+import { TestDriver } from '../src/test-driver/index.js';
 import {
+    gcsList,
     mapBatchJobState,
     parseBatchOutputLine,
     parseGcsBucket,
@@ -42,6 +50,73 @@ describe('vertex batch helpers', () => {
         expect(mapBatchJobState('JOB_STATE_PENDING')).toBe(BatchInferenceJobStatus.queued);
         expect(mapBatchJobState('JOB_STATE_RUNNING')).toBe(BatchInferenceJobStatus.running);
         expect(mapBatchJobState(undefined)).toBe(BatchInferenceJobStatus.running);
+    });
+
+    it('mapBatchJobState treats JOB_STATE_PARTIALLY_SUCCEEDED as terminal (succeeded)', () => {
+        // Partial results are retrievable; item-level errors surface per-record.
+        // Mapping to 'running' would make pollers loop forever.
+        expect(mapBatchJobState('JOB_STATE_PARTIALLY_SUCCEEDED')).toBe(BatchInferenceJobStatus.succeeded);
+    });
+
+    it('gcsList follows nextPageToken pagination', async () => {
+        const request = vi
+            .fn()
+            .mockResolvedValueOnce({ data: { items: [{ name: 'a' }, { name: 'b' }], nextPageToken: 'page-2' } })
+            .mockResolvedValueOnce({ data: { items: [{ name: 'c' }] } });
+        const auth = { request } as unknown as AuthClient;
+        const names = await gcsList(auth, 'bucket', 'prefix');
+        expect(names).toEqual(['a', 'b', 'c']);
+        expect(request).toHaveBeenCalledTimes(2);
+        expect(vi.mocked(request).mock.calls[1][0].url).toContain('pageToken=page-2');
+    });
+
+    it('parseBatchOutputLine falls back to request.labels.custom_id when not echoed top-level', () => {
+        const line = JSON.stringify({
+            request: { labels: { custom_id: 'page-42' } },
+            response: { candidates: [{ content: { parts: [{ text: 'ok' }] } }] },
+        });
+        const item = parseBatchOutputLine(line, 0);
+        expect(item?.custom_id).toBe('page-42');
+    });
+
+    it('startBatchInference rejects requests targeting different models', async () => {
+        const driver = new VertexAIDriver({ project: 'test-project', region: 'us-central1' });
+        const mkItem = (custom_id: string, model: string): BatchInferenceRequestItem => ({
+            custom_id,
+            segments: [{ role: PromptRole.user, content: 'hi' }],
+            options: { model } as ExecutionOptions,
+        });
+        await expect(
+            driver.startBatchInference([
+                mkItem('a', 'publishers/google/models/gemini-2.5-flash'),
+                mkItem('b', 'publishers/google/models/gemini-2.5-pro'),
+            ]),
+        ).rejects.toThrow(/same model/);
+    });
+
+    it('startBatchInference mirrors custom_id into per-request labels', async () => {
+        const request: BatchInferenceRequestItem = {
+            custom_id: 'page-7',
+            segments: [{ role: PromptRole.user, content: 'hello' }],
+            options: { model: 'publishers/google/models/gemini-2.5-flash' } as ExecutionOptions,
+        };
+        const putText = vi.fn().mockResolvedValue('gs://tenant-bucket/batch/input.jsonl');
+        const blobStore: BatchBlobStore = { putText, readOutput: vi.fn().mockResolvedValue([]) };
+        const driver = new VertexAIDriver({ project: 'test-project', region: 'us-central1' });
+        vi.spyOn(driver, 'getGoogleGenAIClient').mockReturnValue({
+            batches: {
+                create: vi.fn().mockResolvedValue({ name: 'batch-1', state: 'JOB_STATE_PENDING' }),
+            },
+        } as unknown as ReturnType<VertexAIDriver['getGoogleGenAIClient']>);
+
+        await driver.startBatchInference([request], { name: 'labels', blobStore });
+
+        const input = JSON.parse(vi.mocked(putText).mock.calls[0][1]) as {
+            custom_id: string;
+            request: { labels?: Record<string, string> };
+        };
+        expect(input.custom_id).toBe('page-7');
+        expect(input.request.labels).toEqual({ custom_id: 'page-7' });
     });
 
     it('toRestGenerateContentRequest nests generation params under generationConfig and prunes undefined', () => {
@@ -202,5 +277,67 @@ describe('bedrock batch helpers', () => {
         const item = parseBedrockBatchOutputLine(line, 0);
         expect(item?.custom_id).toBe('p1');
         expect(item?.result).toEqual([{ type: 'text', value: 'x' }]);
+    });
+
+    it('isBedrockBatchOutputKey excludes the manifest job-summary file', () => {
+        expect(isBedrockBatchOutputKey('run/output/input.jsonl.out')).toBe(true);
+        expect(isBedrockBatchOutputKey('run/output/records.jsonl')).toBe(true);
+        expect(isBedrockBatchOutputKey('run/output/manifest.json.out')).toBe(false);
+        expect(isBedrockBatchOutputKey('run/output/results.csv')).toBe(false);
+    });
+
+    it('s3List follows ContinuationToken pagination', async () => {
+        const send = vi
+            .fn()
+            .mockResolvedValueOnce({
+                Contents: [{ Key: 'a' }, { Key: 'b' }],
+                IsTruncated: true,
+                NextContinuationToken: 'tok-2',
+            })
+            .mockResolvedValueOnce({ Contents: [{ Key: 'c' }], IsTruncated: false });
+        const s3 = { send } as unknown as S3Client;
+        const keys = await s3List(s3, 'bucket', 'prefix');
+        expect(keys).toEqual(['a', 'b', 'c']);
+        expect(send).toHaveBeenCalledTimes(2);
+        expect(vi.mocked(send).mock.calls[1][0].input).toMatchObject({ ContinuationToken: 'tok-2' });
+    });
+
+    it('supportsBatchInference is gated off until native modelInput mapping lands', () => {
+        const driver = new BedrockDriver({ region: 'us-east-1' });
+        expect(driver.supportsBatchInference()).toBe(false);
+    });
+
+    it('startBatchInference rejects an injected blobStore', async () => {
+        const driver = new BedrockDriver({ region: 'us-east-1' });
+        const blobStore: BatchBlobStore = {
+            putText: vi.fn().mockResolvedValue('s3://b/k'),
+            readOutput: vi.fn().mockResolvedValue([]),
+        };
+        const item: BatchInferenceRequestItem = {
+            custom_id: 'a',
+            segments: [{ role: PromptRole.user, content: 'hi' }],
+            options: { model: 'anthropic.claude-3-haiku' } as ExecutionOptions,
+        };
+        await expect(driver.startBatchInference([item], { blobStore })).rejects.toThrow(/blobStore/);
+    });
+});
+
+describe('batch inference limits', () => {
+    it('drivers report provider-documented job limits', () => {
+        const vertex = new VertexAIDriver({ project: 'p', region: 'us-central1' });
+        expect(vertex.getBatchInferenceLimits()).toEqual({ max_requests_per_job: 200_000, max_concurrent_jobs: 75 });
+
+        const openai = new OpenAIDriver({ apiKey: 'test-key' });
+        expect(openai.getBatchInferenceLimits()).toEqual({
+            max_requests_per_job: 50_000,
+            max_input_bytes: 200 * 1024 * 1024,
+        });
+
+        const bedrock = new BedrockDriver({ region: 'us-east-1' });
+        expect(bedrock.getBatchInferenceLimits()).toEqual({ max_requests_per_job: 50_000, min_requests_per_job: 100 });
+    });
+
+    it('drivers without a batch implementation report the conservative default', () => {
+        expect(new TestDriver().getBatchInferenceLimits()).toEqual({ max_requests_per_job: 10_000 });
     });
 });


### PR DESCRIPTION
## Summary

- Add a provider-neutral asynchronous batch-inference lifecycle with submit, poll, cancel, and result retrieval APIs.
- Support injectable batch blob storage so hosts can stage provider JSONL in tenant-owned GCS or S3 storage.
- Implement batch inference for Vertex Gemini, OpenAI Responses, and Amazon Bedrock, with capability reporting and normalized provider job resources.
- Send OpenAI batch images as signed HTTPS URLs while preserving inline base64 images for synchronous requests.
- Add unit and gated integration coverage for provider payloads, status mapping, result parsing, and batch-versus-sync behavior.

## Test Plan

- [x] `pnpm lint`
- [x] `pnpm typecheck:test`
- [x] `pnpm build`
- [x] `pnpm test` — 483 passed, 22 skipped
- [x] `pnpm test src/openai/batch-input.test.ts` — 2 passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core driver interfaces and multi-provider I/O (GCS/S3, large JSONL); Bedrock batch is intentionally off but live OpenAI/Vertex paths affect production batch routing and staging credentials.
> 
> **Overview**
> Introduces a **provider-neutral async batch inference API** on the driver contract: submit jobs from the same `segments`/`options` as `execute()`, poll/cancel, and fetch per-`custom_id` results (text-only today). Shared types cover job status, optional **`BatchBlobStore`** staging, `input_uri`, and **`getBatchInferenceLimits`** for splitting large workloads.
> 
> **OpenAI (Responses)** builds batch JSONL from the same body as sync (refactored via `buildTextCompletionRequest` / `buildResponsesBody`); batch images use **signed URLs** instead of inlined base64. **Vertex Gemini** stages GCS JSONL (or injected blob store), normalizes catalog model ids/locations, and maps Gemini batch output including partial success as terminal.
> 
> **Bedrock** adds S3 `CreateModelInvocationJob` plumbing and parsers, but **`supportsBatchInference` stays false** until Converse prompts are mapped to native InvokeModel bodies; injected `blobStore` is rejected on Bedrock.
> 
> Adds shared bucket parsing, broad unit tests, and env-gated integration tests comparing batch vs sync on document pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3903c27218d2a1db193c1e12cc7d1526e695d5b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->