### PR TITLE
feat: preserve native thinking output across providers

### DIFF
--- a/common/src/options/anthropic.ts
+++ b/common/src/options/anthropic.ts
@@ -26,7 +26,7 @@ export interface AnthropicClaudeOptions {
 
 export function getAnthropicOptions(model: string, option?: ModelOptions): ModelOptionsInfo {
     const max_tokens_limit = getClaudeMaxTokensLimit(model);
-    const excludeOptions = ['max_tokens', 'presence_penalty', 'frequency_penalty'];
+    const excludeOptions = ['max_tokens', 'presence_penalty', 'frequency_penalty', 'include_thoughts'];
     let commonOptions = textOptionsFallback.options.filter((o) => !excludeOptions.includes(o.name));
 
     const hasSamplingRestriction = hasSamplingParameterRestriction(model);

--- a/common/src/options/bedrock.test.ts
+++ b/common/src/options/bedrock.test.ts
@@ -73,6 +73,7 @@ describe('Bedrock Mantle metadata', () => {
             'temperature',
             'top_p',
             'stop_sequence',
+            'include_thoughts',
         ]);
         expect(capabilities.input).toMatchObject({ text: true, image: true });
         expect(capabilities.output.text).toBe(true);

--- a/common/src/options/bedrock_mantle.ts
+++ b/common/src/options/bedrock_mantle.ts
@@ -210,7 +210,7 @@ function getResponsesOptions(model: string): ModelOptionsInfo {
 }
 
 function getChatCompletionsOptions(model: string): ModelOptionsInfo {
-    const allowedOptions = new Set(['max_tokens', 'temperature', 'top_p', 'stop_sequence']);
+    const allowedOptions = new Set(['max_tokens', 'temperature', 'top_p', 'stop_sequence', 'include_thoughts']);
     const maxOutputTokens = getBedrockModelKnowledge(model).max_output_tokens;
     return {
         _option_id: 'bedrock-mantle-chat-completions',

--- a/common/src/options/fallback.ts
+++ b/common/src/options/fallback.ts
@@ -73,5 +73,11 @@ export const textOptionsFallback: ModelOptionsInfo = {
             value: [],
             description: 'The generation will halt if one of the stop sequences is output',
         },
+        {
+            name: 'include_thoughts',
+            type: OptionType.boolean,
+            default: true,
+            description: 'Include visible model reasoning as separate thoughts results.',
+        },
     ],
 };

--- a/common/src/options/shared-parsing.ts
+++ b/common/src/options/shared-parsing.ts
@@ -121,7 +121,7 @@ export function buildClaudeIncludeThoughtsOption(model: string): ModelOptionInfo
         {
             name: 'include_thoughts',
             type: OptionType.boolean,
-            default: false,
+            default: true,
             description: "Include the model's thinking content in the response.",
         },
     ];

--- a/common/src/options/vertexai.ts
+++ b/common/src/options/vertexai.ts
@@ -348,7 +348,7 @@ function getGeminiThinkingOptionItems(model: string): ModelOptionInfoItem[] {
         {
             name: 'include_thoughts',
             type: OptionType.boolean,
-            default: false,
+            default: true,
             description: "Include the model's reasoning process in the response",
         },
         {
@@ -367,7 +367,14 @@ function getGeminiOptions(model: string, option?: ModelOptions): ModelOptionsInf
         const isGemini3OrLater = isGeminiModelVersionGte(model, '3.0');
 
         const max_tokens_limit = getGeminiMaxTokensLimit(model);
-        const excludeOptions = ['max_tokens', 'presence_penalty', 'frequency_penalty', 'seed', 'top_k'];
+        const excludeOptions = [
+            'max_tokens',
+            'presence_penalty',
+            'frequency_penalty',
+            'seed',
+            'top_k',
+            'include_thoughts',
+        ];
         let commonOptions = textOptionsFallback.options.filter((option) => !excludeOptions.includes(option.name));
 
         // Set max temperature to 2.0
@@ -486,7 +493,7 @@ function getGeminiOptions(model: string, option?: ModelOptions): ModelOptionsInf
         };
     }
     const max_tokens_limit = getGeminiMaxTokensLimit(model);
-    const excludeOptions = ['max_tokens'];
+    const excludeOptions = ['max_tokens', 'include_thoughts'];
     const commonOptions = textOptionsFallback.options.filter((option) => !excludeOptions.includes(option.name));
 
     const max_tokens: ModelOptionInfoItem[] = [
@@ -569,7 +576,7 @@ function getGeminiOptions(model: string, option?: ModelOptions): ModelOptionsInf
             {
                 name: 'include_thoughts',
                 type: OptionType.boolean,
-                default: false,
+                default: true,
                 description: "Include the model's reasoning process in the response",
             },
             {
@@ -598,7 +605,7 @@ function getGeminiOptions(model: string, option?: ModelOptions): ModelOptionsInf
 
 function getClaudeOptions(model: string, option?: ModelOptions): ModelOptionsInfo {
     const max_tokens_limit = getClaudeMaxTokensLimit(model);
-    const excludeOptions = ['max_tokens', 'presence_penalty', 'frequency_penalty'];
+    const excludeOptions = ['max_tokens', 'presence_penalty', 'frequency_penalty', 'include_thoughts'];
     let commonOptions = textOptionsFallback.options.filter((option) => !excludeOptions.includes(option.name));
 
     // Opus 4.7+ models no longer support temperature, top_p, top_k (returns 400 error)

--- a/common/src/schemas/completion.test.ts
+++ b/common/src/schemas/completion.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { CompletionResultSchema } from './completion.js';
+
+describe('CompletionResultSchema', () => {
+    it('accepts thoughts as a separate completion result type', () => {
+        expect(CompletionResultSchema.parse({ type: 'thoughts', value: 'Reasoning summary' })).toEqual({
+            type: 'thoughts',
+            value: 'Reasoning summary',
+        });
+    });
+});

--- a/common/src/schemas/completion.ts
+++ b/common/src/schemas/completion.ts
@@ -104,6 +104,10 @@ export const TextResultSchema = z
     .strictObject({ type: z.literal('text'), value: z.string() })
     .meta({ id: 'TextResult' });
 
+export const ThoughtsResultSchema = z
+    .strictObject({ type: z.literal('thoughts'), value: z.string() })
+    .meta({ id: 'ThoughtsResult' });
+
 export const JsonResultSchema = z
     .strictObject({ type: z.literal('json'), value: JSONValueSchema })
     .meta({ id: 'JsonResult' });
@@ -113,7 +117,7 @@ export const ImageResultSchema = z
     .meta({ id: 'ImageResult' });
 
 export const CompletionResultSchema = z
-    .discriminatedUnion('type', [TextResultSchema, JsonResultSchema, ImageResultSchema])
+    .discriminatedUnion('type', [TextResultSchema, ThoughtsResultSchema, JsonResultSchema, ImageResultSchema])
     .meta({ id: 'CompletionResult' });
 
 export const ExecutionTokenUsageSchema = z

--- a/common/src/schemas/model-options.ts
+++ b/common/src/schemas/model-options.ts
@@ -41,6 +41,7 @@ export const TextFallbackOptionsSchema = z
         presence_penalty: z.number().optional(),
         frequency_penalty: z.number().optional(),
         stop_sequence: z.array(z.string()).optional(),
+        include_thoughts: z.boolean().optional(),
     })
     .meta({ id: 'TextFallbackOptions' });
 
@@ -68,6 +69,7 @@ export const BedrockConverseOptionsSchema = z
         temperature: z.number().optional(),
         top_p: z.number().optional(),
         stop_sequence: z.array(z.string()).optional(),
+        include_thoughts: z.boolean().optional(),
     })
     .meta({ id: 'BedrockConverseOptions' });
 
@@ -78,6 +80,7 @@ export const BedrockNovaOptionsSchema = z
         temperature: z.number().optional(),
         top_p: z.number().optional(),
         stop_sequence: z.array(z.string()).optional(),
+        include_thoughts: z.boolean().optional(),
     })
     .meta({ id: 'BedrockNovaOptions' });
 
@@ -88,6 +91,7 @@ export const BedrockMistralOptionsSchema = z
         temperature: z.number().optional(),
         top_p: z.number().optional(),
         stop_sequence: z.array(z.string()).optional(),
+        include_thoughts: z.boolean().optional(),
     })
     .meta({ id: 'BedrockMistralOptions' });
 
@@ -98,6 +102,7 @@ export const BedrockAI21OptionsSchema = z
         temperature: z.number().optional(),
         top_p: z.number().optional(),
         stop_sequence: z.array(z.string()).optional(),
+        include_thoughts: z.boolean().optional(),
     })
     .meta({ id: 'BedrockAI21Options' });
 
@@ -108,6 +113,7 @@ export const BedrockCohereCommandOptionsSchema = z
         temperature: z.number().optional(),
         top_p: z.number().optional(),
         stop_sequence: z.array(z.string()).optional(),
+        include_thoughts: z.boolean().optional(),
     })
     .meta({ id: 'BedrockCohereCommandOptions' });
 
@@ -200,6 +206,7 @@ export const BedrockMantleResponsesOptionsSchema = z
         reasoning_effort: z.enum(['none', 'low', 'medium', 'high', 'xhigh']).optional(),
         verbosity: z.enum(['low', 'medium', 'high']).optional(),
         image_detail: z.enum(['low', 'high', 'auto']).optional(),
+        include_thoughts: z.boolean().optional(),
     })
     .meta({ id: 'BedrockMantleResponsesOptions' });
 
@@ -210,6 +217,7 @@ export const BedrockMantleChatCompletionsOptionsSchema = z
         temperature: z.number().optional(),
         top_p: z.number().optional(),
         stop_sequence: z.array(z.string()).optional(),
+        include_thoughts: z.boolean().optional(),
     })
     .meta({ id: 'BedrockMantleChatCompletionsOptions' });
 
@@ -239,6 +247,7 @@ export const OpenAiThinkingOptionsSchema = z
         effort: ReasoningEffortSchema.optional(),
         reasoning_effort: ReasoningEffortSchema.optional(),
         image_detail: z.enum(['low', 'high', 'auto']).optional(),
+        include_thoughts: z.boolean().optional(),
     })
     .meta({ id: 'OpenAiThinkingOptions' });
 
@@ -252,6 +261,7 @@ export const OpenAiTextOptionsSchema = z
         frequency_penalty: z.number().optional(),
         stop_sequence: z.array(z.string()).optional(),
         image_detail: z.enum(['low', 'high', 'auto']).optional(),
+        include_thoughts: z.boolean().optional(),
     })
     .meta({ id: 'OpenAiTextOptions' });
 

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -362,12 +362,18 @@ export class LlumiverseError extends Error {
 // ============== Result Types ===============
 
 export interface BaseResult {
-    type: 'text' | 'json' | 'image';
+    type: 'text' | 'thoughts' | 'json' | 'image';
     value: unknown;
 }
 
 export interface TextResult extends BaseResult {
     type: 'text';
+    value: string;
+}
+
+/** A visible projection of model reasoning, separate from the answer text. */
+export interface ThoughtsResult extends BaseResult {
+    type: 'thoughts';
     value: string;
 }
 
@@ -384,7 +390,7 @@ export interface ImageResult extends BaseResult {
 /**
  * @discriminator type
  */
-export type CompletionResult = TextResult | JsonResult | ImageResult;
+export type CompletionResult = TextResult | ThoughtsResult | JsonResult | ImageResult;
 
 //Internal structure used in driver implementation.
 export interface CompletionChunkObject {

--- a/core/src/CompletionStream.thoughts.test.ts
+++ b/core/src/CompletionStream.thoughts.test.ts
@@ -9,14 +9,19 @@ import type {
     ModelSearchPayload,
 } from '@llumiverse/common';
 import { describe, expect, it } from 'vitest';
-import { DefaultCompletionStream } from './CompletionStream.js';
+import { DefaultCompletionStream, FallbackCompletionStream } from './CompletionStream.js';
 import { AbstractDriver } from './Driver.js';
 
 class ThoughtsStreamDriver extends AbstractDriver<DriverOptions, string> {
     provider = 'test';
 
     async requestTextCompletion(): Promise<Completion> {
-        throw new Error('not used');
+        return {
+            result: [
+                { type: 'thoughts', value: 'reason-fallback' },
+                { type: 'text', value: 'answer-fallback' },
+            ],
+        };
     }
 
     async requestTextCompletionStream(prompt: string): Promise<DriverCompletionStream> {
@@ -45,19 +50,33 @@ class ThoughtsStreamDriver extends AbstractDriver<DriverOptions, string> {
 }
 
 describe('DefaultCompletionStream thoughts', () => {
-    it('keeps the public string stream answer-only while exposing typed thoughts', async () => {
+    it('streams visible thoughts before the answer while preserving typed results', async () => {
         const driver = new ThoughtsStreamDriver({});
         const stream = new DefaultCompletionStream(driver, 'one', { model: 'test' });
 
         const visible: string[] = [];
         for await (const chunk of stream) visible.push(chunk);
 
-        expect(visible).toEqual(['answer-one']);
+        expect(visible).toEqual(['reason-one', '\nanswer-one']);
         expect(stream.completion?.result).toEqual([
             { type: 'thoughts', value: 'reason-one' },
             { type: 'text', value: 'answer-one' },
         ]);
         expect(stream.completion?.conversation).toEqual({ role: 'assistant', id: 'one' });
+    });
+
+    it('separates thoughts from the answer in the fallback string stream', async () => {
+        const driver = new ThoughtsStreamDriver({});
+        const stream = new FallbackCompletionStream(driver, 'fallback', { model: 'test' });
+
+        const visible: string[] = [];
+        for await (const chunk of stream) visible.push(chunk);
+
+        expect(visible).toEqual(['reason-fallback\nanswer-fallback']);
+        expect(stream.completion?.result).toEqual([
+            { type: 'thoughts', value: 'reason-fallback' },
+            { type: 'text', value: 'answer-fallback' },
+        ]);
     });
 
     it('isolates native finalizers across concurrent streams', async () => {

--- a/core/src/CompletionStream.thoughts.test.ts
+++ b/core/src/CompletionStream.thoughts.test.ts
@@ -1,0 +1,80 @@
+import type {
+    AIModel,
+    Completion,
+    DriverCompletionStream,
+    DriverOptions,
+    EmbeddingsOptions,
+    EmbeddingsResult,
+    ExecutionOptions,
+    ModelSearchPayload,
+} from '@llumiverse/common';
+import { describe, expect, it } from 'vitest';
+import { DefaultCompletionStream } from './CompletionStream.js';
+import { AbstractDriver } from './Driver.js';
+
+class ThoughtsStreamDriver extends AbstractDriver<DriverOptions, string> {
+    provider = 'test';
+
+    async requestTextCompletion(): Promise<Completion> {
+        throw new Error('not used');
+    }
+
+    async requestTextCompletionStream(prompt: string): Promise<DriverCompletionStream> {
+        const nativeAssistant = { role: 'assistant', id: prompt };
+        return {
+            async *[Symbol.asyncIterator]() {
+                yield { result: [{ type: 'thoughts', value: `reason-${prompt}` }] };
+                await Promise.resolve();
+                yield { result: [{ type: 'text', value: `answer-${prompt}` }], finish_reason: 'stop' };
+            },
+            finalizeConversation: () => nativeAssistant,
+        };
+    }
+
+    async listModels(_params?: ModelSearchPayload): Promise<AIModel[]> {
+        return [];
+    }
+
+    async validateConnection(): Promise<boolean> {
+        return true;
+    }
+
+    async generateEmbeddings(_options: EmbeddingsOptions): Promise<EmbeddingsResult> {
+        throw new Error('not used');
+    }
+}
+
+describe('DefaultCompletionStream thoughts', () => {
+    it('keeps the public string stream answer-only while exposing typed thoughts', async () => {
+        const driver = new ThoughtsStreamDriver({});
+        const stream = new DefaultCompletionStream(driver, 'one', { model: 'test' });
+
+        const visible: string[] = [];
+        for await (const chunk of stream) visible.push(chunk);
+
+        expect(visible).toEqual(['answer-one']);
+        expect(stream.completion?.result).toEqual([
+            { type: 'thoughts', value: 'reason-one' },
+            { type: 'text', value: 'answer-one' },
+        ]);
+        expect(stream.completion?.conversation).toEqual({ role: 'assistant', id: 'one' });
+    });
+
+    it('isolates native finalizers across concurrent streams', async () => {
+        const driver = new ThoughtsStreamDriver({});
+        const streams = ['left', 'right'].map(
+            (prompt) => new DefaultCompletionStream(driver, prompt, { model: 'test' } satisfies ExecutionOptions),
+        );
+
+        await Promise.all(
+            streams.map(async (stream) => {
+                for await (const _chunk of stream) {
+                    // drain
+                }
+            }),
+        );
+
+        expect(streams[0].completion?.conversation).toEqual({ role: 'assistant', id: 'left' });
+        expect(streams[1].completion?.conversation).toEqual({ role: 'assistant', id: 'right' });
+    });
+});

--- a/core/src/CompletionStream.thoughts.test.ts
+++ b/core/src/CompletionStream.thoughts.test.ts
@@ -28,7 +28,8 @@ class ThoughtsStreamDriver extends AbstractDriver<DriverOptions, string> {
         const nativeAssistant = { role: 'assistant', id: prompt };
         return {
             async *[Symbol.asyncIterator]() {
-                yield { result: [{ type: 'thoughts', value: `reason-${prompt}` }] };
+                yield { result: [{ type: 'thoughts', value: 'reason-' }] };
+                yield { result: [{ type: 'thoughts', value: prompt }] };
                 await Promise.resolve();
                 yield { result: [{ type: 'text', value: `answer-${prompt}` }], finish_reason: 'stop' };
             },
@@ -57,7 +58,7 @@ describe('DefaultCompletionStream thoughts', () => {
         const visible: string[] = [];
         for await (const chunk of stream) visible.push(chunk);
 
-        expect(visible).toEqual(['reason-one', '\nanswer-one']);
+        expect(visible).toEqual(['reason-', 'one', '\nanswer-one']);
         expect(stream.completion?.result).toEqual([
             { type: 'thoughts', value: 'reason-one' },
             { type: 'text', value: 'answer-one' },

--- a/core/src/CompletionStream.ts
+++ b/core/src/CompletionStream.ts
@@ -111,6 +111,7 @@ export class DefaultCompletionStream<PromptT = unknown> implements CompletionStr
         let sourceIterator: AsyncIterator<CompletionChunkObject> | undefined;
         let stream: DriverCompletionStream | undefined;
         let streamCompleted = false;
+        let previousStreamedResultType: CompletionResult['type'] | undefined;
 
         try {
             stream = await httpScope.run(() => this.driver.requestTextCompletionStream(this.prompt, this.options));
@@ -205,11 +206,14 @@ export class DefaultCompletionStream<PromptT = unknown> implements CompletionStr
                             // Only yield if we have results to show
                             const resultText = chunk.result
                                 .map((r) => {
+                                    const prefix =
+                                        previousStreamedResultType === 'thoughts' && r.type !== 'thoughts' ? '\n' : '';
+                                    previousStreamedResultType = r.type;
                                     switch (r.type) {
                                         case 'text':
-                                            return r.value;
+                                            return prefix + r.value;
                                         case 'thoughts':
-                                            return '';
+                                            return r.value;
                                         case 'json':
                                             return JSON.stringify(r.value);
                                         case 'image': {
@@ -360,13 +364,16 @@ export class FallbackCompletionStream<PromptT = unknown> implements CompletionSt
         try {
             const completion = await this.driver._execute(this.prompt, this.options);
             // For fallback streaming, yield the text content but keep the original completion
+            let previousResultType: CompletionResult['type'] | undefined;
             const content = completion.result
                 .map((r) => {
+                    const prefix = previousResultType === 'thoughts' && r.type !== 'thoughts' ? '\n' : '';
+                    previousResultType = r.type;
                     switch (r.type) {
-                    case 'text':
-                        return r.value;
-                    case 'thoughts':
-                        return '';
+                        case 'text':
+                            return prefix + r.value;
+                        case 'thoughts':
+                            return r.value;
                         case 'json':
                             return JSON.stringify(r.value);
                         case 'image': {

--- a/core/src/CompletionStream.ts
+++ b/core/src/CompletionStream.ts
@@ -208,6 +208,8 @@ export class DefaultCompletionStream<PromptT = unknown> implements CompletionStr
                                     switch (r.type) {
                                         case 'text':
                                             return r.value;
+                                        case 'thoughts':
+                                            return '';
                                         case 'json':
                                             return JSON.stringify(r.value);
                                         case 'image': {
@@ -361,8 +363,10 @@ export class FallbackCompletionStream<PromptT = unknown> implements CompletionSt
             const content = completion.result
                 .map((r) => {
                     switch (r.type) {
-                        case 'text':
-                            return r.value;
+                    case 'text':
+                        return r.value;
+                    case 'thoughts':
+                        return '';
                         case 'json':
                             return JSON.stringify(r.value);
                         case 'image': {

--- a/core/src/CompletionStream.ts
+++ b/core/src/CompletionStream.ts
@@ -158,43 +158,46 @@ export class DefaultCompletionStream<PromptT = unknown> implements CompletionStr
                                 // Check if we can combine with the last accumulated result
                                 const lastResult = accumulatedResults[accumulatedResults.length - 1];
 
-                                if (
-                                    lastResult &&
-                                    ((lastResult.type === 'text' && result.type === 'text') ||
-                                        (lastResult.type === 'json' && result.type === 'json'))
-                                ) {
-                                    // Combine consecutive text or JSON results
-                                    if (result.type === 'text') {
-                                        lastResult.value += result.value;
-                                    } else if (result.type === 'json') {
-                                        // For JSON, combine the parsed objects directly
-                                        try {
-                                            const lastParsed = lastResult.value;
-                                            const currentParsed = result.value;
-                                            if (
-                                                lastParsed !== null &&
-                                                typeof lastParsed === 'object' &&
-                                                currentParsed !== null &&
-                                                typeof currentParsed === 'object'
-                                            ) {
-                                                const combined = { ...lastParsed, ...currentParsed };
-                                                lastResult.value = combined;
-                                            } else {
-                                                // If not objects, convert to string and concatenate
-                                                const lastStr =
-                                                    typeof lastParsed === 'string'
-                                                        ? lastParsed
-                                                        : JSON.stringify(lastParsed);
-                                                const currentStr =
-                                                    typeof currentParsed === 'string'
-                                                        ? currentParsed
-                                                        : JSON.stringify(currentParsed);
-                                                lastResult.value = lastStr + currentStr;
+                                if (lastResult?.type === result.type) {
+                                    switch (result.type) {
+                                        case 'text':
+                                        case 'thoughts':
+                                            lastResult.value = String(lastResult.value) + result.value;
+                                            break;
+                                        case 'json':
+                                            // For JSON, combine the parsed objects directly
+                                            try {
+                                                const lastParsed = lastResult.value;
+                                                const currentParsed = result.value;
+                                                if (
+                                                    lastParsed !== null &&
+                                                    typeof lastParsed === 'object' &&
+                                                    currentParsed !== null &&
+                                                    typeof currentParsed === 'object'
+                                                ) {
+                                                    const combined = { ...lastParsed, ...currentParsed };
+                                                    lastResult.value = combined;
+                                                } else {
+                                                    // If not objects, convert to string and concatenate
+                                                    const lastStr =
+                                                        typeof lastParsed === 'string'
+                                                            ? lastParsed
+                                                            : JSON.stringify(lastParsed);
+                                                    const currentStr =
+                                                        typeof currentParsed === 'string'
+                                                            ? currentParsed
+                                                            : JSON.stringify(currentParsed);
+                                                    lastResult.value = lastStr + currentStr;
+                                                }
+                                            } catch {
+                                                // If anything fails, just concatenate string representations
+                                                lastResult.value = String(lastResult.value) + String(result.value);
                                             }
-                                        } catch {
-                                            // If anything fails, just concatenate string representations
-                                            lastResult.value = String(lastResult.value) + String(result.value);
-                                        }
+                                            break;
+                                        case 'image':
+                                            // Images are discrete results and must retain their original boundaries.
+                                            accumulatedResults.push(result);
+                                            break;
                                     }
                                 } else {
                                     // Add as new result
@@ -202,8 +205,10 @@ export class DefaultCompletionStream<PromptT = unknown> implements CompletionStr
                                 }
                             }
 
-                            // Convert CompletionResult[] to string for streaming
-                            // Only yield if we have results to show
+                            // The async iterator is intentionally a flattened live-preview stream. It includes both
+                            // thoughts and answer content so long reasoning phases remain visibly active instead of
+                            // looking like a network stall. Canonical consumers must use `completion.result`, where
+                            // thoughts remain separately typed and are never merged into answer or structured output.
                             const resultText = chunk.result
                                 .map((r) => {
                                     const prefix =

--- a/core/src/conversation-utils.ts
+++ b/core/src/conversation-utils.ts
@@ -30,8 +30,6 @@ export interface ConversationMeta {
  * Options for stripping functions
  */
 export interface StripOptions {
-    /** Native protocol unit that generic cleanup must not modify. */
-    preserveSubtree?: (value: unknown) => boolean;
     /**
      * Provider hook for native protocol units that must remain byte-for-byte unchanged.
      * When true, generic media, text, and heartbeat cleanup does not descend into the value.

--- a/core/src/conversation-utils.ts
+++ b/core/src/conversation-utils.ts
@@ -33,6 +33,11 @@ export interface StripOptions {
     /** Native protocol unit that generic cleanup must not modify. */
     preserveSubtree?: (value: unknown) => boolean;
     /**
+     * Provider hook for native protocol units that must remain byte-for-byte unchanged.
+     * When true, generic media, text, and heartbeat cleanup does not descend into the value.
+     */
+    preserveSubtree?: (value: unknown) => boolean;
+    /**
      * Number of turns to keep images before stripping.
      * - Infinity or undefined: Never strip (default — callers must opt in)
      * - 0: Strip immediately

--- a/core/src/validation.test.ts
+++ b/core/src/validation.test.ts
@@ -1,0 +1,19 @@
+import type { CompletionResult } from '@llumiverse/common';
+import { describe, expect, it } from 'vitest';
+import { validateResult } from './validation.js';
+
+describe('validateResult', () => {
+    it('preserves thoughts while replacing the response content with validated JSON', () => {
+        const result: CompletionResult[] = [
+            { type: 'thoughts', value: 'first thought' },
+            { type: 'text', value: '{"answer":"ok"}' },
+            { type: 'thoughts', value: 'second thought' },
+        ];
+
+        expect(validateResult(result, { type: 'object' })).toEqual([
+            { type: 'thoughts', value: 'first thought' },
+            { type: 'json', value: { answer: 'ok' } },
+            { type: 'thoughts', value: 'second thought' },
+        ]);
+    });
+});

--- a/core/src/validation.ts
+++ b/core/src/validation.ts
@@ -107,5 +107,20 @@ export function validateResult(data: CompletionResult[], schema: object): Comple
         }
     }
 
-    return [{ type: 'json', value: json }];
+    // Structured-output validation applies only to response content. Thoughts are
+    // separate first-class results and must remain available to callers.
+    const validatedResult: CompletionResult = { type: 'json', value: json };
+    const firstContentIndex = data.findIndex((part) => part.type !== 'thoughts');
+    if (firstContentIndex === -1) {
+        return [validatedResult];
+    }
+
+    return data.reduce<CompletionResult[]>((results, part, index) => {
+        if (part.type === 'thoughts') {
+            results.push(part);
+        } else if (index === firstContentIndex) {
+            results.push(validatedResult);
+        }
+        return results;
+    }, []);
 }

--- a/core/test/conversation-strip.test.ts
+++ b/core/test/conversation-strip.test.ts
@@ -162,6 +162,32 @@ describe('stripBinaryFromConversation', () => {
     });
 });
 
+describe('provider-protected pruning subtrees', () => {
+    test('keeps a signed native unit unchanged while pruning adjacent content', () => {
+        const signed = {
+            type: 'thinking',
+            thinking: 'signed reasoning that must remain unchanged',
+            signature: 'opaque-signature-that-must-remain-unchanged',
+        };
+        const conversation = {
+            messages: [
+                { role: 'assistant', content: [signed] },
+                { role: 'user', content: 'ordinary tool output that is intentionally long' },
+            ],
+        };
+        const preserveSubtree = (value: unknown) =>
+            !!value && typeof value === 'object' && (value as { type?: unknown }).type === 'thinking';
+
+        const result = truncateLargeTextInConversation(conversation, {
+            textMaxTokens: 2,
+            preserveSubtree,
+        }) as typeof conversation;
+
+        expect(result.messages[0].content).toEqual([signed]);
+        expect(result.messages[1].content).toContain('[Content truncated');
+    });
+});
+
 describe('stripBase64ImagesFromConversation', () => {
     test('should replace OpenAI image_url block with text block', () => {
         const input = {

--- a/drivers/src/anthropic/index.ts
+++ b/drivers/src/anthropic/index.ts
@@ -3,7 +3,7 @@ import type { AnthropicClaudeOptions } from '@llumiverse/common';
 import {
     type AIModel,
     type Completion,
-    type CompletionChunkObject,
+    type DriverCompletionStream,
     type DriverOptions,
     type EmbeddingsOptions,
     type EmbeddingsResult,
@@ -66,7 +66,7 @@ export class AnthropicDriver extends AbstractDriver<AnthropicDriverOptions, Clau
     async requestTextCompletionStream(
         prompt: ClaudePrompt,
         options: ExecutionOptions,
-    ): Promise<AsyncIterable<CompletionChunkObject>> {
+    ): Promise<DriverCompletionStream> {
         const model_options = options.model_options as AnthropicClaudeOptions | undefined;
         if (model_options?._option_id !== undefined && model_options?._option_id !== 'anthropic-claude') {
             this.logger.debug({ options: options.model_options }, 'Unexpected option id');

--- a/drivers/src/azure/azure_foundry.test.ts
+++ b/drivers/src/azure/azure_foundry.test.ts
@@ -183,7 +183,8 @@ describe('AzureFoundryDriver protocol composition', () => {
             expect.objectContaining({
                 model: 'gpt-deployment',
                 stream: false,
-                reasoning: { effort: 'high' },
+                reasoning: { effort: 'high', summary: 'auto' },
+                include: ['reasoning.encrypted_content'],
                 temperature: undefined,
                 top_p: undefined,
                 tools: [expect.objectContaining({ type: 'function', name: 'lookup' })],
@@ -242,7 +243,7 @@ describe('AzureFoundryDriver protocol composition', () => {
                 ]),
             }),
         );
-        expect(completion.result).toEqual([{ type: 'text', value: 'Answer' }]);
+        expect(completion.result).toEqual([{ type: 'text', value: '<think>hidden</think>Answer' }]);
     });
 
     it('preserves Azure HTTP status and retryability in LlumiverseError', async () => {

--- a/drivers/src/bedrock-mantle/index.test.ts
+++ b/drivers/src/bedrock-mantle/index.test.ts
@@ -23,12 +23,6 @@ type ResponsesCreate = (
 ) => Promise<OpenAI.Responses.Response>;
 type ModelsListResult = Pick<Awaited<ReturnType<OpenAI['models']['list']>>, 'data'>;
 type ModelsList = (...args: Parameters<OpenAI['models']['list']>) => Promise<ModelsListResult>;
-type ClaudeStreamResult = Pick<ReturnType<Anthropic['messages']['stream']>, 'finalMessage'>;
-type ClaudeStream = (
-    params: Parameters<Anthropic['messages']['stream']>[0],
-    options?: Parameters<Anthropic['messages']['stream']>[1],
-) => ClaudeStreamResult;
-
 function isRecord(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
@@ -405,8 +399,8 @@ describe('BedrockMantleDriver protocol execution', () => {
                 service_tier: null,
             },
         } satisfies Anthropic.Message;
-        const finalMessage = vi.fn<ClaudeStreamResult['finalMessage']>(async () => message);
-        const stream = vi.fn<ClaudeStream>(() => ({ finalMessage }));
+        const finalMessage = vi.fn(async () => message);
+        const stream = vi.fn(() => ({ finalMessage }));
         const messagesClient = { messages: { stream } };
         Reflect.set(driver, 'anthropicService', messagesClient);
         const prompt = await driver.createPrompt(promptSegments, { model: 'anthropic.claude-haiku-4-5' });

--- a/drivers/src/bedrock-mantle/index.test.ts
+++ b/drivers/src/bedrock-mantle/index.test.ts
@@ -466,7 +466,8 @@ describe('Bedrock Mantle Responses options', () => {
             expect.objectContaining({
                 model: 'openai.gpt-5.5',
                 max_output_tokens: 100,
-                reasoning: { effort: 'low' },
+                reasoning: { effort: 'low', summary: 'auto' },
+                include: ['reasoning.encrypted_content'],
                 text: expect.objectContaining({
                     verbosity: 'low',
                     format: expect.objectContaining({ type: 'json_schema', name: 'format_output' }),
@@ -495,7 +496,8 @@ describe('Bedrock Mantle Responses options', () => {
         expect(create).toHaveBeenCalledWith(
             expect.objectContaining({
                 model: 'xai.grok-4.3',
-                reasoning: { effort: 'none' },
+                reasoning: { effort: 'none', summary: 'auto' },
+                include: ['reasoning.encrypted_content'],
                 temperature: 0.4,
                 top_p: 0.9,
             }),

--- a/drivers/src/bedrock-mantle/index.ts
+++ b/drivers/src/bedrock-mantle/index.ts
@@ -4,7 +4,7 @@ import type { AwsCredentialIdentity, Provider } from '@aws-sdk/types';
 import {
     type AIModel,
     type Completion,
-    type CompletionChunkObject,
+    type DriverCompletionStream,
     type DriverOptions,
     type EmbeddingsOptions,
     type EmbeddingsResult,
@@ -27,7 +27,6 @@ import {
     buildOpenAIChatCompletionsStreamingConversation,
     type OpenAIChatCompletionsPrompt,
     OpenAISDKChatCompletionsProtocol,
-    stripOpenAIChatCompletionsThinkBlocksFromCompletion,
 } from '../openai/openai_chat_completions.js';
 import { formatOpenAIDebugPrompt } from '../openai/openai_format.js';
 import {
@@ -203,7 +202,7 @@ export class BedrockMantleDriver extends AbstractDriver<BedrockMantleDriverOptio
     requestTextCompletionStream(
         prompt: BedrockMantlePrompt,
         options: ExecutionOptions,
-    ): Promise<AsyncIterable<CompletionChunkObject>> {
+    ): Promise<DriverCompletionStream> {
         switch (getBedrockMantleProtocol(options.model)) {
             case 'responses':
                 return this.responsesDelegate.requestTextCompletionStream(requireResponsesPrompt(prompt), options);
@@ -246,14 +245,6 @@ export class BedrockMantleDriver extends AbstractDriver<BedrockMantleDriverOptio
             default:
                 return undefined;
         }
-    }
-
-    validateResult(result: Completion, options: ExecutionOptions): void {
-        const processedResult =
-            getBedrockMantleProtocol(options.model) === 'chat_completions'
-                ? stripOpenAIChatCompletionsThinkBlocksFromCompletion(result)
-                : result;
-        super.validateResult(processedResult, options);
     }
 
     formatLlumiverseError(error: unknown, context: LlumiverseErrorContext): LlumiverseError {

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -1054,6 +1054,8 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
                 switch (r.type) {
                     case 'text':
                         return r.value;
+                    case 'thoughts':
+                        return '';
                     case 'json':
                         return typeof r.value === 'string' ? r.value : JSON.stringify(r.value);
                     case 'image':

--- a/drivers/src/mistral/index.test.ts
+++ b/drivers/src/mistral/index.test.ts
@@ -4,6 +4,152 @@ import { describe, expect, it, vi } from 'vitest';
 import { MistralAIDriver } from './index.js';
 
 describe('MistralAIDriver official SDK transport', () => {
+    it('preserves signed thinking for replay after JSON roundtrip while projecting thoughts by default', async () => {
+        const driver = new MistralAIDriver({ apiKey: 'test-key' });
+        const response = {
+            id: 'mistral-signed',
+            object: 'chat.completion',
+            created: 1,
+            model: 'magistral',
+            choices: [
+                {
+                    index: 0,
+                    finishReason: 'stop',
+                    message: {
+                        role: 'assistant' as const,
+                        content: [
+                            {
+                                type: 'thinking' as const,
+                                thinking: [{ type: 'text' as const, text: 'native plan' }],
+                                signature: 'signed-thinking',
+                                closed: true,
+                            },
+                            { type: 'text' as const, text: 'answer' },
+                        ],
+                    },
+                },
+            ],
+            usage: { promptTokens: 2, completionTokens: 3, totalTokens: 5 },
+        };
+        const complete = vi.fn(async (_request: unknown) => response);
+        Object.defineProperty(driver.client.chat, 'complete', { value: complete });
+
+        const first = await driver.requestTextCompletion(
+            { messages: [{ role: 'user', content: 'question' }] },
+            { model: 'magistral', stripTextMaxTokens: 1, stripImagesAfterTurns: 0 },
+        );
+        expect(first.result).toEqual([
+            { type: 'thoughts', value: 'native plan' },
+            { type: 'text', value: 'answer' },
+        ]);
+
+        const persisted = JSON.parse(JSON.stringify(first.conversation));
+        await driver.requestTextCompletion(
+            { messages: [{ role: 'user', content: 'continue' }] },
+            { model: 'magistral', conversation: persisted },
+        );
+        expect((complete.mock.calls[1][0] as { messages: unknown[] }).messages).toContainEqual(
+            response.choices[0].message,
+        );
+
+        const hidden = await driver.requestTextCompletion(
+            { messages: [{ role: 'user', content: 'hidden' }] },
+            {
+                model: 'magistral',
+                model_options: { _option_id: 'text-fallback', include_thoughts: false },
+            },
+        );
+        expect(hidden.result).toEqual([{ type: 'text', value: 'answer' }]);
+        expect(hidden.conversation).toMatchObject({
+            messages: expect.arrayContaining([response.choices[0].message]),
+        });
+    });
+
+    it('reconstructs fragmented signed thinking in the native streaming assistant message', async () => {
+        const driver = new MistralAIDriver({ apiKey: 'test-key' });
+        Object.defineProperty(driver.client.chat, 'stream', {
+            value: vi.fn(async () =>
+                (async function* () {
+                    yield {
+                        data: {
+                            id: 'chunk-1',
+                            model: 'magistral',
+                            choices: [
+                                {
+                                    index: 0,
+                                    delta: {
+                                        content: [
+                                            {
+                                                type: 'thinking',
+                                                thinking: [{ type: 'text', text: 'plan' }],
+                                            },
+                                        ],
+                                    },
+                                },
+                            ],
+                        },
+                    };
+                    yield {
+                        data: {
+                            id: 'chunk-2',
+                            model: 'magistral',
+                            choices: [
+                                {
+                                    index: 0,
+                                    finishReason: 'stop',
+                                    delta: {
+                                        content: [
+                                            {
+                                                type: 'thinking',
+                                                thinking: [{ type: 'text', text: ' more' }],
+                                                signature: 'stream-signature',
+                                                closed: true,
+                                            },
+                                            { type: 'text', text: 'answer' },
+                                        ],
+                                    },
+                                },
+                            ],
+                        },
+                    };
+                })(),
+            ),
+        });
+
+        const stream = await driver.requestTextCompletionStream(
+            { messages: [{ role: 'user', content: 'question' }] },
+            { model: 'magistral' },
+        );
+        const results = [];
+        for await (const chunk of stream) results.push(...chunk.result);
+        const conversation = await stream.finalizeConversation?.({ result: results });
+
+        expect(results).toEqual([
+            { type: 'thoughts', value: 'plan' },
+            { type: 'thoughts', value: ' more' },
+            { type: 'text', value: 'answer' },
+        ]);
+        expect(conversation).toMatchObject({
+            messages: expect.arrayContaining([
+                expect.objectContaining({
+                    role: 'assistant',
+                    content: [
+                        {
+                            type: 'thinking',
+                            thinking: [
+                                { type: 'text', text: 'plan' },
+                                { type: 'text', text: ' more' },
+                            ],
+                            signature: 'stream-signature',
+                            closed: true,
+                        },
+                        { type: 'text', text: 'answer' },
+                    ],
+                }),
+            ]),
+        });
+    });
+
     it('maps canonical Chat requests and preserves typed content, tools, usage, and the native response', async () => {
         const driver = new MistralAIDriver({ apiKey: 'test-key', endpoint_url: 'https://mistral.example.test' });
         const response = {

--- a/drivers/src/mistral/index.test.ts
+++ b/drivers/src/mistral/index.test.ts
@@ -215,6 +215,27 @@ describe('MistralAIDriver official SDK transport', () => {
         expect(completion.original_response).toBe(response);
     });
 
+    it('preserves the driver-level token default when using the native Mistral protocol', async () => {
+        const driver = new MistralAIDriver({
+            apiKey: 'test-key',
+            defaultMaxTokens: 2048,
+        });
+        const complete = vi.fn(async () => ({
+            choices: [{ index: 0, finishReason: 'stop', message: { role: 'assistant', content: 'done' } }],
+            usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+        }));
+        Object.defineProperty(driver.client.chat, 'complete', { value: complete });
+
+        await driver.requestTextCompletion(
+            { messages: [{ role: 'user', content: 'Hello' }] },
+            { model: 'caller-model' },
+        );
+
+        expect(complete).toHaveBeenCalledWith(
+            expect.objectContaining({ model: 'caller-model', maxTokens: 2048, stream: false }),
+        );
+    });
+
     it('uses the SDK for models, validation, embeddings, endpoint override, and fetch wiring', async () => {
         const driver = new MistralAIDriver({ apiKey: 'test-key', endpoint_url: 'https://mistral.example.test' });
         const list = vi.fn(async () => ({

--- a/drivers/src/mistral/index.test.ts
+++ b/drivers/src/mistral/index.test.ts
@@ -122,7 +122,7 @@ describe('MistralAIDriver official SDK transport', () => {
         );
         const results = [];
         for await (const chunk of stream) results.push(...chunk.result);
-        const conversation = await stream.finalizeConversation?.({ result: results });
+        const conversation = await stream.finalizeConversation?.();
 
         expect(results).toEqual([
             { type: 'thoughts', value: 'plan' },

--- a/drivers/src/mistral/index.ts
+++ b/drivers/src/mistral/index.ts
@@ -331,7 +331,7 @@ function prepareMistralConversation(
     if (conversation && typeof conversation === 'object' && 'messages' in conversation) {
         const stored = conversation as { messages?: unknown[]; _is_openai_chat_completions?: boolean };
         if (Array.isArray(stored.messages)) {
-            // TODO: Remove after the persisted-conversation migration reports zero
+            // TODO: Remove after 2026-08-14 once migration telemetry reports zero
             // `_is_openai_chat_completions` Mistral records for one full release cycle.
             existing = stored._is_openai_chat_completions
                 ? (stored.messages as OpenAIChatCompletionsPrompt['messages']).map(legacyOpenAIMessageToMistral)
@@ -481,27 +481,33 @@ function finalizeMistralConversation(
     options: ExecutionOptions,
 ): MistralPrompt {
     let completed = incrementConversationTurn({ messages: [...conversation.messages, message] }) as MistralPrompt;
-    const hasSignedThinking = completed.messages.some(
-        (storedMessage) =>
-            Array.isArray(storedMessage.content) &&
-            storedMessage.content.some((part) => part.type === 'thinking' && !!part.signature),
-    );
-    if (hasSignedThinking) {
-        // Mistral does not document a safe way to rewrite history covered by a
-        // signed thinking chunk. Retain the complete chain conservatively.
-        return completed;
-    }
     const currentTurn = getConversationMeta(completed).turnNumber;
+    const preserveSubtree = (value: unknown): boolean => {
+        if (!value || typeof value !== 'object') return false;
+        const content = (value as { content?: unknown }).content;
+        return (
+            Array.isArray(content) &&
+            content.some(
+                (part) =>
+                    !!part &&
+                    typeof part === 'object' &&
+                    (part as { type?: unknown }).type === 'thinking' &&
+                    !!(part as { signature?: unknown }).signature,
+            )
+        );
+    };
     const stripOptions = {
         keepForTurns: options.stripImagesAfterTurns ?? Infinity,
         currentTurn,
         textMaxTokens: options.stripTextMaxTokens,
+        preserveSubtree,
     };
     completed = stripBase64ImagesFromConversation(completed, stripOptions) as MistralPrompt;
     completed = truncateLargeTextInConversation(completed, stripOptions) as MistralPrompt;
     completed = stripHeartbeatsFromConversation(completed, {
         keepForTurns: options.stripHeartbeatsAfterTurns ?? 1,
         currentTurn,
+        preserveSubtree,
     }) as MistralPrompt;
     return completed;
 }

--- a/drivers/src/mistral/index.ts
+++ b/drivers/src/mistral/index.ts
@@ -1,12 +1,30 @@
 import {
     type AIModel,
+    type Completion,
+    type CompletionResult,
+    type DriverCompletionStream,
     type EmbeddingResultItem,
     type EmbeddingsOptions,
     type EmbeddingsResult,
+    type ExecutionOptions,
+    type ExecutionTokenUsage,
+    getConversationMeta,
+    incrementConversationTurn,
+    type JSONObject,
     LlumiverseError,
     MISTRAL_DEFAULT_EMBEDDING_MODEL,
     normalizeEmbeddingsOptions,
+    type PromptOptions,
+    PromptRole,
+    type PromptSegment,
     Providers,
+    readStreamAsBase64,
+    stripBase64ImagesFromConversation,
+    stripHeartbeatsFromConversation,
+    type TextFallbackOptions,
+    type ToolDefinition,
+    type ToolUse,
+    truncateLargeTextInConversation,
 } from '@llumiverse/core';
 import { HTTPClient, Mistral } from '@mistralai/mistralai';
 import type {
@@ -14,8 +32,8 @@ import type {
     ChatCompletionRequestMessage,
     ChatCompletionRequestTool,
     ChatCompletionResponse,
-    CompletionChunk,
     ContentChunk,
+    ToolCall,
 } from '@mistralai/mistralai/models/components';
 import {
     HTTPClientError,
@@ -23,16 +41,11 @@ import {
     MistralError,
     RequestAbortedError,
 } from '@mistralai/mistralai/models/errors';
-import {
-    OpenAIChatCompletionsDriverBase,
-    type OpenAIChatCompletionsDriverOptions,
-    type OpenAIChatCompletionsPayload,
-    type OpenAIChatCompletionsResponse,
-    type OpenAIChatCompletionsStreamResponse,
-    openAIChatCompletionsStreamToSSE,
-    preserveOpenAIChatCompletionsOriginalResponse,
+import type {
+    OpenAIChatCompletionsDriverOptions,
+    OpenAIChatCompletionsPrompt,
 } from '../openai/openai_chat_completions.js';
-import type { CompatibleAPIError } from '../openai/openai_compatible.js';
+import { type CompatibleAPIError, OpenAICompatibleDriverBase } from '../openai/openai_compatible.js';
 
 const ENDPOINT = 'https://api.mistral.ai';
 
@@ -41,7 +54,11 @@ export interface MistralAIDriverOptions extends OpenAIChatCompletionsDriverOptio
     endpoint_url?: string;
 }
 
-export class MistralAIDriver extends OpenAIChatCompletionsDriverBase<MistralAIDriverOptions> {
+export interface MistralPrompt {
+    messages: ChatCompletionRequestMessage[];
+}
+
+export class MistralAIDriver extends OpenAICompatibleDriverBase<MistralAIDriverOptions, MistralPrompt> {
     static readonly PROVIDER = Providers.mistralai;
     readonly provider = Providers.mistralai;
     readonly apiKey: string;
@@ -59,15 +76,87 @@ export class MistralAIDriver extends OpenAIChatCompletionsDriverBase<MistralAIDr
         });
     }
 
-    async _postChatCompletion(payload: OpenAIChatCompletionsPayload): Promise<OpenAIChatCompletionsResponse> {
-        const request = toMistralRequest(payload, false);
-        const response = await this.client.chat.complete(request);
-        return preserveOpenAIChatCompletionsOriginalResponse(normalizeMistralResponse(response), response);
+    protected async formatPrompt(segments: PromptSegment[], options: PromptOptions): Promise<MistralPrompt> {
+        return { messages: await formatMistralMessages(segments, options) };
     }
 
-    async _postChatCompletionStream(payload: OpenAIChatCompletionsPayload): Promise<ReadableStream> {
-        const stream = await this.client.chat.stream(toMistralRequest(payload, true));
-        return openAIChatCompletionsStreamToSSE(normalizeMistralStream(stream));
+    async requestTextCompletion(
+        prompt: MistralPrompt | OpenAIChatCompletionsPrompt,
+        options: ExecutionOptions,
+    ): Promise<Completion> {
+        const conversation = prepareMistralConversation(options.conversation, prompt);
+        const response = await this.client.chat.complete(buildMistralRequest(conversation, options, false));
+        const choice = response.choices[0];
+        const message = choice?.message;
+        if (!message) throw new Error('Mistral response is not valid: no assistant message');
+
+        const includeThoughts =
+            (options.model_options as TextFallbackOptions & { include_thoughts?: boolean })?.include_thoughts !== false;
+        const result = projectMistralContent(message.content, includeThoughts);
+        const tool_use = collectMistralTools(message.toolCalls);
+        const completed = finalizeMistralConversation(conversation, { ...message, role: 'assistant' }, options);
+
+        return {
+            result,
+            tool_use,
+            token_usage: mapMistralUsage(response),
+            finish_reason: tool_use?.length ? 'tool_use' : (choice.finishReason ?? undefined),
+            original_response: options.include_original_response ? response : undefined,
+            conversation: completed,
+        };
+    }
+
+    async requestTextCompletionStream(
+        prompt: MistralPrompt | OpenAIChatCompletionsPrompt,
+        options: ExecutionOptions,
+    ): Promise<DriverCompletionStream> {
+        const conversation = prepareMistralConversation(options.conversation, prompt);
+        const response = await this.client.chat.stream(buildMistralRequest(conversation, options, true));
+        const includeThoughts =
+            (options.model_options as TextFallbackOptions & { include_thoughts?: boolean })?.include_thoughts !== false;
+        const nativeContent: ContentChunk[] = [];
+        const nativeToolCalls = new Map<number, ToolCall>();
+
+        const stream: DriverCompletionStream = {
+            async *[Symbol.asyncIterator]() {
+                for await (const event of response) {
+                    const chunk = event.data;
+                    const choice = chunk.choices[0];
+                    const delta = choice?.delta;
+                    if (!delta) continue;
+
+                    const content = normalizeMistralDeltaContent(delta.content);
+                    appendMistralContent(nativeContent, content);
+                    const tool_use = appendMistralToolDeltas(nativeToolCalls, delta.toolCalls);
+                    const projected = projectMistralContent(content, includeThoughts);
+                    yield {
+                        result: projected,
+                        tool_use,
+                        finish_reason: tool_use?.length ? 'tool_use' : (choice.finishReason ?? undefined),
+                        token_usage: chunk.usage
+                            ? {
+                                  prompt: chunk.usage.promptTokens ?? 0,
+                                  result: chunk.usage.completionTokens ?? 0,
+                                  total: chunk.usage.totalTokens ?? 0,
+                              }
+                            : undefined,
+                    };
+                }
+            },
+            finalizeConversation: () =>
+                finalizeMistralConversation(
+                    conversation,
+                    {
+                        role: 'assistant',
+                        content: nativeContent,
+                        toolCalls: [...nativeToolCalls.entries()]
+                            .sort(([left], [right]) => left - right)
+                            .map(([, toolCall]) => toolCall),
+                    },
+                    options,
+                ),
+        };
+        return stream;
     }
 
     async listModels(): Promise<AIModel[]> {
@@ -150,23 +239,9 @@ export class MistralAIDriver extends OpenAIChatCompletionsDriverBase<MistralAIDr
     }
 }
 
-function toMistralRequest(payload: OpenAIChatCompletionsPayload, stream: boolean): ChatCompletionRequest {
-    return {
-        model: payload.model,
-        messages: payload.messages.map(toMistralMessage),
-        maxTokens: payload.max_tokens ?? undefined,
-        temperature: payload.temperature ?? undefined,
-        topP: payload.top_p ?? undefined,
-        presencePenalty: payload.presence_penalty ?? undefined,
-        frequencyPenalty: payload.frequency_penalty ?? undefined,
-        stop: payload.stop ?? undefined,
-        n: payload.n ?? undefined,
-        tools: payload.tools?.flatMap(toMistralTool),
-        stream,
-    } satisfies ChatCompletionRequest;
-}
-
-function toMistralMessage(message: OpenAIChatCompletionsPayload['messages'][number]): ChatCompletionRequestMessage {
+function legacyOpenAIMessageToMistral(
+    message: OpenAIChatCompletionsPrompt['messages'][number],
+): ChatCompletionRequestMessage {
     const textContent = typeof message.content === 'string' || message.content === null ? message.content : undefined;
     const contentParts = Array.isArray(message.content)
         ? message.content.map(
@@ -204,126 +279,229 @@ function toMistralMessage(message: OpenAIChatCompletionsPayload['messages'][numb
     }
 }
 
-function toMistralTool(tool: NonNullable<OpenAIChatCompletionsPayload['tools']>[number]): ChatCompletionRequestTool[] {
-    if (tool.type !== 'function') {
-        return [];
+async function formatMistralMessages(
+    segments: PromptSegment[],
+    options: PromptOptions,
+): Promise<ChatCompletionRequestMessage[]> {
+    const messages: ChatCompletionRequestMessage[] = [];
+    const system = segments
+        .filter((segment) => segment.role === PromptRole.system && segment.content)
+        .map((segment) => segment.content)
+        .join('\n');
+    if (system) messages.push({ role: 'system', content: system });
+    if (options.result_schema) {
+        messages.push({
+            role: 'system',
+            content: `Only answer with JSON matching this schema: ${JSON.stringify(options.result_schema)}`,
+        });
     }
-    return [
-        {
-            type: 'function',
-            function: {
-                name: tool.function.name,
-                description: tool.function.description,
-                parameters: tool.function.parameters ?? {},
-            },
-        },
-    ];
-}
 
-function normalizeMistralContent(content: string | ContentChunk[] | null | undefined): {
-    content: string | null;
-    reasoning?: string;
-} {
-    if (typeof content === 'string' || content == null) {
-        return { content: content ?? null };
-    }
-    const text: string[] = [];
-    const reasoning: string[] = [];
-    for (const part of content) {
-        if (part.type === 'text') {
-            text.push(part.text);
-        } else if (part.type === 'thinking' && 'thinking' in part && Array.isArray(part.thinking)) {
-            reasoning.push(
-                ...part.thinking.flatMap((entry) =>
-                    typeof entry === 'object' && entry && 'text' in entry && typeof entry.text === 'string'
-                        ? [entry.text]
-                        : [],
-                ),
-            );
+    for (const segment of segments) {
+        if (segment.role === PromptRole.system) continue;
+        const parts: ContentChunk[] = [];
+        if (segment.content) parts.push({ type: 'text', text: segment.content });
+        for (const file of segment.files ?? []) {
+            if (file.mime_type?.startsWith('image/')) {
+                parts.push({
+                    type: 'image_url',
+                    imageUrl: `data:${file.mime_type};base64,${await readStreamAsBase64(await file.getStream())}`,
+                });
+            } else if (file.mime_type?.startsWith('text/')) {
+                const chunks: Buffer[] = [];
+                for await (const chunk of await file.getStream()) chunks.push(Buffer.from(chunk));
+                parts.push({ type: 'text', text: Buffer.concat(chunks).toString('utf8') });
+            }
+        }
+        const content = parts.length === 1 && parts[0]?.type === 'text' ? parts[0].text : parts;
+        if (segment.role === PromptRole.tool) {
+            if (!segment.tool_use_id) throw new Error('Mistral tool response requires tool_use_id');
+            messages.push({ role: 'tool', toolCallId: segment.tool_use_id, content });
+        } else {
+            messages.push({ role: segment.role === PromptRole.assistant ? 'assistant' : 'user', content });
         }
     }
-    // TODO: Proper multi-turn thinking support must preserve SDK-native thinking chunks and their signatures.
-    // The shared Chat Completions stream currently reconstructs conversations from normalized text and tool calls,
-    // so Mistral reasoning is exposed as text here but signed thinking state is intentionally not replayed.
-    return { content: text.join(''), reasoning: reasoning.length ? reasoning.join('') : undefined };
+    return messages;
 }
 
-function normalizeMistralResponse(response: ChatCompletionResponse): OpenAIChatCompletionsResponse {
+function prepareMistralConversation(
+    conversation: unknown,
+    prompt: MistralPrompt | OpenAIChatCompletionsPrompt,
+): MistralPrompt {
+    let existing: ChatCompletionRequestMessage[] = [];
+    if (conversation && typeof conversation === 'object' && 'messages' in conversation) {
+        const stored = conversation as { messages?: unknown[]; _is_openai_chat_completions?: boolean };
+        if (Array.isArray(stored.messages)) {
+            // TODO: Remove after the persisted-conversation migration reports zero
+            // `_is_openai_chat_completions` Mistral records for one full release cycle.
+            existing = stored._is_openai_chat_completions
+                ? (stored.messages as OpenAIChatCompletionsPrompt['messages']).map(legacyOpenAIMessageToMistral)
+                : (stored.messages as ChatCompletionRequestMessage[]);
+        }
+    }
+    const isLegacy = (prompt as OpenAIChatCompletionsPrompt)._is_openai_chat_completions === true;
+    const promptMessages = isLegacy
+        ? (prompt as OpenAIChatCompletionsPrompt).messages.map(legacyOpenAIMessageToMistral)
+        : (prompt as MistralPrompt).messages;
+    return { messages: [...existing, ...promptMessages] };
+}
+
+function buildMistralRequest(
+    conversation: MistralPrompt,
+    options: ExecutionOptions,
+    stream: boolean,
+): ChatCompletionRequest {
+    const modelOptions = options.model_options as TextFallbackOptions;
     return {
-        id: response.id,
-        object: 'chat.completion',
-        created: response.created,
-        model: response.model,
-        choices: response.choices.map((choice) => {
-            const normalizedContent = normalizeMistralContent(choice.message?.content);
-            return {
-                index: choice.index,
-                finish_reason: choice.finishReason,
-                message: {
-                    role: choice.message?.role,
-                    ...normalizedContent,
-                    tool_calls: choice.message?.toolCalls?.map((toolCall) => ({
-                        id: toolCall.id ?? '',
-                        type: 'function',
-                        function: {
-                            name: toolCall.function.name,
-                            arguments:
-                                typeof toolCall.function.arguments === 'string'
-                                    ? toolCall.function.arguments
-                                    : JSON.stringify(toolCall.function.arguments),
-                        },
-                    })),
-                },
-            };
-        }),
-        usage: {
-            prompt_tokens: response.usage.promptTokens ?? 0,
-            completion_tokens: response.usage.completionTokens ?? 0,
-            total_tokens: response.usage.totalTokens ?? 0,
+        model: options.model,
+        messages: conversation.messages,
+        maxTokens: modelOptions?.max_tokens,
+        temperature: modelOptions?.temperature,
+        topP: modelOptions?.top_p,
+        presencePenalty: modelOptions?.presence_penalty,
+        frequencyPenalty: modelOptions?.frequency_penalty,
+        stop: modelOptions?.stop_sequence,
+        n: 1,
+        tools: options.tools?.map(toMistralTool),
+        stream,
+    };
+}
+
+function toMistralTool(tool: ToolDefinition): ChatCompletionRequestTool {
+    return {
+        type: 'function',
+        function: {
+            name: tool.name,
+            description: tool.description,
+            parameters: (tool.input_schema as JSONObject | undefined) ?? {},
         },
     };
 }
 
-async function* normalizeMistralStream(
-    stream: AsyncIterable<{ data: CompletionChunk }>,
-): AsyncIterable<OpenAIChatCompletionsStreamResponse> {
-    for await (const event of stream) {
-        const chunk = event.data;
-        yield {
-            id: chunk.id,
-            object: 'chat.completion.chunk',
-            created: chunk.created ?? 0,
-            model: chunk.model,
-            choices: chunk.choices.map((choice) => {
-                const normalizedContent = normalizeMistralContent(choice.delta.content);
-                return {
-                    index: choice.index,
-                    finish_reason: choice.finishReason,
-                    delta: {
-                        role: choice.delta.role ?? undefined,
-                        ...normalizedContent,
-                        tool_calls: choice.delta.toolCalls?.map((toolCall) => ({
-                            index: toolCall.index,
-                            id: toolCall.id,
-                            type: 'function',
-                            function: {
-                                name: toolCall.function.name,
-                                arguments:
-                                    typeof toolCall.function.arguments === 'string'
-                                        ? toolCall.function.arguments
-                                        : JSON.stringify(toolCall.function.arguments),
-                            },
-                        })),
-                    },
-                };
-            }),
-            usage: chunk.usage
-                ? {
-                      prompt_tokens: chunk.usage.promptTokens ?? 0,
-                      completion_tokens: chunk.usage.completionTokens ?? 0,
-                      total_tokens: chunk.usage.totalTokens ?? 0,
-                  }
-                : undefined,
-        };
+function projectMistralContent(
+    content: string | ContentChunk[] | null | undefined,
+    includeThoughts: boolean,
+): CompletionResult[] {
+    if (typeof content === 'string') return content ? [{ type: 'text', value: content }] : [];
+    const result: CompletionResult[] = [];
+    for (const part of content ?? []) {
+        if (part.type === 'text' && part.text) {
+            result.push({ type: 'text', value: part.text });
+        } else if (part.type === 'thinking' && includeThoughts) {
+            for (const thought of part.thinking) {
+                if (thought.type === 'text' && thought.text) result.push({ type: 'thoughts', value: thought.text });
+            }
+        }
     }
+    return result;
+}
+
+function normalizeMistralDeltaContent(content: string | ContentChunk[] | null | undefined): ContentChunk[] {
+    if (typeof content === 'string') return content ? [{ type: 'text', text: content }] : [];
+    return content ?? [];
+}
+
+function appendMistralContent(target: ContentChunk[], incoming: ContentChunk[]): void {
+    for (const part of incoming) {
+        const previous = target[target.length - 1];
+        if (part.type === 'text' && previous?.type === 'text') {
+            previous.text += part.text;
+        } else if (part.type === 'thinking' && previous?.type === 'thinking' && !previous.closed) {
+            previous.thinking.push(...structuredClone(part.thinking));
+            if (part.signature !== undefined) previous.signature = part.signature;
+            if (part.closed !== undefined) previous.closed = part.closed;
+        } else {
+            target.push(structuredClone(part));
+        }
+    }
+}
+
+function appendMistralToolDeltas(
+    target: Map<number, ToolCall>,
+    deltas: ToolCall[] | null | undefined,
+): ToolUse<unknown>[] | undefined {
+    if (!deltas?.length) return undefined;
+    return deltas.map((delta, offset) => {
+        const index = delta.index ?? offset;
+        const current = target.get(index) ?? {
+            id: '',
+            index,
+            type: 'function' as const,
+            function: { name: '', arguments: '' },
+        };
+        if (delta.id) current.id = delta.id;
+        if (delta.function.name) current.function.name += delta.function.name;
+        const args = delta.function.arguments;
+        if (typeof args === 'string') {
+            current.function.arguments = `${current.function.arguments ?? ''}${args}`;
+        } else if (args) {
+            current.function.arguments = args;
+        }
+        target.set(index, current);
+        return {
+            id: `tool_${index}`,
+            tool_name: delta.function.name ?? '',
+            tool_input: typeof args === 'string' ? args : ((args as JSONObject | undefined) ?? {}),
+            ...(delta.id && { _actual_id: delta.id }),
+        };
+    });
+}
+
+function collectMistralTools(toolCalls: ToolCall[] | null | undefined): ToolUse[] | undefined {
+    const tools = toolCalls?.map((toolCall) => ({
+        id: toolCall.id ?? '',
+        tool_name: toolCall.function.name,
+        tool_input:
+            typeof toolCall.function.arguments === 'string'
+                ? safeJsonParse(toolCall.function.arguments)
+                : (toolCall.function.arguments as JSONObject),
+    }));
+    return tools?.length ? tools : undefined;
+}
+
+function safeJsonParse(value: string): JSONObject {
+    try {
+        const parsed = JSON.parse(value) as unknown;
+        return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? (parsed as JSONObject) : {};
+    } catch {
+        return {};
+    }
+}
+
+function mapMistralUsage(response: ChatCompletionResponse): ExecutionTokenUsage {
+    return {
+        prompt: response.usage.promptTokens ?? 0,
+        result: response.usage.completionTokens ?? 0,
+        total: response.usage.totalTokens ?? 0,
+    };
+}
+
+function finalizeMistralConversation(
+    conversation: MistralPrompt,
+    message: ChatCompletionRequestMessage,
+    options: ExecutionOptions,
+): MistralPrompt {
+    let completed = incrementConversationTurn({ messages: [...conversation.messages, message] }) as MistralPrompt;
+    const hasSignedThinking = completed.messages.some(
+        (storedMessage) =>
+            Array.isArray(storedMessage.content) &&
+            storedMessage.content.some((part) => part.type === 'thinking' && !!part.signature),
+    );
+    if (hasSignedThinking) {
+        // Mistral does not document a safe way to rewrite history covered by a
+        // signed thinking chunk. Retain the complete chain conservatively.
+        return completed;
+    }
+    const currentTurn = getConversationMeta(completed).turnNumber;
+    const stripOptions = {
+        keepForTurns: options.stripImagesAfterTurns ?? Infinity,
+        currentTurn,
+        textMaxTokens: options.stripTextMaxTokens,
+    };
+    completed = stripBase64ImagesFromConversation(completed, stripOptions) as MistralPrompt;
+    completed = truncateLargeTextInConversation(completed, stripOptions) as MistralPrompt;
+    completed = stripHeartbeatsFromConversation(completed, {
+        keepForTurns: options.stripHeartbeatsAfterTurns ?? 1,
+        currentTurn,
+    }) as MistralPrompt;
+    return completed;
 }

--- a/drivers/src/mistral/index.ts
+++ b/drivers/src/mistral/index.ts
@@ -85,7 +85,9 @@ export class MistralAIDriver extends OpenAICompatibleDriverBase<MistralAIDriverO
         options: ExecutionOptions,
     ): Promise<Completion> {
         const conversation = prepareMistralConversation(options.conversation, prompt);
-        const response = await this.client.chat.complete(buildMistralRequest(conversation, options, false));
+        const response = await this.client.chat.complete(
+            buildMistralRequest(conversation, options, false, this.options.defaultMaxTokens),
+        );
         const choice = response.choices[0];
         const message = choice?.message;
         if (!message) throw new Error('Mistral response is not valid: no assistant message');
@@ -111,7 +113,9 @@ export class MistralAIDriver extends OpenAICompatibleDriverBase<MistralAIDriverO
         options: ExecutionOptions,
     ): Promise<DriverCompletionStream> {
         const conversation = prepareMistralConversation(options.conversation, prompt);
-        const response = await this.client.chat.stream(buildMistralRequest(conversation, options, true));
+        const response = await this.client.chat.stream(
+            buildMistralRequest(conversation, options, true, this.options.defaultMaxTokens),
+        );
         const includeThoughts =
             (options.model_options as TextFallbackOptions & { include_thoughts?: boolean })?.include_thoughts !== false;
         const nativeContent: ContentChunk[] = [];
@@ -349,12 +353,13 @@ function buildMistralRequest(
     conversation: MistralPrompt,
     options: ExecutionOptions,
     stream: boolean,
+    defaultMaxTokens?: number,
 ): ChatCompletionRequest {
     const modelOptions = options.model_options as TextFallbackOptions;
     return {
         model: options.model,
         messages: conversation.messages,
-        maxTokens: modelOptions?.max_tokens,
+        maxTokens: modelOptions?.max_tokens ?? defaultMaxTokens,
         temperature: modelOptions?.temperature,
         topP: modelOptions?.top_p,
         presencePenalty: modelOptions?.presence_penalty,

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -101,6 +101,25 @@ export function openAIReasoningEffort(model: string, effort: string | undefined)
         : undefined;
 }
 
+function openAIReasoning(
+    effort: string | undefined,
+    isReasoningModel: boolean,
+    preserveCurrentTurn: boolean,
+): OpenAI.Responses.ResponseCreateParams['reasoning'] {
+    if (!effort && !isReasoningModel) return undefined;
+    return {
+        effort,
+        summary: 'auto',
+        ...(preserveCurrentTurn && { context: 'current_turn' }),
+    } as OpenAI.Responses.ResponseCreateParams['reasoning'];
+}
+
+function supportsOpenAICurrentTurnReasoning(provider: Providers, model: string): boolean {
+    if (provider !== Providers.openai) return false;
+    const modelId = model.toLowerCase().split('/').pop() ?? '';
+    return /^gpt-5\.(?:4|5|6)(?:$|-)/.test(modelId);
+}
+
 function hasExplicitPromptCacheBreakpoint(item: ResponseInputItem): boolean {
     if (!('content' in item) || !Array.isArray(item.content)) {
         return false;
@@ -215,10 +234,12 @@ export class OpenAIResponsesProtocol {
         }
 
         const isReasoningModel = isOpenAIReasoningModel(options.model);
-        const effort = openAIReasoningEffort(options.model, model_options?.effort ?? model_options?.reasoning_effort);
-        // The SDK can lag newly documented effort values (for example `max`).
-        // Preserve caller input and let the provider validate model-specific support.
-        const reasoning = effort ? ({ effort } as unknown as OpenAIReasoning) : undefined;
+        const reasoning = openAIReasoning(
+            openAIReasoningEffort(options.model, model_options?.effort ?? model_options?.reasoning_effort),
+            isReasoningModel,
+            supportsOpenAICurrentTurnReasoning(driver.provider, options.model),
+        );
+        const includeThoughts = model_options?.include_thoughts ?? false;
 
         const promptCache = configureOpenAIPromptCaching(
             conversation,
@@ -232,6 +253,7 @@ export class OpenAIResponsesProtocol {
             prompt_cache_options: promptCache.options,
             input: promptCache.input,
             reasoning,
+            include: reasoning ? ['reasoning.encrypted_content'] : undefined,
             temperature: isReasoningModel ? undefined : model_options?.temperature,
             top_p: isReasoningModel ? undefined : model_options?.top_p,
             max_output_tokens: model_options?.max_tokens,
@@ -244,7 +266,9 @@ export class OpenAIResponsesProtocol {
             ),
         });
 
-        return mapResponseStream(stream);
+        return mapResponseStream(stream, includeThoughts, (response) =>
+            finalizeOpenAIResponsesConversation(conversation, response.output, options),
+        );
     }
 
     async requestTextCompletion(
@@ -292,8 +316,11 @@ export class OpenAIResponsesProtocol {
         }
 
         const isReasoningModel = isOpenAIReasoningModel(options.model);
-        const effort = openAIReasoningEffort(options.model, model_options?.effort ?? model_options?.reasoning_effort);
-        const reasoning = effort ? ({ effort } as unknown as OpenAIReasoning) : undefined;
+        const reasoning = openAIReasoning(
+            openAIReasoningEffort(options.model, model_options?.effort ?? model_options?.reasoning_effort),
+            isReasoningModel,
+            supportsOpenAICurrentTurnReasoning(driver.provider, options.model),
+        );
 
         const promptCache = configureOpenAIPromptCaching(
             conversation,
@@ -307,6 +334,7 @@ export class OpenAIResponsesProtocol {
             prompt_cache_options: promptCache.options,
             input: promptCache.input,
             reasoning,
+            include: reasoning ? ['reasoning.encrypted_content'] : undefined,
             temperature: isReasoningModel ? undefined : model_options?.temperature,
             top_p: isReasoningModel ? undefined : model_options?.top_p,
             max_output_tokens: model_options?.max_tokens, //TODO: use max_tokens for older models, currently relying on OpenAI to handle it

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -1148,21 +1148,24 @@ function finalizeOpenAIResponsesConversation(
 ): ResponseInputItem[] {
     let completed = updateConversation(conversation, output as ResponseInputItem[]);
     completed = incrementConversationTurn(completed) as ResponseInputItem[];
-    const completedItems = unwrapConversationArray<ResponseInputItem>(completed) ?? [];
-    if (completedItems.some((item) => (item as { encrypted_content?: string | null }).encrypted_content))
-        return completed;
-
     const currentTurn = getConversationMeta(completed).turnNumber;
+    const preserveSubtree = (value: unknown): boolean => {
+        if (!value || typeof value !== 'object') return false;
+        const encryptedContent = (value as { encrypted_content?: unknown }).encrypted_content;
+        return typeof encryptedContent === 'string' && encryptedContent.length > 0;
+    };
     const stripOptions = {
         keepForTurns: options.stripImagesAfterTurns ?? Infinity,
         currentTurn,
         textMaxTokens: options.stripTextMaxTokens,
+        preserveSubtree,
     };
     let processed = stripBase64ImagesFromConversation(completed, stripOptions);
     processed = truncateLargeTextInConversation(processed, stripOptions);
     processed = stripHeartbeatsFromConversation(processed, {
         keepForTurns: options.stripHeartbeatsAfterTurns ?? 1,
         currentTurn,
+        preserveSubtree,
     });
     return processed as ResponseInputItem[];
 }

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -4,6 +4,7 @@ import {
     type CompletionChunkObject,
     type CompletionResult,
     type DataSource,
+    type DriverCompletionStream,
     type DriverOptions,
     type EmbeddingResultItem,
     type EmbeddingsOptions,
@@ -24,7 +25,7 @@ import {
     type OpenAiGptImageOptions,
     type PromptOptions,
     type PromptSegment,
-    type Providers,
+    Providers,
     stripBase64ImagesFromConversation,
     stripHeartbeatsFromConversation,
     supportsToolUse,
@@ -47,12 +48,13 @@ import { formatOpenAISchema } from './schema.js';
 // Response API types
 type ResponseInputItem = OpenAI.Responses.ResponseInputItem;
 type EasyInputMessage = OpenAI.Responses.EasyInputMessage;
-type OpenAIReasoning = NonNullable<OpenAI.Responses.ResponseCreateParams['reasoning']>;
 type OpenAIRequestOptions = Partial<TextFallbackOptions> & {
     image_detail?: 'low' | 'high' | 'auto';
     effort?: string;
     reasoning_effort?: string;
     verbosity?: 'low' | 'medium' | 'high';
+    prompt_cache_key?: string;
+    prompt_cache_retention?: 'in_memory' | '24h';
 };
 type OpenAIErrorWithStatus = Error & { status?: unknown };
 type OpenAIUsageWithProviderDetails = OpenAI.Responses.ResponseUsage & {
@@ -192,7 +194,7 @@ export class OpenAIResponsesProtocol {
         driver: OpenAIResponsesDriverBase,
         prompt: ResponseInputItem[],
         options: ExecutionOptions,
-    ): Promise<AsyncIterable<CompletionChunkObject>> {
+    ): Promise<DriverCompletionStream> {
         if (
             options.model_options?._option_id !== undefined &&
             options.model_options?._option_id !== 'openai-text' &&
@@ -239,17 +241,20 @@ export class OpenAIResponsesProtocol {
             isReasoningModel,
             supportsOpenAICurrentTurnReasoning(driver.provider, options.model),
         );
-        const includeThoughts = model_options?.include_thoughts ?? false;
+        const includeThoughts = model_options?.include_thoughts !== false;
+        const promptCacheKey = model_options?.prompt_cache_key ?? options.prompt_cache_key;
+        const promptCacheRetention = model_options?.prompt_cache_retention;
 
         const promptCache = configureOpenAIPromptCaching(
             conversation,
             driver.getResponsesRequestModel(options.model),
-            options.prompt_cache_key,
+            promptCacheKey,
         );
         const stream = await driver.service.responses.create({
             stream: true,
             model: driver.getResponsesRequestModel(options.model),
-            prompt_cache_key: options.prompt_cache_key,
+            prompt_cache_key: promptCacheKey,
+            prompt_cache_retention: promptCacheRetention,
             prompt_cache_options: promptCache.options,
             input: promptCache.input,
             reasoning,
@@ -321,16 +326,19 @@ export class OpenAIResponsesProtocol {
             isReasoningModel,
             supportsOpenAICurrentTurnReasoning(driver.provider, options.model),
         );
+        const promptCacheKey = model_options?.prompt_cache_key ?? options.prompt_cache_key;
+        const promptCacheRetention = model_options?.prompt_cache_retention;
 
         const promptCache = configureOpenAIPromptCaching(
             conversation,
             driver.getResponsesRequestModel(options.model),
-            options.prompt_cache_key,
+            promptCacheKey,
         );
         const res = await driver.service.responses.create({
             stream: false,
             model: driver.getResponsesRequestModel(options.model),
-            prompt_cache_key: options.prompt_cache_key,
+            prompt_cache_key: promptCacheKey,
+            prompt_cache_retention: promptCacheRetention,
             prompt_cache_options: promptCache.options,
             input: promptCache.input,
             reasoning,
@@ -352,30 +360,9 @@ export class OpenAIResponsesProtocol {
             completion.original_response = res;
         }
 
-        conversation = updateConversation(conversation, createAssistantMessageFromCompletion(completion));
-
-        // Increment turn counter for deferred stripping
-        conversation = incrementConversationTurn(conversation) as ResponseInputItem[];
-
-        // Strip large base64 image data based on options.stripImagesAfterTurns
-        const currentTurn = getConversationMeta(conversation).turnNumber;
-        const stripOptions = {
-            keepForTurns: options.stripImagesAfterTurns ?? Infinity,
-            currentTurn,
-            textMaxTokens: options.stripTextMaxTokens,
-        };
-        let processedConversation = stripBase64ImagesFromConversation(conversation, stripOptions);
-
-        // Truncate large text content if configured
-        processedConversation = truncateLargeTextInConversation(processedConversation, stripOptions);
-
-        // Strip old heartbeat status messages
-        processedConversation = stripHeartbeatsFromConversation(processedConversation, {
-            keepForTurns: options.stripHeartbeatsAfterTurns ?? 1,
-            currentTurn,
-        });
-
-        completion.conversation = processedConversation;
+        completion.conversation = res.output.length
+            ? finalizeOpenAIResponsesConversation(conversation, res.output, options)
+            : updateConversation(conversation, createAssistantMessageFromCompletion(completion));
 
         return completion;
     }
@@ -422,7 +409,9 @@ export abstract class OpenAIResponsesDriverBase extends OpenAICompatibleDriverBa
 
         const tools = collectTools(result.output);
         // Collect all parts in order (text and images)
-        const allResults = extractCompletionResults(result.output);
+        const includeThoughts =
+            (_options.model_options as OpenAIRequestOptions | undefined)?.include_thoughts !== false;
+        const allResults = extractCompletionResults(result.output, includeThoughts);
 
         if (allResults.length === 0 && !tools) {
             this.logger.error({ result }, '[OpenAI] Response is not valid');
@@ -440,7 +429,7 @@ export abstract class OpenAIResponsesDriverBase extends OpenAICompatibleDriverBa
     requestTextCompletionStream(
         prompt: ResponseInputItem[],
         options: ExecutionOptions,
-    ): Promise<AsyncIterable<CompletionChunkObject>> {
+    ): Promise<DriverCompletionStream> {
         return this.responsesProtocol.requestTextCompletionStream(this, prompt, options);
     }
 
@@ -845,6 +834,8 @@ function completionResultsToText(completionResults: CompletionResult[] | undefin
             switch (r.type) {
                 case 'text':
                     return r.value;
+                case 'thoughts':
+                    return '';
                 case 'json':
                     return typeof r.value === 'string' ? r.value : JSON.stringify(r.value);
                 case 'image':
@@ -917,8 +908,11 @@ function createAssistantMessageFromCompletion(completion: Completion): ResponseI
 
 export function mapResponseStream(
     stream: AsyncIterable<OpenAI.Responses.ResponseStreamEvent>,
-): AsyncIterable<CompletionChunkObject> {
+    includeThoughts = false,
+    finalize?: (response: OpenAI.Responses.Response) => unknown | Promise<unknown>,
+): DriverCompletionStream {
     const toolCallMetadata = new Map<string, { syntheticId: string; callId?: string; name?: string }>();
+    let finalResponse: OpenAI.Responses.Response | undefined;
 
     return {
         async *[Symbol.asyncIterator]() {
@@ -985,6 +979,13 @@ export function mapResponseStream(
                             result: textToCompletionResult(event.text),
                         } satisfies CompletionChunkObject;
                     }
+                } else if (
+                    event.type === 'response.reasoning_summary_text.delta' ||
+                    event.type === 'response.reasoning_text.delta'
+                ) {
+                    if (includeThoughts && event.delta) {
+                        yield { result: [{ type: 'thoughts', value: event.delta }] } satisfies CompletionChunkObject;
+                    }
                 } else if (event.type === 'response.refusal.delta') {
                     refusalText += event.delta;
                 } else if (event.type === 'response.refusal.done') {
@@ -999,6 +1000,7 @@ export function mapResponseStream(
                     event.type === 'response.incomplete' ||
                     event.type === 'response.failed'
                 ) {
+                    finalResponse = event.response;
                     const finalTools = collectTools(event.response.output);
                     yield {
                         result: [],
@@ -1008,6 +1010,12 @@ export function mapResponseStream(
                 }
             }
         },
+        finalizeConversation: finalize
+            ? () => {
+                  if (!finalResponse) throw new Error('OpenAI Responses stream ended without a final response');
+                  return finalize(finalResponse);
+              }
+            : undefined,
     };
 }
 
@@ -1133,6 +1141,32 @@ function updateConversation(conversation: unknown, items: ResponseInputItem[]): 
     return [...convArray, ...items];
 }
 
+function finalizeOpenAIResponsesConversation(
+    conversation: ResponseInputItem[],
+    output: OpenAI.Responses.ResponseOutputItem[],
+    options: ExecutionOptions,
+): ResponseInputItem[] {
+    let completed = updateConversation(conversation, output as ResponseInputItem[]);
+    completed = incrementConversationTurn(completed) as ResponseInputItem[];
+    const completedItems = unwrapConversationArray<ResponseInputItem>(completed) ?? [];
+    if (completedItems.some((item) => (item as { encrypted_content?: string | null }).encrypted_content))
+        return completed;
+
+    const currentTurn = getConversationMeta(completed).turnNumber;
+    const stripOptions = {
+        keepForTurns: options.stripImagesAfterTurns ?? Infinity,
+        currentTurn,
+        textMaxTokens: options.stripTextMaxTokens,
+    };
+    let processed = stripBase64ImagesFromConversation(completed, stripOptions);
+    processed = truncateLargeTextInConversation(processed, stripOptions);
+    processed = stripHeartbeatsFromConversation(processed, {
+        keepForTurns: options.stripHeartbeatsAfterTurns ?? 1,
+        currentTurn,
+    });
+    return processed as ResponseInputItem[];
+}
+
 export function collectTools(output?: OpenAI.Responses.ResponseOutputItem[]): ToolUse<unknown>[] | undefined {
     if (!output) {
         return undefined;
@@ -1159,13 +1193,22 @@ export function collectTools(output?: OpenAI.Responses.ResponseOutputItem[]): To
  * Collect all parts (text and images) from response output in order.
  * This preserves the original ordering of text and image parts.
  */
-function extractCompletionResults(output?: OpenAI.Responses.ResponseOutputItem[]): CompletionResult[] {
+function extractCompletionResults(
+    output?: OpenAI.Responses.ResponseOutputItem[],
+    includeThoughts = true,
+): CompletionResult[] {
     if (!output) {
         return [];
     }
 
     const results: CompletionResult[] = [];
     for (const item of output) {
+        if (item.type === 'reasoning' && includeThoughts) {
+            for (const summary of item.summary ?? []) {
+                if (summary.type === 'summary_text' && summary.text)
+                    results.push({ type: 'thoughts', value: summary.text });
+            }
+        }
         if (item.type === 'message') {
             // Extract text from message content
             for (const part of item.content) {

--- a/drivers/src/openai/openai_chat_completions.test.ts
+++ b/drivers/src/openai/openai_chat_completions.test.ts
@@ -11,7 +11,7 @@ import {
     type OpenAIChatCompletionsProtocolOptions,
     type OpenAIChatCompletionsResponse,
     parseOpenAIChatCompletionsToolCalls,
-    stripOpenAIChatCompletionsThinkBlocksFromCompletion,
+    prepareOpenAIChatCompletionsConversation,
 } from './openai_chat_completions.js';
 
 function createSSEStream(events: ServerSentEvent[]): ReadableStream<ServerSentEvent> {
@@ -224,10 +224,169 @@ describe('OpenAIChatCompletionsProtocol', () => {
 
         const completion = await model.requestTextCompletion(undefined, prompt, options);
 
-        expect(completion.result).toEqual([{ type: 'text', value: 'first\nsecond' }]);
+        expect(completion.result).toEqual([
+            { type: 'thoughts', value: 'hidden' },
+            { type: 'text', value: 'first\nsecond' },
+        ]);
     });
 
-    it('uses reasoning as a non-streaming fallback only when content is absent', async () => {
+    it('hides thoughts only when explicitly disabled and keeps native replay fields', async () => {
+        const model = new TestOpenAIChatCompletionsProtocol({
+            id: 'chatcmpl-thoughts',
+            object: 'chat.completion',
+            created: 1,
+            model: 'test/model',
+            choices: [
+                {
+                    index: 0,
+                    message: {
+                        role: 'assistant',
+                        content: 'answer',
+                        reasoning_content: 'signed-or-native-reasoning',
+                    },
+                    finish_reason: 'stop',
+                    logprobs: null,
+                },
+            ],
+        });
+
+        const explicit = await model.requestTextCompletion(undefined, prompt, {
+            ...options,
+            model_options: { _option_id: 'text-fallback', include_thoughts: true },
+        });
+        expect(explicit.result).toEqual([
+            { type: 'thoughts', value: 'signed-or-native-reasoning' },
+            { type: 'text', value: 'answer' },
+        ]);
+
+        const hidden = await model.requestTextCompletion(undefined, prompt, {
+            ...options,
+            model_options: { _option_id: 'text-fallback', include_thoughts: false },
+        });
+        expect(hidden.result).toEqual([{ type: 'text', value: 'answer' }]);
+        expect(hidden.conversation).toMatchObject({
+            messages: expect.arrayContaining([
+                expect.objectContaining({ reasoning_content: 'signed-or-native-reasoning' }),
+            ]),
+        });
+    });
+
+    it('removes DeepSeek R1 reasoning from replay while still projecting it as thoughts', async () => {
+        const model = new TestOpenAIChatCompletionsProtocol({
+            id: 'chatcmpl-r1',
+            object: 'chat.completion',
+            created: 1,
+            model: 'deepseek-r1-0528-maas',
+            choices: [
+                {
+                    index: 0,
+                    message: { role: 'assistant', content: 'answer', reasoning_content: 'visible reasoning' },
+                    finish_reason: 'stop',
+                    logprobs: null,
+                },
+            ],
+        });
+
+        const completion = await model.requestTextCompletion(undefined, prompt, {
+            ...options,
+            model: 'deepseek-ai/deepseek-r1-0528-maas',
+        });
+
+        expect(completion.result).toEqual([
+            { type: 'thoughts', value: 'visible reasoning' },
+            { type: 'text', value: 'answer' },
+        ]);
+        expect(JSON.stringify(completion.conversation)).not.toContain('visible reasoning');
+    });
+
+    it('replays DeepSeek V3.2 reasoning only within the current user tool turn', () => {
+        const currentTurn = prepareOpenAIChatCompletionsConversation(
+            {
+                messages: [
+                    { role: 'user', content: 'first question' },
+                    {
+                        role: 'assistant',
+                        content: null,
+                        reasoning_content: 'current reasoning',
+                        tool_calls: [
+                            {
+                                id: 'call-1',
+                                type: 'function',
+                                function: { name: 'lookup', arguments: '{}' },
+                            },
+                        ],
+                    },
+                    { role: 'tool', tool_call_id: 'call-1', content: 'result' },
+                ],
+            },
+            {
+                model: 'deepseek-ai/deepseek-v3.2-maas',
+                tools: [{ name: 'lookup', input_schema: { type: 'object' } }],
+            },
+        );
+        expect(currentTurn.messages[1].reasoning_content).toBe('current reasoning');
+
+        const nextTurn = prepareOpenAIChatCompletionsConversation(
+            { messages: [...currentTurn.messages, { role: 'user', content: 'next question' }] },
+            {
+                model: 'deepseek-ai/deepseek-v3.2-maas',
+                tools: [{ name: 'lookup', input_schema: { type: 'object' } }],
+            },
+        );
+        expect(nextTurn.messages[1].reasoning_content).toBeUndefined();
+    });
+
+    it('keeps DeepSeek V4 tool reasoning history immutable until checkpoint', async () => {
+        const model = new TestOpenAIChatCompletionsProtocol({
+            id: 'chatcmpl-v4',
+            object: 'chat.completion',
+            created: 1,
+            model: 'deepseek-v4-pro',
+            choices: [
+                {
+                    index: 0,
+                    message: {
+                        role: 'assistant',
+                        content: null,
+                        reasoning_content: 'tool reasoning',
+                        tool_calls: [
+                            {
+                                id: 'call-1',
+                                type: 'function',
+                                function: { name: 'lookup', arguments: '{}' },
+                            },
+                        ],
+                    },
+                    finish_reason: 'tool_calls',
+                    logprobs: null,
+                },
+            ],
+        });
+        const imagePrompt: OpenAIChatCompletionsPrompt = {
+            messages: [
+                {
+                    role: 'user',
+                    content: [
+                        { type: 'text', text: 'question' },
+                        { type: 'image_url', image_url: { url: 'data:image/png;base64,aW1hZ2U=' } },
+                    ],
+                },
+            ],
+        };
+
+        const completion = await model.requestTextCompletion(undefined, imagePrompt, {
+            ...options,
+            model: 'deepseek-v4-pro',
+            tools: [{ name: 'lookup', input_schema: { type: 'object' } }],
+            stripImagesAfterTurns: 0,
+        });
+        const conversation = completion.conversation as OpenAIChatCompletionsPrompt;
+
+        expect(conversation.messages[0]).toEqual(imagePrompt.messages[0]);
+        expect(conversation.messages[1].reasoning_content).toBe('tool reasoning');
+    });
+
+    it('returns native reasoning separately whether or not answer content is present', async () => {
         const fallbackModel = new TestOpenAIChatCompletionsProtocol({
             id: 'chatcmpl-1',
             object: 'chat.completion',
@@ -258,14 +417,17 @@ describe('OpenAIChatCompletionsProtocol', () => {
         });
 
         await expect(fallbackModel.requestTextCompletion(undefined, prompt, options)).resolves.toMatchObject({
-            result: [{ type: 'text', value: 'fallback text' }],
+            result: [{ type: 'thoughts', value: 'fallback text' }],
         });
         await expect(contentModel.requestTextCompletion(undefined, prompt, options)).resolves.toMatchObject({
-            result: [{ type: 'text', value: 'visible' }],
+            result: [
+                { type: 'thoughts', value: 'hidden' },
+                { type: 'text', value: 'visible' },
+            ],
         });
     });
 
-    it('uses reasoning as a non-streaming fallback when content is blank after think-block stripping', async () => {
+    it('projects both native reasoning and embedded think blocks as thoughts', async () => {
         const model = new TestOpenAIChatCompletionsProtocol({
             id: 'chatcmpl-1',
             object: 'chat.completion',
@@ -287,10 +449,13 @@ describe('OpenAIChatCompletionsProtocol', () => {
 
         const completion = await model.requestTextCompletion(undefined, prompt, options);
 
-        expect(completion.result).toEqual([{ type: 'text', value: 'fallback text' }]);
+        expect(completion.result).toEqual([
+            { type: 'thoughts', value: 'fallback text' },
+            { type: 'thoughts', value: 'hidden' },
+        ]);
     });
 
-    it('strips provider-emitted think blocks from completed non-streaming output and conversation', async () => {
+    it('projects provider think blocks while preserving native conversation content', async () => {
         const model = new TestOpenAIChatCompletionsProtocol({
             id: 'chatcmpl-1',
             object: 'chat.completion',
@@ -311,9 +476,17 @@ describe('OpenAIChatCompletionsProtocol', () => {
 
         const completion = await model.requestTextCompletion(undefined, prompt, options);
 
-        expect(completion.result).toEqual([{ type: 'text', value: '{"answer":"Paris"}' }]);
+        expect(completion.result).toEqual([
+            { type: 'thoughts', value: 'hidden reasoning' },
+            { type: 'text', value: '{"answer":"Paris"}' },
+        ]);
         expect(completion.conversation).toMatchObject({
-            messages: expect.arrayContaining([{ role: 'assistant', content: '{"answer":"Paris"}' }]),
+            messages: expect.arrayContaining([
+                expect.objectContaining({
+                    role: 'assistant',
+                    content: '<think>hidden reasoning</think>\n\n{"answer":"Paris"}',
+                }),
+            ]),
         });
     });
 
@@ -361,25 +534,43 @@ describe('OpenAIChatCompletionsProtocol', () => {
         ]);
     });
 
-    it('strips provider-emitted think blocks from final accumulated completion objects', () => {
-        const completion = stripOpenAIChatCompletionsThinkBlocksFromCompletion({
-            result: [{ type: 'text', value: '<think>hidden</think>\n\nfinal answer' }],
-            conversation: {
-                _is_openai_chat_completions: true,
-                messages: [
-                    { role: 'user', content: 'Hello' },
-                    { role: 'assistant', content: '<think>hidden</think>\n\nfinal answer' },
-                ],
-            },
-        });
-
-        expect(completion.result).toEqual([{ type: 'text', value: 'final answer' }]);
-        expect(completion.conversation).toMatchObject({
-            messages: [
-                { role: 'user', content: 'Hello' },
-                { role: 'assistant', content: 'final answer' },
+    it('does not treat every compatible reasoning field as an immutable history chain', async () => {
+        const model = new TestOpenAIChatCompletionsProtocol({
+            id: 'chatcmpl-reasoning',
+            object: 'chat.completion',
+            created: 1,
+            model: 'compatible-model',
+            choices: [
+                {
+                    index: 0,
+                    message: { role: 'assistant', content: 'ok', reasoning_content: 'reasoning projection' },
+                    finish_reason: 'stop',
+                    logprobs: null,
+                },
             ],
         });
+        const imagePrompt: OpenAIChatCompletionsPrompt = {
+            messages: [
+                {
+                    role: 'user',
+                    content: [
+                        { type: 'text', text: 'question' },
+                        { type: 'image_url', image_url: { url: 'data:image/png;base64,aW1hZ2U=' } },
+                    ],
+                },
+            ],
+        };
+
+        const completion = await model.requestTextCompletion(undefined, imagePrompt, {
+            ...options,
+            stripImagesAfterTurns: 0,
+            stripTextMaxTokens: 1,
+        });
+        const conversation = completion.conversation as OpenAIChatCompletionsPrompt;
+
+        expect(JSON.stringify(conversation.messages[0].content)).not.toContain('aW1hZ2U=');
+        expect(JSON.stringify(conversation.messages[0].content)).toContain('Content truncated');
+        expect(conversation.messages[1].reasoning_content).toContain('Content truncated');
     });
 
     it('reads streaming content arrays', async () => {
@@ -404,7 +595,7 @@ describe('OpenAIChatCompletionsProtocol', () => {
         expect(chunks.flatMap((chunk) => chunk.result)).toEqual([{ type: 'text', value: 'hello' }]);
     });
 
-    it('uses buffered streaming reasoning as a fallback only when no content arrives', async () => {
+    it('streams reasoning fields as thoughts', async () => {
         const model = new TestOpenAIChatCompletionsProtocol(
             undefined,
             createSSEStream([
@@ -433,10 +624,87 @@ describe('OpenAIChatCompletionsProtocol', () => {
 
         const chunks = await collectChunks(await model.requestTextCompletionStream(undefined, prompt, options));
 
-        expect(chunks.flatMap((chunk) => chunk.result)).toEqual([{ type: 'text', value: 'fallback text' }]);
+        expect(chunks.flatMap((chunk) => chunk.result)).toEqual([
+            { type: 'thoughts', value: 'fallback' },
+            { type: 'thoughts', value: ' text' },
+        ]);
     });
 
-    it('uses streaming reasoning fallback when content is blank after think-block stripping', async () => {
+    it('finalizes streaming conversation from native reasoning and tool-call deltas', async () => {
+        const model = new TestOpenAIChatCompletionsProtocol(
+            undefined,
+            createSSEStream([
+                {
+                    type: 'event',
+                    data: JSON.stringify({
+                        id: 'chatcmpl-1',
+                        object: 'chat.completion.chunk',
+                        created: 1,
+                        model: 'test/model',
+                        choices: [
+                            {
+                                index: 0,
+                                delta: {
+                                    reasoning_content: 'plan',
+                                    tool_calls: [
+                                        {
+                                            index: 0,
+                                            id: 'call-1',
+                                            type: 'function',
+                                            function: { name: 'lookup', arguments: '{"city":' },
+                                        },
+                                    ],
+                                },
+                            },
+                        ],
+                    }),
+                },
+                {
+                    type: 'event',
+                    data: JSON.stringify({
+                        id: 'chatcmpl-1',
+                        object: 'chat.completion.chunk',
+                        created: 1,
+                        model: 'test/model',
+                        choices: [
+                            {
+                                index: 0,
+                                finish_reason: 'tool_calls',
+                                delta: {
+                                    content: 'checking',
+                                    tool_calls: [{ index: 0, function: { arguments: '"Paris"}' } }],
+                                },
+                            },
+                        ],
+                    }),
+                },
+            ]),
+        );
+
+        const stream = await model.requestTextCompletionStream(undefined, prompt, options);
+        const results = [];
+        for await (const chunk of stream) results.push(...chunk.result);
+        const conversation = await stream.finalizeConversation?.({ result: results });
+
+        expect(conversation).toMatchObject({
+            messages: expect.arrayContaining([
+                expect.objectContaining({
+                    role: 'assistant',
+                    content: 'checking',
+                    reasoning_content: 'plan',
+                    tool_calls: [
+                        {
+                            id: 'call-1',
+                            type: 'function',
+                            function: { name: 'lookup', arguments: '{"city":"Paris"}' },
+                        },
+                    ],
+                }),
+            ]),
+        });
+    });
+
+    it('streams native and embedded reasoning as thoughts', async () => {
         const model = new TestOpenAIChatCompletionsProtocol(
             undefined,
             createSSEStream([
@@ -465,7 +733,10 @@ describe('OpenAIChatCompletionsProtocol', () => {
 
         const chunks = await collectChunks(await model.requestTextCompletionStream(undefined, prompt, options));
 
-        expect(chunks.flatMap((chunk) => chunk.result)).toEqual([{ type: 'text', value: 'fallback text' }]);
+        expect(chunks.flatMap((chunk) => chunk.result)).toEqual([
+            { type: 'thoughts', value: 'fallback text' },
+            { type: 'thoughts', value: 'hidden' },
+        ]);
     });
 
     it('normalizes non-streaming tool-call finish reasons', async () => {

--- a/drivers/src/openai/openai_chat_completions.test.ts
+++ b/drivers/src/openai/openai_chat_completions.test.ts
@@ -684,7 +684,7 @@ describe('OpenAIChatCompletionsProtocol', () => {
         const stream = await model.requestTextCompletionStream(undefined, prompt, options);
         const results = [];
         for await (const chunk of stream) results.push(...chunk.result);
-        const conversation = await stream.finalizeConversation?.({ result: results });
+        const conversation = await stream.finalizeConversation?.();
 
         expect(conversation).toMatchObject({
             messages: expect.arrayContaining([

--- a/drivers/src/openai/openai_chat_completions.ts
+++ b/drivers/src/openai/openai_chat_completions.ts
@@ -3,6 +3,7 @@ import {
     type Completion,
     type CompletionChunkObject,
     type CompletionResult,
+    type DriverCompletionStream,
     type DriverOptions,
     type EmbeddingResultItem,
     type EmbeddingsOptions,
@@ -50,6 +51,9 @@ export type OpenAIChatCompletionsMessage = {
      * Tool calls from assistant messages - stored and sent back with tool results.
      */
     tool_calls?: OpenAIChatCompletionsToolCall[];
+    /** Provider-native reasoning fields used by OpenAI-compatible APIs for replay. */
+    reasoning_content?: string | null;
+    reasoning?: string | null;
 };
 
 export type OpenAIChatCompletionsRequestMessage = {
@@ -57,6 +61,8 @@ export type OpenAIChatCompletionsRequestMessage = {
     content?: string | null | OpenAIChatCompletionsContentPart[];
     tool_call_id?: string;
     tool_calls?: OpenAIChatCompletionsToolCall[];
+    reasoning_content?: string | null;
+    reasoning?: string | null;
 };
 
 export type OpenAIChatCompletionsPayload = Omit<
@@ -261,15 +267,51 @@ export function updateOpenAIChatCompletionsConversation(
 
 export function prepareOpenAIChatCompletionsConversation(
     conversation: OpenAIChatCompletionsPrompt,
-    options: Pick<ExecutionOptions, 'tools'>,
+    options: Pick<ExecutionOptions, 'tools'> & Partial<Pick<ExecutionOptions, 'model'>>,
 ): OpenAIChatCompletionsPrompt {
     let messages = fixOrphanedOpenAIChatCompletionsToolResults(
         fixOrphanedOpenAIChatCompletionsToolUse(conversation.messages),
     );
+    messages = prepareOpenAIChatCompletionsReasoning(messages, options.model);
     if (!options.tools || options.tools.length === 0) {
         messages = convertOpenAIChatCompletionsToolMessagesToText(messages);
     }
     return { ...conversation, messages };
+}
+
+type OpenAIChatReasoningReplayPolicy = 'none' | 'omit' | 'active_tool_turn' | 'full_tool_history';
+
+function getOpenAIChatReasoningReplayPolicy(model: string | undefined): OpenAIChatReasoningReplayPolicy {
+    const modelId = model?.toLowerCase() ?? '';
+    if (/deepseek-(?:r1|reasoner)|deepseek\.r1/.test(modelId)) return 'omit';
+    if (/deepseek-v4(?:-|$)/.test(modelId)) return 'full_tool_history';
+    if (/deepseek-v3\.2(?:-|$)/.test(modelId)) return 'active_tool_turn';
+    return 'none';
+}
+
+function withoutOpenAIChatReasoning(message: OpenAIChatCompletionsMessage): OpenAIChatCompletionsMessage {
+    if (message.reasoning_content === undefined && message.reasoning === undefined) return message;
+    const { reasoning_content: _reasoningContent, reasoning: _reasoning, ...rest } = message;
+    return rest;
+}
+
+function prepareOpenAIChatCompletionsReasoning(
+    messages: OpenAIChatCompletionsMessage[],
+    model: string | undefined,
+): OpenAIChatCompletionsMessage[] {
+    const policy = getOpenAIChatReasoningReplayPolicy(model);
+    if (policy === 'omit') return messages.map(withoutOpenAIChatReasoning);
+    if (policy !== 'active_tool_turn') return messages;
+
+    let currentTurnStart = -1;
+    for (let index = messages.length - 1; index >= 0; index--) {
+        if (messages[index].role === 'user') {
+            currentTurnStart = index;
+            break;
+        }
+    }
+    if (currentTurnStart <= 0) return messages;
+    return messages.map((message, index) => (index < currentTurnStart ? withoutOpenAIChatReasoning(message) : message));
 }
 
 export function parseOpenAIChatCompletionsToolCalls(
@@ -447,64 +489,122 @@ export function stripOpenAIChatCompletionsThinkBlocks(value: string): string {
     return value.replace(/<think\b[^>]*>[\s\S]*?<\/think>/gi, '').trim();
 }
 
-export function stripOpenAIChatCompletionsThinkBlocksFromCompletion(completion: Completion): Completion {
-    completion.result = completion.result.map((result): CompletionResult => {
-        if (result.type === 'text') {
-            return { ...result, value: stripOpenAIChatCompletionsThinkBlocks(result.value) };
-        }
-        if (result.type === 'json' && typeof result.value === 'string') {
-            return { ...result, value: stripOpenAIChatCompletionsThinkBlocks(result.value) };
-        }
-        return result;
-    });
-
-    const conversation = completion.conversation as OpenAIChatCompletionsPrompt | undefined;
-    if (conversation?._is_openai_chat_completions && Array.isArray(conversation.messages)) {
-        completion.conversation = {
-            ...conversation,
-            messages: conversation.messages.map((message) => {
-                if (typeof message.content === 'string') {
-                    return { ...message, content: stripOpenAIChatCompletionsThinkBlocks(message.content) };
-                }
-                if (Array.isArray(message.content)) {
-                    return {
-                        ...message,
-                        content: message.content.map((part) =>
-                            part.type === 'text'
-                                ? { ...part, text: stripOpenAIChatCompletionsThinkBlocks(part.text) }
-                                : part,
-                        ),
-                    };
-                }
-                return message;
-            }),
-        };
-    }
-
-    return completion;
-}
-
-export function extractOpenAIChatCompletionsText(
+export function extractOpenAIChatCompletionsResults(
     source:
         | Pick<OpenAIChatCompletionsResponseChoice['message'], 'content' | 'reasoning_content' | 'reasoning'>
         | Pick<OpenAIChatCompletionsStreamChoiceDelta, 'content' | 'reasoning_content' | 'reasoning'>
         | undefined,
-    includeThoughts: boolean,
-): string {
-    if (!source) return '';
+    includeThoughts = true,
+): CompletionResult[] {
+    if (!source) return [];
 
-    const content = stripOpenAIChatCompletionsThinkBlocks(extractOpenAIChatCompletionsContentText(source.content));
+    const results = splitOpenAIChatCompletionsThinkBlocks(
+        extractOpenAIChatCompletionsContentText(source.content),
+        includeThoughts,
+    );
     const reasoning = extractOpenAIChatCompletionsReasoningText(source);
-
     if (includeThoughts && reasoning) {
-        return content ? `${reasoning}\n\n${content}` : reasoning;
+        results.unshift({ type: 'thoughts', value: reasoning });
+    }
+    return results;
+}
+
+export function splitOpenAIChatCompletionsThinkBlocks(value: string, includeThoughts = true): CompletionResult[] {
+    const results: CompletionResult[] = [];
+    const pattern = /<think\b[^>]*>([\s\S]*?)(?:<\/think>|$)/gi;
+    let offset = 0;
+    for (const match of value.matchAll(pattern)) {
+        const index = match.index ?? 0;
+        if (index > offset) {
+            const text = value.slice(offset, index).trim();
+            if (text) results.push({ type: 'text', value: text });
+        }
+        if (includeThoughts && match[1]) {
+            results.push({ type: 'thoughts', value: match[1] });
+        }
+        offset = index + match[0].length;
+    }
+    if (offset < value.length) {
+        const text = value.slice(offset).trim();
+        if (text) results.push({ type: 'text', value: text });
+    }
+    return results;
+}
+
+class OpenAIThinkStreamProjector {
+    private buffer = '';
+    private inThoughts = false;
+    private trimNextTextStart = false;
+
+    push(value: string, final = false): CompletionResult[] {
+        this.buffer += value;
+        const results: CompletionResult[] = [];
+
+        while (this.buffer) {
+            if (this.inThoughts) {
+                const closeIndex = this.buffer.toLowerCase().indexOf('</think>');
+                if (closeIndex >= 0) {
+                    this.append(results, 'thoughts', this.buffer.slice(0, closeIndex));
+                    this.buffer = this.buffer.slice(closeIndex + '</think>'.length);
+                    this.inThoughts = false;
+                    this.trimNextTextStart = true;
+                    continue;
+                }
+                if (final) {
+                    this.append(results, 'thoughts', this.buffer);
+                    this.buffer = '';
+                    break;
+                }
+                const retained = this.partialTagSuffixLength('</think>');
+                this.append(results, 'thoughts', this.buffer.slice(0, this.buffer.length - retained));
+                this.buffer = this.buffer.slice(this.buffer.length - retained);
+                break;
+            }
+
+            const open = /<think\b[^>]*>/i.exec(this.buffer);
+            if (open?.index !== undefined) {
+                this.append(results, 'text', this.buffer.slice(0, open.index).trimEnd());
+                this.buffer = this.buffer.slice(open.index + open[0].length);
+                this.inThoughts = true;
+                continue;
+            }
+            if (final) {
+                this.append(results, 'text', this.buffer);
+                this.buffer = '';
+                break;
+            }
+
+            const lower = this.buffer.toLowerCase();
+            const lastOpen = lower.lastIndexOf('<');
+            const candidate = lastOpen >= 0 ? lower.slice(lastOpen) : '';
+            const retainCandidate =
+                candidate.length > 0 &&
+                ('<think'.startsWith(candidate) || (candidate.startsWith('<think') && !candidate.includes('>')));
+            const retained = retainCandidate ? candidate.length : 0;
+            this.append(results, 'text', this.buffer.slice(0, this.buffer.length - retained));
+            this.buffer = this.buffer.slice(this.buffer.length - retained);
+            break;
+        }
+
+        return results;
     }
 
-    // Some OpenAI-compatible model servers can emit thinking-only chunks or messages
-    // using reasoning_content/reasoning. Use those fields only as a fallback so normal
-    // assistant content remains the visible output whenever it exists after provider
-    // <think>...</think> blocks and whitespace-only output are removed.
-    return content || stripOpenAIChatCompletionsThinkBlocks(reasoning);
+    private partialTagSuffixLength(tag: string): number {
+        const lower = this.buffer.toLowerCase();
+        for (let length = Math.min(lower.length, tag.length - 1); length > 0; length--) {
+            if (tag.startsWith(lower.slice(-length))) return length;
+        }
+        return 0;
+    }
+
+    private append(results: CompletionResult[], type: 'text' | 'thoughts', value: string): void {
+        if (type === 'text' && this.trimNextTextStart) {
+            value = value.trimStart();
+            if (value) this.trimNextTextStart = false;
+        }
+        if (type === 'text' && !value.trim()) return;
+        if (value) results.push({ type, value });
+    }
 }
 
 export function extractOpenAIChatCompletionsReasoningText(
@@ -514,9 +614,8 @@ export function extractOpenAIChatCompletionsReasoningText(
         | undefined,
 ): string {
     if (!source) return '';
-    return [source.reasoning_content, source.reasoning]
-        .filter((value): value is string => typeof value === 'string' && value.length > 0)
-        .join('');
+    const value = source.reasoning_content ?? source.reasoning;
+    return typeof value === 'string' ? value : '';
 }
 
 export function extractOpenAIChatCompletionsContentText(
@@ -577,6 +676,12 @@ export function convertToOpenAIChatCompletionsMessages(
 
         if (msg.tool_calls && msg.tool_calls.length > 0) {
             result.tool_calls = msg.tool_calls;
+        }
+        if (msg.reasoning_content !== undefined) {
+            result.reasoning_content = msg.reasoning_content;
+        }
+        if (msg.reasoning !== undefined) {
+            result.reasoning = msg.reasoning;
         }
 
         if (msg.content === null) {
@@ -686,6 +791,29 @@ function finalizeOpenAIChatCompletionsConversation(
     options: ExecutionOptions,
 ): OpenAIChatCompletionsPrompt {
     conversation = incrementConversationTurn(conversation) as OpenAIChatCompletionsPrompt;
+    const reasoningPolicy = getOpenAIChatReasoningReplayPolicy(options.model);
+    if (reasoningPolicy === 'omit') {
+        conversation = { ...conversation, messages: conversation.messages.map(withoutOpenAIChatReasoning) };
+    }
+
+    const latestAssistant = conversation.messages.findLast((message) => message.role === 'assistant');
+    const hasActiveReasoningToolTurn =
+        reasoningPolicy === 'active_tool_turn' &&
+        !!latestAssistant?.tool_calls?.length &&
+        (latestAssistant.reasoning_content != null || latestAssistant.reasoning != null);
+    const hasReasoningToolHistory =
+        reasoningPolicy === 'full_tool_history' &&
+        conversation.messages.some(
+            (message) =>
+                !!message.tool_calls?.length && (message.reasoning_content != null || message.reasoning != null),
+        );
+    if (hasActiveReasoningToolTurn || hasReasoningToolHistory) {
+        return conversation;
+    }
+
+    if (reasoningPolicy === 'active_tool_turn') {
+        conversation = { ...conversation, messages: conversation.messages.map(withoutOpenAIChatReasoning) };
+    }
     const currentTurn = getConversationMeta(conversation).turnNumber;
     const stripOptions = {
         keepForTurns: options.stripImagesAfterTurns ?? Infinity,
@@ -847,27 +975,30 @@ export abstract class OpenAIChatCompletionsProtocol<DriverT> {
             prompt,
         );
         conversation = prepareOpenAIChatCompletionsConversation(conversation, options);
-        const includeThoughts = (options.model_options as TextFallbackOptions & { include_thoughts?: boolean })
-            ?.include_thoughts;
+        const includeThoughts =
+            (options.model_options as TextFallbackOptions & { include_thoughts?: boolean })?.include_thoughts !== false;
         const payload = this.buildPayload(conversation, options, false);
         const result = await this.postChatCompletion(driver, payload, options);
 
         const choice = result?.choices?.[0];
         const message = choice?.message;
-        const text = stripOpenAIChatCompletionsThinkBlocks(
-            extractOpenAIChatCompletionsText(message, includeThoughts ?? false),
-        );
+        const completionResults = extractOpenAIChatCompletionsResults(message, includeThoughts);
         const tool_use = parseOpenAIChatCompletionsToolCalls(message?.tool_calls);
-        if (!text && (!tool_use || tool_use.length === 0)) {
+        if (
+            !message ||
+            (completionResults.length === 0 && !extractOpenAIChatCompletionsReasoningText(message) && !tool_use?.length)
+        ) {
             throw new Error('Chat Completions response is not valid: no data');
         }
 
         const assistantMessage: OpenAIChatCompletionsMessage = {
             role: 'assistant',
-            content: text || null,
+            content: message.content ?? null,
+            reasoning_content: message.reasoning_content,
+            reasoning: message.reasoning,
         };
 
-        if (tool_use && tool_use.length > 0 && message?.tool_calls) {
+        if (tool_use && tool_use.length > 0 && message.tool_calls) {
             assistantMessage.tool_calls = message.tool_calls.filter(
                 (toolCall): toolCall is OpenAI.Chat.ChatCompletionMessageFunctionToolCall =>
                     toolCall.type === 'function',
@@ -880,7 +1011,7 @@ export abstract class OpenAIChatCompletionsProtocol<DriverT> {
         conversation = finalizeOpenAIChatCompletionsConversation(conversation, options);
 
         return {
-            result: text ? [{ type: 'text', value: text }] : [],
+            result: completionResults,
             tool_use,
             token_usage: mapOpenAIChatCompletionsUsage(result.usage),
             finish_reason: normalizeOpenAIChatCompletionsFinishReason(choice?.finish_reason, !!tool_use?.length),
@@ -895,29 +1026,66 @@ export abstract class OpenAIChatCompletionsProtocol<DriverT> {
         driver: DriverT,
         prompt: OpenAIChatCompletionsPrompt,
         options: ExecutionOptions,
-    ): Promise<AsyncIterable<CompletionChunkObject>> {
+    ): Promise<DriverCompletionStream> {
         let conversation = updateOpenAIChatCompletionsConversation(
             options.conversation as OpenAIChatCompletionsPrompt,
             prompt,
         );
         conversation = prepareOpenAIChatCompletionsConversation(conversation, options);
-        const includeThoughts = (options.model_options as TextFallbackOptions & { include_thoughts?: boolean })
-            ?.include_thoughts;
+        const includeThoughts =
+            (options.model_options as TextFallbackOptions & { include_thoughts?: boolean })?.include_thoughts !== false;
         const payload = this.buildPayload(conversation, options, true);
         const responseStream = await this.postChatCompletionStream(driver, payload, options);
 
-        let emittedContent = false;
-        let reasoningFallback = '';
+        const projector = new OpenAIThinkStreamProjector();
+        let nativeContent = '';
+        let nativeReasoningContent: string | undefined;
+        let nativeReasoning: string | undefined;
+        const nativeToolCalls = new Map<
+            number,
+            { id: string; type: 'function'; function: { name: string; arguments: string } }
+        >();
 
-        return transformSSEStream(responseStream, (data: string) => {
+        const stream = transformSSEStream(responseStream, (data: string) => {
             const json = JSON.parse(data) as OpenAIChatCompletionsStreamResponse;
             const choice = json.choices?.[0];
             const delta = choice?.delta;
+            const chunkResults: CompletionResult[] = [];
+            const content = extractOpenAIChatCompletionsContentText(delta?.content);
+            if (content) {
+                nativeContent += content;
+                chunkResults.push(...projector.push(content, !!choice?.finish_reason));
+            } else if (choice?.finish_reason) {
+                chunkResults.push(...projector.push('', true));
+            }
 
+            if (typeof delta?.reasoning_content === 'string') {
+                nativeReasoningContent = (nativeReasoningContent ?? '') + delta.reasoning_content;
+                if (includeThoughts && delta.reasoning_content) {
+                    chunkResults.unshift({ type: 'thoughts', value: delta.reasoning_content });
+                }
+            } else if (typeof delta?.reasoning === 'string') {
+                nativeReasoning = (nativeReasoning ?? '') + delta.reasoning;
+                if (includeThoughts && delta.reasoning) {
+                    chunkResults.unshift({ type: 'thoughts', value: delta.reasoning });
+                }
+            }
+
+            let toolUseChunks: StreamingOpenAIToolUse[] | undefined;
             if (delta?.tool_calls && delta.tool_calls.length > 0) {
-                const toolUseChunks: StreamingOpenAIToolUse[] = delta.tool_calls.map((tc) => {
+                toolUseChunks = delta.tool_calls.map((tc) => {
+                    const index = tc.index ?? 0;
+                    const native = nativeToolCalls.get(index) ?? {
+                        id: '',
+                        type: 'function' as const,
+                        function: { name: '', arguments: '' },
+                    };
+                    if (tc.id) native.id = tc.id;
+                    if (tc.function?.name) native.function.name += tc.function.name;
+                    if (tc.function?.arguments) native.function.arguments += tc.function.arguments;
+                    nativeToolCalls.set(index, native);
                     const toolUse: StreamingOpenAIToolUse = {
-                        id: `tool_${tc.index ?? 0}`,
+                        id: `tool_${index}`,
                         tool_name: tc.function?.name ?? '',
                         tool_input:
                             typeof tc.function?.arguments === 'string' && tc.function.arguments.length > 0
@@ -929,39 +1097,36 @@ export abstract class OpenAIChatCompletionsProtocol<DriverT> {
                     }
                     return toolUse;
                 });
-
-                return {
-                    result: [],
-                    tool_use: toolUseChunks,
-                    finish_reason: choice?.finish_reason
-                        ? normalizeOpenAIChatCompletionsFinishReason(choice.finish_reason, toolUseChunks.length > 0)
-                        : undefined,
-                    token_usage: mapOpenAIChatCompletionsUsage(json.usage),
-                } satisfies CompletionChunkObject;
             }
-
-            const content = extractOpenAIChatCompletionsContentText(delta?.content);
-            const reasoning = extractOpenAIChatCompletionsReasoningText(delta);
-            const visibleContent = stripOpenAIChatCompletionsThinkBlocks(content);
-            if (visibleContent) {
-                emittedContent = true;
-            } else if (reasoning) {
-                reasoningFallback += reasoning;
-            }
-
-            const text = includeThoughts ? reasoning + content : content;
-            // Intentionally stream provider <think> blocks as they arrive. The final
-            // accumulated Completion/conversation strips them in validateResult();
-            // for fallback purposes they do not count as normal content.
-            const fallbackText =
-                !includeThoughts && choice?.finish_reason && !emittedContent
-                    ? stripOpenAIChatCompletionsThinkBlocks(reasoningFallback)
-                    : '';
             return {
-                result: text || fallbackText ? [{ type: 'text', value: fallbackText || text }] : [],
-                finish_reason: normalizeOpenAIChatCompletionsFinishReason(choice?.finish_reason),
+                result: includeThoughts ? chunkResults : chunkResults.filter((result) => result.type !== 'thoughts'),
+                tool_use: toolUseChunks,
+                finish_reason: normalizeOpenAIChatCompletionsFinishReason(
+                    choice?.finish_reason,
+                    !!toolUseChunks?.length,
+                ),
                 token_usage: mapOpenAIChatCompletionsUsage(json.usage),
             } satisfies CompletionChunkObject;
+        });
+
+        return Object.assign(stream, {
+            finalizeConversation: () => {
+                const assistantMessage: OpenAIChatCompletionsMessage = {
+                    role: 'assistant',
+                    content: nativeContent || null,
+                    ...(nativeReasoningContent !== undefined && { reasoning_content: nativeReasoningContent }),
+                    ...(nativeReasoning !== undefined && { reasoning: nativeReasoning }),
+                    ...(nativeToolCalls.size > 0 && {
+                        tool_calls: [...nativeToolCalls.entries()]
+                            .sort(([left], [right]) => left - right)
+                            .map(([, toolCall]) => toolCall),
+                    }),
+                };
+                return finalizeOpenAIChatCompletionsConversation(
+                    updateOpenAIChatCompletionsConversation(conversation, { messages: [assistantMessage] }),
+                    options,
+                );
+            },
         });
     }
 
@@ -1091,7 +1256,9 @@ function toOpenAISDKMessage(message: OpenAIChatCompletionsRequestMessage): OpenA
                 role: 'assistant',
                 content: typeof message.content === 'string' || message.content === null ? message.content : textParts,
                 tool_calls: message.tool_calls,
-            };
+                reasoning_content: message.reasoning_content,
+                reasoning: message.reasoning,
+            } as OpenAI.Chat.ChatCompletionAssistantMessageParam;
         case 'developer':
         case 'system':
             return {
@@ -1208,7 +1375,7 @@ export abstract class OpenAIChatCompletionsDriverBase<
     requestTextCompletionStream(
         prompt: OpenAIChatCompletionsPrompt,
         options: ExecutionOptions,
-    ): Promise<AsyncIterable<CompletionChunkObject>> {
+    ): Promise<DriverCompletionStream> {
         return this.chatCompletionsProtocol.requestTextCompletionStream(this, prompt, options);
     }
 
@@ -1219,10 +1386,6 @@ export abstract class OpenAIChatCompletionsDriverBase<
         options: ExecutionOptions,
     ): OpenAIChatCompletionsPrompt {
         return buildOpenAIChatCompletionsStreamingConversation(prompt, result, toolUse, options);
-    }
-
-    validateResult(result: Completion, options: ExecutionOptions) {
-        super.validateResult(stripOpenAIChatCompletionsThinkBlocksFromCompletion(result), options);
     }
 }
 

--- a/drivers/src/openai/openai_chat_completions.ts
+++ b/drivers/src/openai/openai_chat_completions.ts
@@ -257,7 +257,8 @@ export function updateOpenAIChatCompletionsConversation(
     conversation: OpenAIChatCompletionsPrompt | OpenAIChatCompletionsMessage[] | undefined | null,
     prompt: OpenAIChatCompletionsPrompt,
 ): OpenAIChatCompletionsPrompt {
-    // TODO: Remove legacy array-shaped conversation compatibility after 2026-07-27.
+    // TODO: Remove legacy array-shaped conversation compatibility after 2026-08-14,
+    // once all resumable conversations written before the native container migration have expired.
     const baseMessages = Array.isArray(conversation) ? conversation : (conversation?.messages ?? []);
     return {
         _is_openai_chat_completions: true,

--- a/drivers/src/openai/responses-reasoning.test.ts
+++ b/drivers/src/openai/responses-reasoning.test.ts
@@ -1,0 +1,160 @@
+import { Providers } from '@llumiverse/core';
+import type OpenAI from 'openai';
+import { describe, expect, it, vi } from 'vitest';
+import { OpenAIResponsesDriverBase } from './index.js';
+
+class TestResponsesDriver extends OpenAIResponsesDriverBase {
+    provider: Providers.openai = Providers.openai;
+    service: OpenAI;
+
+    constructor(create: (request: unknown) => Promise<unknown>) {
+        super({});
+        this.service = { responses: { create } } as unknown as OpenAI;
+    }
+}
+
+const reasoningItem = {
+    id: 'reason-1',
+    type: 'reasoning' as const,
+    summary: [{ type: 'summary_text' as const, text: 'visible plan' }],
+    encrypted_content: 'encrypted-replay-state',
+    status: 'completed' as const,
+};
+const messageItem = {
+    id: 'msg-1',
+    type: 'message' as const,
+    role: 'assistant' as const,
+    status: 'completed' as const,
+    content: [{ type: 'output_text' as const, text: 'answer', annotations: [], logprobs: [] }],
+};
+
+function response() {
+    return {
+        id: 'response-1',
+        object: 'response',
+        created_at: 1,
+        model: 'gpt-5',
+        status: 'completed',
+        output: [reasoningItem, messageItem],
+        output_text: 'answer',
+        parallel_tool_calls: true,
+        tool_choice: 'auto',
+        tools: [],
+        error: null,
+        incomplete_details: null,
+        instructions: null,
+        metadata: null,
+        temperature: null,
+        top_p: null,
+        usage: { input_tokens: 1, output_tokens: 2, total_tokens: 3, input_tokens_details: { cached_tokens: 0 } },
+    } as unknown as OpenAI.Responses.Response;
+}
+
+describe('OpenAI Responses reasoning', () => {
+    it.each([
+        'gpt-5.4',
+        'gpt-5.5',
+        'gpt-5.6',
+        'gpt-5.6-sol',
+    ])('uses current-turn reasoning context for %s', async (model) => {
+        const create = vi.fn(async (_request: unknown) => response());
+        const driver = new TestResponsesDriver(create);
+
+        await driver.requestTextCompletion([{ type: 'message', role: 'user', content: 'question' }], {
+            model,
+            model_options: { _option_id: 'openai-thinking' },
+        });
+
+        expect(create).toHaveBeenCalledWith(
+            expect.objectContaining({
+                reasoning: expect.objectContaining({ context: 'current_turn' }),
+            }),
+        );
+    });
+
+    it('does not request cross-turn reasoning controls for models without documented support', async () => {
+        const create = vi.fn(async (_request: unknown) => response());
+        const driver = new TestResponsesDriver(create);
+
+        await driver.requestTextCompletion([{ type: 'message', role: 'user', content: 'question' }], {
+            model: 'gpt-5',
+            model_options: { _option_id: 'openai-thinking' },
+        });
+
+        expect(create.mock.calls[0][0]).toMatchObject({ reasoning: { summary: 'auto' } });
+        expect((create.mock.calls[0][0] as { reasoning: Record<string, unknown> }).reasoning).not.toHaveProperty(
+            'context',
+        );
+    });
+
+    it('projects reasoning by default and replays the exact encrypted output item after JSON roundtrip', async () => {
+        const create = vi.fn(async (_request: unknown) => response());
+        const driver = new TestResponsesDriver(create);
+        const prompt = [{ type: 'message', role: 'user', content: 'question' }] as OpenAI.Responses.ResponseInputItem[];
+
+        const first = await driver.requestTextCompletion(prompt, {
+            model: 'gpt-5',
+            model_options: { _option_id: 'openai-thinking' },
+        });
+        expect(first.result).toEqual([
+            { type: 'thoughts', value: 'visible plan' },
+            { type: 'text', value: 'answer' },
+        ]);
+        expect(create).toHaveBeenCalledWith(expect.objectContaining({ include: ['reasoning.encrypted_content'] }));
+
+        const persisted = JSON.parse(JSON.stringify(first.conversation));
+        await driver.requestTextCompletion([{ type: 'message', role: 'user', content: 'continue' }], {
+            model: 'gpt-5',
+            model_options: { _option_id: 'openai-thinking' },
+            conversation: persisted,
+        });
+        expect(create.mock.calls[1][0]).toMatchObject({ input: expect.arrayContaining([reasoningItem]) });
+
+        const hidden = await driver.requestTextCompletion(prompt, {
+            model: 'gpt-5',
+            model_options: { _option_id: 'openai-thinking', include_thoughts: false },
+        });
+        expect(hidden.result).toEqual([{ type: 'text', value: 'answer' }]);
+        expect(JSON.stringify(hidden.conversation)).toContain('encrypted-replay-state');
+    });
+
+    it('streams reasoning separately and finalizes from the authoritative response output', async () => {
+        const final = response();
+        const create = vi.fn(async () =>
+            (async function* () {
+                yield {
+                    type: 'response.reasoning_summary_text.delta',
+                    item_id: 'reason-1',
+                    output_index: 0,
+                    summary_index: 0,
+                    sequence_number: 1,
+                    delta: 'visible plan',
+                };
+                yield {
+                    type: 'response.output_text.delta',
+                    item_id: 'msg-1',
+                    output_index: 1,
+                    content_index: 0,
+                    sequence_number: 2,
+                    delta: 'answer',
+                    logprobs: [],
+                };
+                yield { type: 'response.completed', sequence_number: 3, response: final };
+            })(),
+        );
+        const driver = new TestResponsesDriver(create);
+        const stream = await driver.requestTextCompletionStream(
+            [{ type: 'message', role: 'user', content: 'question' }],
+            { model: 'gpt-5', model_options: { _option_id: 'openai-thinking' } },
+        );
+        const results = [];
+        for await (const chunk of stream) results.push(...chunk.result);
+        const conversation = await stream.finalizeConversation?.({ result: results });
+
+        expect(results).toEqual([
+            { type: 'thoughts', value: 'visible plan' },
+            { type: 'text', value: 'answer' },
+        ]);
+        expect(JSON.stringify(conversation)).toContain('encrypted-replay-state');
+    });
+});

--- a/drivers/src/openai/responses-reasoning.test.ts
+++ b/drivers/src/openai/responses-reasoning.test.ts
@@ -157,4 +157,42 @@ describe('OpenAI Responses reasoning', () => {
         ]);
         expect(JSON.stringify(conversation)).toContain('encrypted-replay-state');
     });
+
+    it.each([false, true])('forwards OpenAI prompt cache controls when stream=%s', async (streaming) => {
+        const create = vi.fn(async (request: unknown) =>
+            (request as { stream?: boolean }).stream
+                ? (async function* () {
+                      yield { type: 'response.completed', sequence_number: 1, response: response() };
+                  })()
+                : response(),
+        );
+        const driver = new TestResponsesDriver(create);
+        const options = {
+            model: 'gpt-5',
+            model_options: {
+                _option_id: 'openai-thinking' as const,
+                prompt_cache_key: 'agent-cache-key',
+                prompt_cache_retention: '24h' as const,
+            },
+        };
+
+        if (streaming) {
+            const stream = await driver.requestTextCompletionStream(
+                [{ type: 'message', role: 'user', content: 'question' }],
+                options,
+            );
+            for await (const _chunk of stream) {
+                // Consume the provider stream.
+            }
+        } else {
+            await driver.requestTextCompletion([{ type: 'message', role: 'user', content: 'question' }], options);
+        }
+
+        expect(create).toHaveBeenCalledWith(
+            expect.objectContaining({
+                prompt_cache_key: 'agent-cache-key',
+                prompt_cache_retention: '24h',
+            }),
+        );
+    });
 });

--- a/drivers/src/openai/responses-reasoning.test.ts
+++ b/drivers/src/openai/responses-reasoning.test.ts
@@ -156,6 +156,53 @@ describe('OpenAI Responses reasoning', () => {
         expect(JSON.stringify(conversation)).toContain('encrypted-replay-state');
     });
 
+    it('prunes adjacent conversation content while preserving encrypted reasoning items', async () => {
+        const create = vi.fn(async (_request: unknown) => response());
+        const driver = new TestResponsesDriver(create);
+        const prompt = [
+            { type: 'message' as const, role: 'user' as const, content: 'old tool output that should be truncated' },
+        ] as OpenAI.Responses.ResponseInputItem[];
+
+        const completion = await driver.requestTextCompletion(prompt, {
+            model: 'gpt-5',
+            model_options: { _option_id: 'openai-thinking' },
+            stripImagesAfterTurns: 0,
+            stripTextMaxTokens: 1,
+        });
+
+        const serialized = JSON.stringify(completion.conversation);
+        expect(serialized).toContain('encrypted-replay-state');
+        expect(serialized).toContain('[Content truncated - exceeded token limit]');
+
+        const imageCompletion = await driver.requestTextCompletion(
+            [
+                {
+                    type: 'message',
+                    role: 'user',
+                    content: [{ type: 'image_url', image_url: { url: 'data:image/png;base64,aW1hZ2U=' } }],
+                } as unknown as OpenAI.Responses.ResponseInputItem,
+            ],
+            {
+                model: 'gpt-5',
+                model_options: { _option_id: 'openai-thinking' },
+                stripImagesAfterTurns: 0,
+            },
+        );
+        expect(JSON.stringify(imageCompletion.conversation)).toContain('[Image removed from conversation history]');
+
+        const heartbeatCompletion = await driver.requestTextCompletion(
+            [{ type: 'message', role: 'user', content: '<heartbeat>old status</heartbeat>' }],
+            {
+                model: 'gpt-5',
+                model_options: { _option_id: 'openai-thinking' },
+                stripHeartbeatsAfterTurns: 0,
+            },
+        );
+        expect(JSON.stringify(heartbeatCompletion.conversation)).toContain(
+            '[Heartbeat removed from conversation history]',
+        );
+    });
+
     it.each([false, true])('forwards OpenAI prompt cache controls when stream=%s', async (streaming) => {
         const create = vi.fn(async (request: unknown) =>
             (request as { stream?: boolean }).stream

--- a/drivers/src/openai/responses-reasoning.test.ts
+++ b/drivers/src/openai/responses-reasoning.test.ts
@@ -51,26 +51,24 @@ function response() {
 }
 
 describe('OpenAI Responses reasoning', () => {
-    it.each([
-        'gpt-5.4',
-        'gpt-5.5',
-        'gpt-5.6',
-        'gpt-5.6-sol',
-    ])('uses current-turn reasoning context for %s', async (model) => {
-        const create = vi.fn(async (_request: unknown) => response());
-        const driver = new TestResponsesDriver(create);
+    it.each(['gpt-5.4', 'gpt-5.5', 'gpt-5.6', 'gpt-5.6-sol'])(
+        'uses current-turn reasoning context for %s',
+        async (model) => {
+            const create = vi.fn(async (_request: unknown) => response());
+            const driver = new TestResponsesDriver(create);
 
-        await driver.requestTextCompletion([{ type: 'message', role: 'user', content: 'question' }], {
-            model,
-            model_options: { _option_id: 'openai-thinking' },
-        });
+            await driver.requestTextCompletion([{ type: 'message', role: 'user', content: 'question' }], {
+                model,
+                model_options: { _option_id: 'openai-thinking' },
+            });
 
-        expect(create).toHaveBeenCalledWith(
-            expect.objectContaining({
-                reasoning: expect.objectContaining({ context: 'current_turn' }),
-            }),
-        );
-    });
+            expect(create).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    reasoning: expect.objectContaining({ context: 'current_turn' }),
+                }),
+            );
+        },
+    );
 
     it('does not request cross-turn reasoning controls for models without documented support', async () => {
         const create = vi.fn(async (_request: unknown) => response());
@@ -149,7 +147,7 @@ describe('OpenAI Responses reasoning', () => {
         );
         const results = [];
         for await (const chunk of stream) results.push(...chunk.result);
-        const conversation = await stream.finalizeConversation?.({ result: results });
+        const conversation = await stream.finalizeConversation?.();
 
         expect(results).toEqual([
             { type: 'thoughts', value: 'visible plan' },

--- a/drivers/src/shared/claude-messages.ts
+++ b/drivers/src/shared/claude-messages.ts
@@ -207,29 +207,16 @@ export function collectClaudeTools(content: ContentBlock[]): ToolUse[] | undefin
     return out.length > 0 ? out : undefined;
 }
 
-export function collectAllTextContent(content: ContentBlock[], includeThoughts = false): string {
-    const textParts: string[] = [];
-
-    if (includeThoughts) {
-        for (const block of content) {
-            if (block.type === 'thinking' && block.thinking) {
-                textParts.push(block.thinking);
-            } else if (block.type === 'redacted_thinking' && block.data) {
-                textParts.push(`[Redacted thinking: ${block.data}]`);
-            }
-        }
-        if (textParts.length > 0) {
-            textParts.push('');
-        }
-    }
-
+export function collectClaudeResults(content: ContentBlock[], includeThoughts = false): CompletionResult[] {
+    const results: CompletionResult[] = [];
     for (const block of content) {
-        if (block.type === 'text' && block.text) {
-            textParts.push(block.text);
+        if (block.type === 'thinking' && block.thinking && includeThoughts) {
+            results.push({ type: 'thoughts', value: block.thinking });
+        } else if (block.type === 'text' && block.text) {
+            results.push({ type: 'text', value: block.text });
         }
     }
-
-    return textParts.join('\n');
+    return results;
 }
 
 // ============================================================================
@@ -982,13 +969,13 @@ export async function executeClaudeCompletion(
     logClaudeTruncation(logger, result.stop_reason, { provider, model: options.model });
 
     const includeThoughts = model_options?.include_thoughts ?? false;
-    const text = collectAllTextContent(result.content, includeThoughts);
+    const completionResults = collectClaudeResults(result.content, includeThoughts);
     const tool_use = collectClaudeTools(result.content);
 
     const processedConversation = finalizeClaudeConversation(conversation, result, options);
 
     return {
-        result: text ? [{ type: 'text', value: text }] : [{ type: 'text', value: '' }],
+        result: completionResults.length > 0 ? completionResults : [{ type: 'text', value: '' }],
         tool_use,
         token_usage: anthropicUsageToTokenUsage(result.usage),
         finish_reason: tool_use ? 'tool_use' : claudeFinishReason(result?.stop_reason ?? ''),
@@ -1050,11 +1037,6 @@ export async function streamClaudeCompletion(
                         ],
                     } satisfies CompletionChunkObject;
                 }
-                if (streamEvent.content_block.type === 'redacted_thinking' && model_options?.include_thoughts) {
-                    return {
-                        result: [{ type: 'text', value: `[Redacted thinking: ${streamEvent.content_block.data}]` }],
-                    } satisfies CompletionChunkObject;
-                }
                 break;
             case 'content_block_delta':
                 switch (streamEvent.delta.type) {
@@ -1085,7 +1067,7 @@ export async function streamClaudeCompletion(
                         if (model_options?.include_thoughts) {
                             return {
                                 result: streamEvent.delta.thinking
-                                    ? [{ type: 'text', value: streamEvent.delta.thinking }]
+                                    ? [{ type: 'thoughts', value: streamEvent.delta.thinking }]
                                     : [],
                             } satisfies CompletionChunkObject;
                         }

--- a/drivers/src/shared/claude-messages.ts
+++ b/drivers/src/shared/claude-messages.ts
@@ -1073,9 +1073,6 @@ export async function streamClaudeCompletion(
                         }
                         break;
                     case 'signature_delta':
-                        if (model_options?.include_thoughts) {
-                            pendingSpacing = true;
-                        }
                         break;
                 }
                 break;

--- a/drivers/src/vertexai/index.ts
+++ b/drivers/src/vertexai/index.ts
@@ -4,8 +4,8 @@ import { PredictionServiceClient, v1beta1 } from '@google-cloud/aiplatform';
 import {
     type AIModel,
     type Completion,
-    type CompletionChunkObject,
     type CompletionResult,
+    type DriverCompletionStream,
     type DriverOptions,
     type EmbeddingsOptions,
     type EmbeddingsResult,
@@ -362,7 +362,7 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
     async requestTextCompletionStream(
         prompt: VertexAIPrompt,
         options: ExecutionOptions,
-    ): Promise<AsyncIterable<CompletionChunkObject>> {
+    ): Promise<DriverCompletionStream> {
         return getModelDefinition(options.model).requestTextCompletionStream(this, prompt, options);
     }
 
@@ -406,6 +406,8 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
                 switch (r.type) {
                     case 'text':
                         return r.value;
+                    case 'thoughts':
+                        return '';
                     case 'json':
                         return typeof r.value === 'string' ? r.value : JSON.stringify(r.value);
                     case 'image':
@@ -507,6 +509,8 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
                 switch (r.type) {
                     case 'text':
                         return r.value;
+                    case 'thoughts':
+                        return '';
                     case 'json':
                         return typeof r.value === 'string' ? r.value : JSON.stringify(r.value);
                     case 'image':

--- a/drivers/src/vertexai/models.ts
+++ b/drivers/src/vertexai/models.ts
@@ -1,7 +1,7 @@
 import type {
     AIModel,
     Completion,
-    CompletionChunkObject,
+    DriverCompletionStream,
     ExecutionOptions,
     LlumiverseError,
     LlumiverseErrorContext,
@@ -27,7 +27,7 @@ export interface ModelDefinition<PromptT = VertexAIPrompt> {
         driver: VertexAIDriver,
         prompt: PromptT,
         options: ExecutionOptions,
-    ): Promise<AsyncIterable<CompletionChunkObject>>;
+    ): Promise<DriverCompletionStream>;
     preValidationProcessing?(
         result: Completion,
         options: ExecutionOptions,

--- a/drivers/src/vertexai/models/claude-streaming-spacing.test.ts
+++ b/drivers/src/vertexai/models/claude-streaming-spacing.test.ts
@@ -80,7 +80,7 @@ describe('ClaudeModelDefinition streaming spacing', () => {
         expect(toolChunks[1]).toMatchObject({ id: 'tool-1', tool_name: '', tool_input: '{"city":"Paris"}' });
     });
 
-    it('flushes deferred spacing into the first text delta after thinking', async () => {
+    it('keeps thinking and answer text as separate results without injected spacing', async () => {
         const modelDef = new ClaudeModelDefinition('claude-sonnet-4-5');
         const driver = {
             logger: { warn: () => {}, info: () => {}, error: () => {} },
@@ -121,7 +121,7 @@ describe('ClaudeModelDefinition streaming spacing', () => {
         const chunks = await collectChunks(stream);
 
         const textParts = chunks.flatMap((chunk) => chunk.result ?? []).map((part) => part.value);
-        expect(textParts).toEqual(['Thinking...', '\n\nAnswer']);
+        expect(textParts).toEqual(['Thinking...', 'Answer']);
     });
 
     it('does not reintroduce deferred spacing when text arrives after a tool call', async () => {

--- a/drivers/src/vertexai/models/claude.ts
+++ b/drivers/src/vertexai/models/claude.ts
@@ -1,7 +1,7 @@
 import {
     type AIModel,
     type Completion,
-    type CompletionChunkObject,
+    type DriverCompletionStream,
     type ExecutionOptions,
     type LlumiverseError,
     type LlumiverseErrorContext,
@@ -90,7 +90,7 @@ export class ClaudeModelDefinition implements ModelDefinition<ClaudePrompt> {
         driver: VertexAIDriver,
         prompt: ClaudePrompt,
         options: ExecutionOptions,
-    ): Promise<AsyncIterable<CompletionChunkObject>> {
+    ): Promise<DriverCompletionStream> {
         const { region, options: resolvedOptions } = resolveVertexAIModelPath(options);
         const client = await driver.getAnthropicClient(region, resolvedOptions.httpTimeout);
         const model_options = resolvedOptions.model_options as VertexAIClaudeOptions | undefined;

--- a/drivers/src/vertexai/models/gemini-conversation-mutation.test.ts
+++ b/drivers/src/vertexai/models/gemini-conversation-mutation.test.ts
@@ -106,8 +106,8 @@ function makeContentsWithFunctionParts() {
 }
 
 function makeDriver(overrides: {
-    generateContent?: () => Promise<unknown>;
-    generateContentStream?: () => Promise<AsyncIterable<unknown>>;
+    generateContent?: (request?: unknown) => Promise<unknown>;
+    generateContentStream?: (request?: unknown) => Promise<AsyncIterable<unknown>>;
 }) {
     return {
         logger: { warn: () => {}, info: () => {}, error: () => {} },
@@ -143,6 +143,163 @@ const mockStreamingChunk = {
 };
 
 describe('GeminiModelDefinition - no conversation mutation', () => {
+    it('preserves signatures on arbitrary Parts and empty terminal Parts across JSON roundtrip', async () => {
+        const modelDef = new GeminiModelDefinition('gemini-3-flash');
+        const nativeContent = {
+            role: 'model',
+            parts: [
+                { text: 'plan', thought: true, thoughtSignature: 'thought-signature' },
+                {
+                    functionCall: { name: 'first', args: { value: 1 } },
+                    thoughtSignature: 'call-signature',
+                },
+                { text: 'answer', thoughtSignature: 'text-signature' },
+                { text: '', thoughtSignature: 'terminal-signature' },
+            ],
+        };
+        const requests: unknown[] = [];
+        const driver = makeDriver({
+            generateContent: async (request) => {
+                requests.push(request);
+                return {
+                    usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1, totalTokenCount: 2 },
+                    candidates: [{ finishReason: FinishReason.STOP, content: nativeContent, safetyRatings: [] }],
+                };
+            },
+        });
+        const first = await modelDef.requestTextCompletion(
+            driver,
+            { contents: [{ role: 'user', parts: [{ text: 'question' }] }] },
+            {
+                model: 'publishers/google/models/gemini-3-flash',
+                tools: [
+                    { name: 'first', input_schema: { type: 'object' } },
+                    { name: 'second', input_schema: { type: 'object' } },
+                ],
+                stripTextMaxTokens: 1,
+                stripImagesAfterTurns: 0,
+            },
+        );
+        expect(first.result).toEqual([
+            { type: 'thoughts', value: 'plan' },
+            { type: 'text', value: 'answer' },
+        ]);
+
+        const persisted = JSON.parse(JSON.stringify(first.conversation));
+        await modelDef.requestTextCompletion(
+            driver,
+            {
+                contents: [
+                    {
+                        role: 'user',
+                        parts: [
+                            { functionResponse: { name: 'first', response: { output: 'one' } } },
+                            { functionResponse: { name: 'second', response: { output: 'two' } } },
+                        ],
+                    },
+                ],
+            },
+            {
+                model: 'publishers/google/models/gemini-3-flash',
+                conversation: persisted,
+                tools: [
+                    { name: 'first', input_schema: { type: 'object' } },
+                    { name: 'second', input_schema: { type: 'object' } },
+                ],
+            },
+        );
+        expect(requests[1]).toMatchObject({ contents: expect.arrayContaining([nativeContent]) });
+
+        const hidden = await modelDef.requestTextCompletion(
+            driver,
+            { contents: [{ role: 'user', parts: [{ text: 'hidden' }] }] },
+            {
+                model: 'publishers/google/models/gemini-3-flash',
+                model_options: { _option_id: 'vertexai-gemini', include_thoughts: false },
+            },
+        );
+        expect(hidden.result).toEqual([{ type: 'text', value: 'answer' }]);
+        expect(JSON.stringify(hidden.conversation)).toContain('terminal-signature');
+    });
+
+    it('reconstructs streamed thought, parallel function-call, and terminal signatures in order', async () => {
+        const modelDef = new GeminiModelDefinition('gemini-3-flash');
+        const driver = makeDriver({
+            generateContentStream: async () =>
+                (async function* () {
+                    yield {
+                        candidates: [
+                            {
+                                content: {
+                                    role: 'model',
+                                    parts: [
+                                        { text: 'plan ', thought: true },
+                                        {
+                                            functionCall: { name: 'first', args: { value: 1 } },
+                                            thoughtSignature: 'first-signature',
+                                        },
+                                    ],
+                                },
+                            },
+                        ],
+                    };
+                    yield {
+                        usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 2, totalTokenCount: 3 },
+                        candidates: [
+                            {
+                                finishReason: FinishReason.STOP,
+                                content: {
+                                    role: 'model',
+                                    parts: [
+                                        { text: 'continued', thought: true, thoughtSignature: 'thought-signature' },
+                                        {
+                                            functionCall: { name: 'second', args: { value: 2 } },
+                                            thoughtSignature: 'second-signature',
+                                        },
+                                        { text: 'answer', thoughtSignature: 'answer-signature' },
+                                        { text: '', thoughtSignature: 'terminal-signature' },
+                                    ],
+                                },
+                                safetyRatings: [],
+                            },
+                        ],
+                    };
+                })(),
+        });
+        const stream = await modelDef.requestTextCompletionStream(
+            driver,
+            { contents: [{ role: 'user', parts: [{ text: 'question' }] }] },
+            { model: 'publishers/google/models/gemini-3-flash' },
+        );
+        const results = [];
+        for await (const chunk of stream) results.push(...chunk.result);
+        const conversation = await stream.finalizeConversation?.({ result: results });
+
+        expect(results).toContainEqual({ type: 'thoughts', value: 'plan ' });
+        expect(results).toContainEqual({ type: 'thoughts', value: 'continued' });
+        expect(conversation).toMatchObject({
+            _arrayConversation: expect.arrayContaining([
+                {
+                    role: 'model',
+                    parts: [
+                        { text: 'plan ', thought: true },
+                        {
+                            functionCall: { name: 'first', args: { value: 1 } },
+                            thoughtSignature: 'first-signature',
+                        },
+                        { text: 'continued', thought: true, thoughtSignature: 'thought-signature' },
+                        {
+                            functionCall: { name: 'second', args: { value: 2 } },
+                            thoughtSignature: 'second-signature',
+                        },
+                        { text: 'answer', thoughtSignature: 'answer-signature' },
+                        { text: '', thoughtSignature: 'terminal-signature' },
+                    ],
+                },
+            ]),
+        });
+    });
+
     it('createPrompt uses DataSource URIs directly for Gemini file data', async () => {
         const modelDef = new GeminiModelDefinition('gemini-2.0-flash');
         const file: DataSource = {

--- a/drivers/src/vertexai/models/gemini-conversation-mutation.test.ts
+++ b/drivers/src/vertexai/models/gemini-conversation-mutation.test.ts
@@ -340,6 +340,51 @@ describe('GeminiModelDefinition - no conversation mutation', () => {
         });
     });
 
+    it('does not merge a signed streamed Part into an unsigned Part', async () => {
+        const modelDef = new GeminiModelDefinition('gemini-3-flash');
+        const driver = makeDriver({
+            generateContentStream: async () =>
+                (async function* () {
+                    yield {
+                        candidates: [{ content: { role: 'model', parts: [{ text: 'first ', thought: true }] } }],
+                    };
+                    yield {
+                        candidates: [
+                            {
+                                finishReason: FinishReason.STOP,
+                                content: {
+                                    role: 'model',
+                                    parts: [{ text: 'second', thought: true, thoughtSignature: 'signed-second' }],
+                                },
+                            },
+                        ],
+                    };
+                })(),
+        });
+
+        const stream = await modelDef.requestTextCompletionStream(
+            driver,
+            { contents: [{ role: 'user', parts: [{ text: 'question' }] }] },
+            { model: 'publishers/google/models/gemini-3-flash' },
+        );
+        for await (const _chunk of stream) {
+            // Consume the stream so native finalization has all Parts.
+        }
+        const conversation = await stream.finalizeConversation?.({ result: [] });
+
+        expect(conversation).toMatchObject({
+            _arrayConversation: expect.arrayContaining([
+                {
+                    role: 'model',
+                    parts: [
+                        { text: 'first ', thought: true },
+                        { text: 'second', thought: true, thoughtSignature: 'signed-second' },
+                    ],
+                },
+            ]),
+        });
+    });
+
     it('createPrompt uses DataSource URIs directly for Gemini file data', async () => {
         const modelDef = new GeminiModelDefinition('gemini-2.0-flash');
         const file: DataSource = {

--- a/drivers/src/vertexai/models/gemini-conversation-mutation.test.ts
+++ b/drivers/src/vertexai/models/gemini-conversation-mutation.test.ts
@@ -17,7 +17,7 @@ import { FinishReason } from '@google/genai';
 import { type DataSource, type ExecutionOptions, PromptRole, type PromptSegment } from '@llumiverse/core';
 import { describe, expect, it, vi } from 'vitest';
 import type { GenerateContentPrompt, VertexAIDriver } from '../index.js';
-import { convertGeminiFunctionPartsToText, GeminiModelDefinition } from './gemini.js';
+import { convertGeminiFunctionPartsToText, GeminiModelDefinition, getGeminiPayload } from './gemini.js';
 
 // ---------------------------------------------------------------------------
 // Pure function tests — no driver needed
@@ -91,6 +91,46 @@ describe('convertGeminiFunctionPartsToText', () => {
         const result = convertGeminiFunctionPartsToText(contents);
 
         expect(result[0].parts?.[0]).toBe(textPart);
+    });
+});
+
+describe('Gemini thinking configuration', () => {
+    const prompt = { contents: [{ role: 'user' as const, parts: [{ text: 'Hello' }] }] };
+
+    it('omits thinkingConfig when Gemini 2.5 Flash thinking is disabled by default', () => {
+        const payload = getGeminiPayload({ model: 'publishers/google/models/gemini-2.5-flash' }, prompt);
+
+        expect(payload.config?.thinkingConfig).toBeUndefined();
+    });
+
+    it('omits thinkingConfig when an explicit zero budget disables thinking', () => {
+        const payload = getGeminiPayload(
+            {
+                model: 'publishers/google/models/gemini-2.5-flash',
+                model_options: {
+                    _option_id: 'vertexai-gemini',
+                    thinking_budget_tokens: 0,
+                },
+            },
+            prompt,
+        );
+
+        expect(payload.config?.thinkingConfig).toBeUndefined();
+    });
+
+    it('includes thought summaries when Gemini thinking is enabled', () => {
+        const payload = getGeminiPayload(
+            {
+                model: 'publishers/google/models/gemini-2.5-flash',
+                model_options: {
+                    _option_id: 'vertexai-gemini',
+                    thinking_budget_tokens: 128,
+                },
+            },
+            prompt,
+        );
+
+        expect(payload.config?.thinkingConfig).toEqual({ includeThoughts: true, thinkingBudget: 128 });
     });
 });
 

--- a/drivers/src/vertexai/models/gemini-conversation-mutation.test.ts
+++ b/drivers/src/vertexai/models/gemini-conversation-mutation.test.ts
@@ -313,7 +313,7 @@ describe('GeminiModelDefinition - no conversation mutation', () => {
         );
         const results = [];
         for await (const chunk of stream) results.push(...chunk.result);
-        const conversation = await stream.finalizeConversation?.({ result: results });
+        const conversation = await stream.finalizeConversation?.();
 
         expect(results).toContainEqual({ type: 'thoughts', value: 'plan ' });
         expect(results).toContainEqual({ type: 'thoughts', value: 'continued' });
@@ -370,7 +370,7 @@ describe('GeminiModelDefinition - no conversation mutation', () => {
         for await (const _chunk of stream) {
             // Consume the stream so native finalization has all Parts.
         }
-        const conversation = await stream.finalizeConversation?.({ result: [] });
+        const conversation = await stream.finalizeConversation?.();
 
         expect(conversation).toMatchObject({
             _arrayConversation: expect.arrayContaining([

--- a/drivers/src/vertexai/models/gemini-conversation-mutation.test.ts
+++ b/drivers/src/vertexai/models/gemini-conversation-mutation.test.ts
@@ -340,6 +340,78 @@ describe('GeminiModelDefinition - no conversation mutation', () => {
         });
     });
 
+    it('prunes adjacent conversation content while preserving signed thought Parts', async () => {
+        const modelDef = new GeminiModelDefinition('gemini-3-flash');
+        const driver = makeDriver({
+            generateContent: async () => ({
+                usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1, totalTokenCount: 2 },
+                candidates: [
+                    {
+                        finishReason: FinishReason.STOP,
+                        content: {
+                            role: 'model',
+                            parts: [{ text: 'signed plan', thought: true, thoughtSignature: 'signed-plan' }],
+                        },
+                        safetyRatings: [],
+                    },
+                ],
+            }),
+        });
+
+        const completion = await modelDef.requestTextCompletion(
+            driver,
+            {
+                contents: [
+                    {
+                        role: 'user',
+                        parts: [{ text: 'old tool output that should be truncated' }],
+                    },
+                ],
+            },
+            {
+                model: 'publishers/google/models/gemini-3-flash',
+                stripTextMaxTokens: 1,
+                stripImagesAfterTurns: 0,
+            },
+        );
+
+        const serialized = JSON.stringify(completion.conversation);
+        expect(serialized).toContain('signed plan');
+        expect(serialized).toContain('signed-plan');
+        expect(serialized).toContain('[Content truncated - exceeded token limit]');
+
+        const imageCompletion = await modelDef.requestTextCompletion(
+            driver,
+            {
+                contents: [
+                    {
+                        role: 'user',
+                        parts: [{ inlineData: { data: 'a'.repeat(1001), mimeType: 'image/png' } }],
+                    },
+                ],
+            },
+            {
+                model: 'publishers/google/models/gemini-3-flash',
+                stripImagesAfterTurns: 0,
+            },
+        );
+        expect(JSON.stringify(imageCompletion.conversation)).toContain('[Image removed from conversation history]');
+
+        const heartbeatCompletion = await modelDef.requestTextCompletion(
+            driver,
+            {
+                contents: [{ role: 'user', parts: [{ text: '<heartbeat>old status</heartbeat>' }] }],
+            },
+            {
+                model: 'publishers/google/models/gemini-3-flash',
+                stripHeartbeatsAfterTurns: 0,
+            },
+        );
+        expect(JSON.stringify(heartbeatCompletion.conversation)).toContain(
+            '[Heartbeat removed from conversation history]',
+        );
+    });
+
     it('does not merge a signed streamed Part into an unsigned Part', async () => {
         const modelDef = new GeminiModelDefinition('gemini-3-flash');
         const driver = makeDriver({

--- a/drivers/src/vertexai/models/gemini-thinking-options.test.ts
+++ b/drivers/src/vertexai/models/gemini-thinking-options.test.ts
@@ -15,22 +15,22 @@ describe('Gemini thinking configuration', () => {
 
     it('maps current Gemini 3 effort levels', () => {
         expect(geminiThinkingConfig(options('gemini-3.5-flash', { effort: 'minimal' }))).toEqual({
-            includeThoughts: false,
+            includeThoughts: true,
             thinkingLevel: ThinkingLevel.MINIMAL,
         });
         expect(geminiThinkingConfig(options('gemini-3.1-pro', { effort: 'medium' }))).toEqual({
-            includeThoughts: false,
+            includeThoughts: true,
             thinkingLevel: ThinkingLevel.MEDIUM,
         });
     });
 
     it('passes through caller effort even when advisory metadata does not offer it', () => {
         expect(geminiThinkingConfig(options('gemini-3.1-flash-image', { effort: 'low' }))).toEqual({
-            includeThoughts: false,
+            includeThoughts: true,
             thinkingLevel: ThinkingLevel.LOW,
         });
         expect(geminiThinkingConfig(options('gemini-3-pro-image', { effort: 'minimal' }))).toEqual({
-            includeThoughts: false,
+            includeThoughts: true,
             thinkingLevel: ThinkingLevel.MINIMAL,
         });
     });

--- a/drivers/src/vertexai/models/gemini.ts
+++ b/drivers/src/vertexai/models/gemini.ts
@@ -20,8 +20,8 @@ import {
 import {
     type AIModel,
     type Completion,
-    type CompletionChunkObject,
     type CompletionResult,
+    type DriverCompletionStream,
     type ExecutionOptions,
     type ExecutionTokenUsage,
     getConversationMeta,
@@ -208,16 +208,17 @@ export function getGeminiPayload(options: ExecutionOptions, prompt: GenerateCont
  * Collect all parts (text and images) from content in order.
  * This preserves the original ordering of text and image parts.
  */
-function extractCompletionResults(content: Content): CompletionResult[] {
+function extractCompletionResults(content: Content, includeThoughts = true): CompletionResult[] {
     const results: CompletionResult[] = [];
     const parts = content.parts;
     if (parts) {
         for (const part of parts) {
             if (part.text) {
-                results.push({
-                    type: 'text',
-                    value: part.text,
-                });
+                if (part.thought) {
+                    if (includeThoughts) results.push({ type: 'thoughts', value: part.text });
+                } else {
+                    results.push({ type: 'text', value: part.text });
+                }
             } else if (part.inlineData) {
                 const base64ImageBytes: string = part.inlineData.data ?? '';
                 const mimeType = part.inlineData.mimeType ?? 'image/png';
@@ -230,6 +231,52 @@ function extractCompletionResults(content: Content): CompletionResult[] {
         }
     }
     return results;
+}
+
+function finalizeGeminiConversation(
+    conversation: Content[],
+    assistantContent: Content | undefined,
+    system: Content | undefined,
+    options: ExecutionOptions,
+): GenerateContentPrompt['contents'] {
+    let completed = assistantContent ? updateConversation(conversation, [assistantContent]) : conversation;
+    completed = incrementConversationTurn(completed) as Content[];
+    const contents = unwrapConversationArray<Content>(completed) ?? (Array.isArray(completed) ? completed : []);
+    if (contents.some((content) => content.parts?.some((part) => !!part.thoughtSignature))) {
+        return storeSystemInConversation(completed, system) as Content[];
+    }
+    const currentTurn = getConversationMeta(completed).turnNumber;
+    const stripOptions = {
+        keepForTurns: options.stripImagesAfterTurns ?? Infinity,
+        currentTurn,
+        textMaxTokens: options.stripTextMaxTokens,
+    };
+    let processed = stripBase64ImagesFromConversation(completed, stripOptions);
+    processed = truncateLargeTextInConversation(processed, stripOptions);
+    processed = stripHeartbeatsFromConversation(processed, {
+        keepForTurns: options.stripHeartbeatsAfterTurns ?? 1,
+        currentTurn,
+    });
+    return storeSystemInConversation(processed, system) as Content[];
+}
+
+function appendGeminiStreamParts(target: Part[], incoming: Part[]): void {
+    for (const part of incoming) {
+        const previous = target.at(-1);
+        const canMergeText =
+            typeof part.text === 'string' &&
+            part.text.length > 0 &&
+            typeof previous?.text === 'string' &&
+            !previous.thoughtSignature &&
+            !part.thoughtSignature &&
+            !!previous.thought === !!part.thought;
+        if (canMergeText && previous) {
+            previous.text = (previous.text ?? '') + part.text;
+            if (part.thoughtSignature) previous.thoughtSignature = part.thoughtSignature;
+        } else {
+            target.push(structuredClone(part));
+        }
+    }
 }
 
 function collectToolUseParts(content: Content): ToolUse[] | undefined {
@@ -382,12 +429,15 @@ export function geminiThinkingConfig(option: StatelessExecutionOptions): Thinkin
     const model_options = option.model_options as VertexAIGeminiOptions | undefined;
 
     // If thinking options are explicitly set in model options, use them directly
-    const include_thoughts = model_options?.include_thoughts ?? false;
+    const include_thoughts = model_options?.include_thoughts !== false;
     if (model_options?.thinking_budget_tokens !== undefined || model_options?.thinking_level) {
+        if (model_options.thinking_budget_tokens === 0 && !model_options.thinking_level) return undefined;
         return {
-            includeThoughts: include_thoughts,
-            thinkingBudget: model_options.thinking_budget_tokens,
-            thinkingLevel: model_options.thinking_level,
+            includeThoughts: true,
+            ...(model_options.thinking_budget_tokens !== undefined && {
+                thinkingBudget: model_options.thinking_budget_tokens,
+            }),
+            ...(model_options.thinking_level && { thinkingLevel: model_options.thinking_level }),
         };
     }
     if (model_options?.effort) {
@@ -619,7 +669,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
             prompt.system = existingSystem;
         }
 
-        let conversation = updateConversation(options.conversation, prompt.contents);
+        const conversation = updateConversation(options.conversation, prompt.contents);
         prompt.contents = conversation;
 
         // TODO: Remove hack, use global endpoint manually if needed.
@@ -628,6 +678,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
         }
 
         const model_options = options.model_options as VertexAIGeminiOptions | undefined;
+        const includeThoughts = model_options?.include_thoughts !== false;
         const client = driver.getGoogleGenAIClient(region, model_options?.flex ?? false, options.httpTimeout);
 
         const payload = getGeminiPayload(options, prompt);
@@ -636,6 +687,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
         const token_usage: ExecutionTokenUsage = this.usageMetadataToTokenUsage(driver, response.usageMetadata);
 
         let tool_use: ToolUse[] | undefined;
+        let finalContent: Content | undefined;
         let finish_reason: string | undefined, result: CompletionResult[] | undefined;
         const candidate = response.candidates?.[0];
         if (candidate) {
@@ -680,8 +732,8 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
                     );
                 }
 
-                result = extractCompletionResults(content);
-                conversation = updateConversation(conversation, [content]);
+                result = extractCompletionResults(content, includeThoughts);
+                finalContent = content;
             }
         }
 
@@ -689,29 +741,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
             finish_reason = 'tool_use';
         }
 
-        // Increment turn counter for deferred stripping
-        conversation = incrementConversationTurn(conversation) as Content[];
-
-        // Strip large base64 image data based on options.stripImagesAfterTurns
-        const currentTurn = getConversationMeta(conversation).turnNumber;
-        const stripOptions = {
-            keepForTurns: options.stripImagesAfterTurns ?? Infinity,
-            currentTurn,
-            textMaxTokens: options.stripTextMaxTokens,
-        };
-        let processedConversation = stripBase64ImagesFromConversation(conversation, stripOptions);
-
-        // Truncate large text content if configured
-        processedConversation = truncateLargeTextInConversation(processedConversation, stripOptions);
-
-        // Strip old heartbeat status messages
-        processedConversation = stripHeartbeatsFromConversation(processedConversation, {
-            keepForTurns: options.stripHeartbeatsAfterTurns ?? 1,
-            currentTurn,
-        });
-
-        // Preserve system instruction in conversation for multi-turn support
-        const finalConversation = storeSystemInConversation(processedConversation, prompt.system);
+        const finalConversation = finalizeGeminiConversation(conversation, finalContent, prompt.system, options);
 
         return {
             result: result && result.length > 0 ? result : [{ type: 'text' as const, value: '' }],
@@ -727,7 +757,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
         driver: VertexAIDriver,
         prompt: GenerateContentPrompt,
         options: ExecutionOptions,
-    ): Promise<AsyncIterable<CompletionChunkObject>> {
+    ): Promise<DriverCompletionStream> {
         const splits = options.model.split('/');
         let region: string | undefined;
         if (splits[0] === 'locations' && splits.length >= 2) {
@@ -754,11 +784,13 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
         }
 
         const model_options = options.model_options as VertexAIGeminiOptions | undefined;
+        const includeThoughts = model_options?.include_thoughts !== false;
         const client = driver.getGoogleGenAIClient(region, model_options?.flex ?? false, options.httpTimeout);
 
         const payload = getGeminiPayload(options, prompt);
         const response = await client.models.generateContentStream(payload);
 
+        const nativeParts: Part[] = [];
         const stream = asyncMap(response, async (item) => {
             const token_usage: ExecutionTokenUsage = this.usageMetadataToTokenUsage(driver, item.usageMetadata);
             if (item.candidates && item.candidates.length > 0) {
@@ -789,8 +821,9 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
                         );
                     }
                     if (candidate.content?.role === 'model') {
+                        appendGeminiStreamParts(nativeParts, candidate.content.parts ?? []);
                         // Collect all parts in order (text and images)
-                        const combinedResults = extractCompletionResults(candidate.content);
+                        const combinedResults = extractCompletionResults(candidate.content, includeThoughts);
                         tool_use = collectToolUseParts(candidate.content);
                         if (tool_use) {
                             finish_reason = 'tool_use';
@@ -824,7 +857,15 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
             };
         });
 
-        return stream;
+        return Object.assign(stream, {
+            finalizeConversation: () =>
+                finalizeGeminiConversation(
+                    conversation,
+                    nativeParts.length > 0 ? { role: 'model', parts: nativeParts } : undefined,
+                    prompt.system,
+                    options,
+                ),
+        });
     }
 
     /**

--- a/drivers/src/vertexai/models/gemini.ts
+++ b/drivers/src/vertexai/models/gemini.ts
@@ -241,21 +241,24 @@ function finalizeGeminiConversation(
 ): GenerateContentPrompt['contents'] {
     let completed = assistantContent ? updateConversation(conversation, [assistantContent]) : conversation;
     completed = incrementConversationTurn(completed) as Content[];
-    const contents = unwrapConversationArray<Content>(completed) ?? (Array.isArray(completed) ? completed : []);
-    if (contents.some((content) => content.parts?.some((part) => !!part.thoughtSignature))) {
-        return storeSystemInConversation(completed, system) as Content[];
-    }
     const currentTurn = getConversationMeta(completed).turnNumber;
+    const preserveSubtree = (value: unknown): boolean => {
+        if (!value || typeof value !== 'object') return false;
+        const thoughtSignature = (value as { thoughtSignature?: unknown }).thoughtSignature;
+        return typeof thoughtSignature === 'string' && thoughtSignature.length > 0;
+    };
     const stripOptions = {
         keepForTurns: options.stripImagesAfterTurns ?? Infinity,
         currentTurn,
         textMaxTokens: options.stripTextMaxTokens,
+        preserveSubtree,
     };
     let processed = stripBase64ImagesFromConversation(completed, stripOptions);
     processed = truncateLargeTextInConversation(processed, stripOptions);
     processed = stripHeartbeatsFromConversation(processed, {
         keepForTurns: options.stripHeartbeatsAfterTurns ?? 1,
         currentTurn,
+        preserveSubtree,
     });
     return storeSystemInConversation(processed, system) as Content[];
 }
@@ -272,7 +275,6 @@ function appendGeminiStreamParts(target: Part[], incoming: Part[]): void {
             !!previous.thought === !!part.thought;
         if (canMergeText && previous) {
             previous.text = (previous.text ?? '') + part.text;
-            if (part.thoughtSignature) previous.thoughtSignature = part.thoughtSignature;
         } else {
             target.push(structuredClone(part));
         }

--- a/drivers/src/vertexai/models/openai_chat_completions.test.ts
+++ b/drivers/src/vertexai/models/openai_chat_completions.test.ts
@@ -200,7 +200,7 @@ describe('OpenAIChatCompletionsModelDefinition', () => {
 
         const completion = await modelDef.requestTextCompletion(driver, prompt, options);
 
-        expect(completion.result).toEqual([{ type: 'text', value: 'fallback text' }]);
+        expect(completion.result).toEqual([{ type: 'thoughts', value: 'fallback text' }]);
     });
 
     it('reads text from non-streaming OpenAI content arrays', async () => {
@@ -243,10 +243,13 @@ describe('OpenAIChatCompletionsModelDefinition', () => {
 
         const completion = await modelDef.requestTextCompletion(driver, prompt, options);
 
-        expect(completion.result).toEqual([{ type: 'text', value: 'first\nsecond' }]);
+        expect(completion.result).toEqual([
+            { type: 'thoughts', value: 'hidden reasoning' },
+            { type: 'text', value: 'first\nsecond' },
+        ]);
     });
 
-    it('prefers normal content over reasoning fields in non-streaming responses', async () => {
+    it('keeps normal content and reasoning fields separate', async () => {
         const modelDef = new OpenAIChatCompletionsModelDefinition({
             modelName: 'zai-org/glm-5-maas',
             region: 'global',
@@ -283,7 +286,10 @@ describe('OpenAIChatCompletionsModelDefinition', () => {
 
         const completion = await modelDef.requestTextCompletion(driver, prompt, options);
 
-        expect(completion.result).toEqual([{ type: 'text', value: 'visible content' }]);
+        expect(completion.result).toEqual([
+            { type: 'thoughts', value: 'hidden reasoning' },
+            { type: 'text', value: 'visible content' },
+        ]);
     });
 
     it('uses response_format with normalized JSON schema for structured Vertex MaaS output', async () => {
@@ -517,7 +523,10 @@ describe('OpenAIChatCompletionsModelDefinition', () => {
 
         const chunks = await collectChunks(await modelDef.requestTextCompletionStream(driver, prompt, options));
 
-        expect(chunks.flatMap((chunk) => chunk.result)).toEqual([{ type: 'text', value: 'visible' }]);
+        expect(chunks.flatMap((chunk) => chunk.result)).toEqual([
+            { type: 'thoughts', value: 'hidden' },
+            { type: 'text', value: 'visible' },
+        ]);
     });
 
     it('uses buffered streaming reasoning as a fallback when no content deltas arrive', async () => {
@@ -578,6 +587,9 @@ describe('OpenAIChatCompletionsModelDefinition', () => {
 
         const chunks = await collectChunks(await modelDef.requestTextCompletionStream(driver, prompt, options));
 
-        expect(chunks.flatMap((chunk) => chunk.result)).toEqual([{ type: 'text', value: 'fallback text' }]);
+        expect(chunks.flatMap((chunk) => chunk.result)).toEqual([
+            { type: 'thoughts', value: 'fallback' },
+            { type: 'thoughts', value: ' text' },
+        ]);
     });
 });

--- a/drivers/src/vertexai/models/openai_chat_completions.ts
+++ b/drivers/src/vertexai/models/openai_chat_completions.ts
@@ -1,11 +1,10 @@
-import { type AIModel, type Completion, type ExecutionOptions, ModelType } from '@llumiverse/core';
+import { type AIModel, ModelType } from '@llumiverse/core';
 import {
     type OpenAIChatCompletionsPayload,
     type OpenAIChatCompletionsPrompt,
     OpenAIChatCompletionsProtocol,
     type OpenAIChatCompletionsProtocolOptions,
     type OpenAIChatCompletionsResponse,
-    stripOpenAIChatCompletionsThinkBlocksFromCompletion,
 } from '../../openai/openai_chat_completions.js';
 import type { VertexAIDriver } from '../index.js';
 import type { ModelDefinition } from '../models.js';
@@ -72,13 +71,6 @@ export class OpenAIChatCompletionsModelDefinition
             payload,
             reader: 'sse',
         })) as ReadableStream;
-    }
-
-    preValidationProcessing(
-        result: Completion,
-        options: ExecutionOptions,
-    ): { result: Completion; options: ExecutionOptions } {
-        return { result: stripOpenAIChatCompletionsThinkBlocksFromCompletion(result), options };
     }
 
     private getClient(driver: VertexAIDriver) {

--- a/drivers/test/utils.ts
+++ b/drivers/test/utils.ts
@@ -17,6 +17,8 @@ export function completionResultToString(result: CompletionResult): string {
     switch (result.type) {
         case 'text':
             return result.value;
+        case 'thoughts':
+            return result.value;
         case 'json':
             return JSON.stringify(result.value, null, 2);
         case 'image':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,7 +126,7 @@ importers:
         version: 1.0.0-beta.6
       '@azure/ai-projects':
         specifier: ^2.3.1
-        version: 2.3.1(@aws-sdk/credential-provider-node@3.972.76)(@smithy/hash-node@4.4.6)(@smithy/signature-v4@5.6.11)(ws@8.21.0)(zod@4.4.3)
+        version: 2.3.1(@aws-sdk/credential-provider-node@3.972.76)(@smithy/hash-node@4.4.6)(@smithy/signature-v4@5.6.12)(ws@8.21.0)(zod@4.4.3)
       '@azure/core-auth':
         specifier: ^1.11.0
         version: 1.11.0
@@ -177,7 +177,7 @@ importers:
         version: 0.2.1
       openai:
         specifier: ^6.49.0
-        version: 6.49.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/hash-node@4.4.6)(@smithy/signature-v4@5.6.11)(ws@8.21.0)(zod@4.4.3)
+        version: 6.49.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/hash-node@4.4.6)(@smithy/signature-v4@5.6.12)(ws@8.21.0)(zod@4.4.3)
       replicate:
         specifier: ^1.4.0
         version: 1.4.0
@@ -261,13 +261,6 @@ packages:
   '@aws-sdk/client-s3@3.1101.0':
     resolution: {integrity: sha512-16EFb1aTEBgPcfUAWAjjlB57IZCyn7B3rlfT+xqE7M6WoH8AMMU3vFZO0UOitwh/xvvzVx73YED1/n0PU4qBMw==}
     engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/core@3.977.1':
-    resolution: {integrity: sha512-KVtQRtc00ES/y+Sc3vYXeP6pCIcNlBJCZOwvqSy8ZpVGmbM5+IG+AfhuTKQ2oXmIVqZJewaGMMpzPkywC6xg0w==}
-    engines: {node: '>=20.0.0'}
-    deprecated: |-
-      Deprecated due to Document number parsing bug in JSON, see
-        https://github.com/aws/aws-sdk-js-v3/issues/8246. Newer version available.
 
   '@aws-sdk/core@3.977.4':
     resolution: {integrity: sha512-CEkcQlMOQJCvul60U7wdAOACjtdgFWDsfJI+6wUOGdhGNV2lGbuJpi/R50QLpFG3Tp+sQxa/RmzC3X7KHbhuTA==}
@@ -735,10 +728,6 @@ packages:
     resolution: {integrity: sha512-yI8StAYGQKiI+DxT0xkLhHSzxcIFSZTTWi0c4Lk3WLgmbe2QfLpR/Roo81ZF3VYwfwqH4IQVTKsy3FLZiVRaTQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/core@3.31.0':
-    resolution: {integrity: sha512-sylYk2l9d7CmRv8ts8p0SDQUr3VO+HMeS1nrjL6+UtbO8ktJHTOeQ1McX+aAyvGGccp5aZX9eNtdcXrSwzoZaw==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/core@3.31.1':
     resolution: {integrity: sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==}
     engines: {node: '>=18.0.0'}
@@ -760,10 +749,6 @@ packages:
 
   '@smithy/fetch-http-handler@2.5.0':
     resolution: {integrity: sha512-BOWEBeppWhLn/no/JxUL/ghTfANTjT7kg3Ww2rPqTUY9R4yHPXxJ9JhMe3Z03LN3aPwiwlpDIUcVw1xDyHqEhw==}
-
-  '@smithy/fetch-http-handler@5.6.12':
-    resolution: {integrity: sha512-OpQgP6IGH4j0NJ2zjfYZLjQL85ai+Wi/q51EmZJovXsEwKSvu89qiXUq77Q6EmwZ/hSl7fKpn2Z9mhiDN6OM+Q==}
-    engines: {node: '>=18.0.0'}
 
   '@smithy/fetch-http-handler@5.6.13':
     resolution: {integrity: sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==}
@@ -840,10 +825,6 @@ packages:
   '@smithy/signature-v4@3.1.2':
     resolution: {integrity: sha512-3BcPylEsYtD0esM4Hoyml/+s7WP2LFhcM3J2AGdcL2vx9O60TtfpDOL72gjb4lU8NeRPeKAwR77YNyyGvMbuEA==}
     engines: {node: '>=16.0.0'}
-
-  '@smithy/signature-v4@5.6.11':
-    resolution: {integrity: sha512-7HsspeiNCZvZHEJ22vV5L/QYuJdTyJvPJvMrYD3AgkM3IJB0pkln4jkjPvtpTWRMkHXbO8WKwNjoVdVlBFwHmw==}
-    engines: {node: '>=18.0.0'}
 
   '@smithy/signature-v4@5.6.12':
     resolution: {integrity: sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==}
@@ -1936,7 +1917,7 @@ snapshots:
       '@aws-sdk/client-bedrock-runtime': 3.1101.0
       '@aws-sdk/credential-providers': 3.1101.0
       '@smithy/eventstream-serde-node': 2.2.0
-      '@smithy/fetch-http-handler': 5.6.12
+      '@smithy/fetch-http-handler': 5.6.13
       '@smithy/protocol-http': 3.3.0
       '@smithy/signature-v4': 3.1.2
       '@smithy/smithy-client': 2.5.1
@@ -2031,17 +2012,6 @@ snapshots:
       '@smithy/fetch-http-handler': 5.6.13
       '@smithy/node-http-handler': 4.9.13
       '@smithy/types': 4.16.1
-      tslib: 2.8.1
-
-  '@aws-sdk/core@3.977.1':
-    dependencies:
-      '@aws-sdk/types': 3.974.2
-      '@aws-sdk/xml-builder': 3.972.37
-      '@aws/lambda-invoke-store': 0.3.0
-      '@smithy/core': 3.31.0
-      '@smithy/signature-v4': 5.6.11
-      '@smithy/types': 4.16.1
-      bowser: 2.11.0
       tslib: 2.8.1
 
   '@aws-sdk/core@3.977.4':
@@ -2252,7 +2222,7 @@ snapshots:
 
   '@aws-sdk/util-format-url@3.972.29':
     dependencies:
-      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/core': 3.977.4
       tslib: 2.8.1
 
   '@aws-sdk/util-utf8-browser@3.259.0':
@@ -2273,7 +2243,7 @@ snapshots:
       '@smithy/invalid-dependency': 4.4.6
       '@smithy/node-config-provider': 4.5.6
       '@smithy/protocol-http': 5.5.6
-      '@smithy/signature-v4': 5.6.11
+      '@smithy/signature-v4': 5.6.12
       '@smithy/types': 4.16.1
 
   '@aws/lambda-invoke-store@0.3.0': {}
@@ -2306,7 +2276,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@azure/ai-projects@2.3.1(@aws-sdk/credential-provider-node@3.972.76)(@smithy/hash-node@4.4.6)(@smithy/signature-v4@5.6.11)(ws@8.21.0)(zod@4.4.3)':
+  '@azure/ai-projects@2.3.1(@aws-sdk/credential-provider-node@3.972.76)(@smithy/hash-node@4.4.6)(@smithy/signature-v4@5.6.12)(ws@8.21.0)(zod@4.4.3)':
     dependencies:
       '@azure-rest/core-client': 2.3.4
       '@azure/abort-controller': 2.1.2
@@ -2320,7 +2290,7 @@ snapshots:
       '@azure/logger': 1.1.4
       '@azure/storage-blob': 12.27.0
       '@opentelemetry/api': 1.9.1
-      openai: 6.49.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/hash-node@4.4.6)(@smithy/signature-v4@5.6.11)(ws@8.21.0)(zod@4.4.3)
+      openai: 6.49.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/hash-node@4.4.6)(@smithy/signature-v4@5.6.12)(ws@8.21.0)(zod@4.4.3)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@aws-sdk/credential-provider-node'
@@ -2669,12 +2639,7 @@ snapshots:
 
   '@smithy/config-resolver@4.6.6':
     dependencies:
-      '@smithy/core': 3.31.0
-      tslib: 2.8.1
-
-  '@smithy/core@3.31.0':
-    dependencies:
-      '@smithy/types': 4.16.1
+      '@smithy/core': 3.31.1
       tslib: 2.8.1
 
   '@smithy/core@3.31.1':
@@ -2715,12 +2680,6 @@ snapshots:
       '@smithy/util-base64': 2.3.0
       tslib: 2.8.1
 
-  '@smithy/fetch-http-handler@5.6.12':
-    dependencies:
-      '@smithy/core': 3.31.0
-      '@smithy/types': 4.16.1
-      tslib: 2.8.1
-
   '@smithy/fetch-http-handler@5.6.13':
     dependencies:
       '@smithy/core': 3.31.1
@@ -2729,12 +2688,12 @@ snapshots:
 
   '@smithy/hash-node@4.4.6':
     dependencies:
-      '@smithy/core': 3.31.0
+      '@smithy/core': 3.31.1
       tslib: 2.8.1
 
   '@smithy/invalid-dependency@4.4.6':
     dependencies:
-      '@smithy/core': 3.31.0
+      '@smithy/core': 3.31.1
       tslib: 2.8.1
 
   '@smithy/is-array-buffer@2.2.0':
@@ -2774,7 +2733,7 @@ snapshots:
 
   '@smithy/node-config-provider@4.5.6':
     dependencies:
-      '@smithy/core': 3.31.0
+      '@smithy/core': 3.31.1
       tslib: 2.8.1
 
   '@smithy/node-http-handler@2.5.0':
@@ -2803,7 +2762,7 @@ snapshots:
 
   '@smithy/protocol-http@5.5.6':
     dependencies:
-      '@smithy/core': 3.31.0
+      '@smithy/core': 3.31.1
       tslib: 2.8.1
 
   '@smithy/querystring-builder@2.2.0':
@@ -2830,12 +2789,6 @@ snapshots:
       '@smithy/util-middleware': 3.0.11
       '@smithy/util-uri-escape': 3.0.0
       '@smithy/util-utf8': 3.0.0
-      tslib: 2.8.1
-
-  '@smithy/signature-v4@5.6.11':
-    dependencies:
-      '@smithy/core': 3.31.0
-      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/signature-v4@5.6.12':
@@ -3528,11 +3481,11 @@ snapshots:
       is-inside-container: 1.0.0
       is-wsl: 3.1.0
 
-  openai@6.49.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/hash-node@4.4.6)(@smithy/signature-v4@5.6.11)(ws@8.21.0)(zod@4.4.3):
+  openai@6.49.0(@aws-sdk/credential-provider-node@3.972.76)(@smithy/hash-node@4.4.6)(@smithy/signature-v4@5.6.12)(ws@8.21.0)(zod@4.4.3):
     optionalDependencies:
       '@aws-sdk/credential-provider-node': 3.972.76
       '@smithy/hash-node': 4.4.6
-      '@smithy/signature-v4': 5.6.11
+      '@smithy/signature-v4': 5.6.12
       ws: 8.21.0
       zod: 4.4.3
 


### PR DESCRIPTION
## Summary

- Represents provider reasoning as first-class `thoughts` results in completion and streaming APIs while keeping answer text and structured output separate.
- Preserves native reasoning state, signatures, tool calls, and replay metadata across Anthropic, OpenAI Responses and Chat Completions, OpenAI-compatible, Mistral, Gemini/Vertex, and Bedrock paths.
- Keeps replay and pruning read-only with respect to caller-owned canonical provider history.
- Adds provider cache and reasoning options without changing existing defaults; explicit per-call options continue to win.
- Preserves the existing Mistral driver-level `defaultMaxTokens` fallback, with explicit per-call `max_tokens` taking precedence.
- Adds regression coverage for streaming coalescence, native replay, pruning, signed reasoning, compatibility parsing, and provider-specific options.

## Compatibility

Existing text and structured-result consumers continue to receive answer content without thought results. Native provider conversation state remains available for replay, and constructor-level/provider defaults retain their previous behavior unless explicitly overridden.

## Test Plan

- `pnpm lint`
- `pnpm typecheck:test`
- `pnpm build`
- `pnpm test` — 8 tasks passed; drivers: 49 files passed, 1 skipped; 551 tests passed, 21 skipped
- Focused Mistral transport tests — 8/8 passed
