### PR TITLE
fix(drivers): avoid mislabeling orphaned tool calls

### DIFF
--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -2156,12 +2156,12 @@ function stripClaudeCachePointsFromTools(
 /**
  * Fix orphaned toolUse blocks in the conversation.
  *
- * When an agent is stopped mid-tool-execution, the assistant message contains toolUse blocks
- * but no corresponding toolResult was added. The AWS Converse API requires that every toolUse
+ * Retries, conversation compaction, or cancellation may leave assistant toolUse blocks
+ * without a corresponding toolResult. The AWS Converse API requires that every toolUse
  * must be followed by a toolResult in the next user message.
  *
- * This function detects such cases and injects synthetic toolResult blocks indicating
- * the tools were interrupted, allowing the conversation to continue.
+ * This function detects such cases and injects neutral synthetic toolResult blocks,
+ * allowing the conversation to continue without guessing why the result is missing.
  */
 export function fixOrphanedToolUse(messages: Message[]): Message[] {
     if (messages.length < 2) return messages;
@@ -2208,7 +2208,7 @@ export function fixOrphanedToolUse(messages: Message[]): Message[] {
                                 toolUseId: tu.toolUseId,
                                 content: [
                                     {
-                                        text: `[Tool interrupted: The user stopped the operation before "${tu.name}" could execute.]`,
+                                        text: `[Tool result unavailable: no result was recorded for "${tu.name}". Do not assume whether it ran; retry only if the operation is still needed and safe.]`,
                                     },
                                 ],
                             },
@@ -2231,7 +2231,7 @@ export function fixOrphanedToolUse(messages: Message[]): Message[] {
                             toolUseId: tu.toolUseId,
                             content: [
                                 {
-                                    text: `[Tool interrupted: The user stopped the operation before "${tu.name}" could execute.]`,
+                                    text: `[Tool result unavailable: no result was recorded for "${tu.name}". Do not assume whether it ran; retry only if the operation is still needed and safe.]`,
                                 },
                             ],
                         },

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -185,7 +185,7 @@ export class OpenAIResponsesProtocol {
         }
 
         // Include conversation history (same as non-streaming)
-        // Fix orphaned function_call items (can occur when agent is stopped mid-tool-execution)
+        // Fix orphaned function_call items (for example after retries, compaction, or cancellation)
         let conversation = fixOrphanedToolResults(fixOrphanedToolUse(updateConversation(options.conversation, prompt)));
 
         const toolDefs = getToolDefinitions(options.tools);
@@ -270,7 +270,7 @@ export class OpenAIResponsesProtocol {
         const toolDefs = getToolDefinitions(options.tools);
         const useTools: boolean = toolDefs ? supportsToolUse(options.model, driver.provider) : false;
 
-        // Fix orphaned function_call items (can occur when agent is stopped mid-tool-execution)
+        // Fix orphaned function_call items (for example after retries, compaction, or cancellation)
         let conversation = fixOrphanedToolResults(fixOrphanedToolUse(updateConversation(options.conversation, prompt)));
 
         // When no tools are provided but conversation contains function_call/function_call_output
@@ -1184,12 +1184,12 @@ function responseFinishReason(
 /**
  * Fix orphaned function_call items in the OpenAI Responses API conversation.
  *
- * When an agent is stopped mid-tool-execution, the conversation may contain
- * function_call items without matching function_call_output items. The OpenAI
+ * Retries, conversation compaction, or cancellation may leave the conversation with
+ * function_call items that have no matching function_call_output items. The OpenAI
  * Responses API requires every function_call to have a matching function_call_output.
  *
- * This function detects such cases and injects synthetic function_call_output items
- * indicating the tools were interrupted, allowing the conversation to continue.
+ * This function detects such cases and injects neutral synthetic function_call_output
+ * items, allowing the conversation to continue without guessing why the result is missing.
  */
 export function fixOrphanedToolUse(items: ResponseInputItem[]): ResponseInputItem[] {
     if (items.length < 2) return items;
@@ -1223,7 +1223,7 @@ export function fixOrphanedToolUse(items: ResponseInputItem[]): ResponseInputIte
                     result.push({
                         type: 'function_call_output',
                         call_id: callId,
-                        output: `[Tool interrupted: The user stopped the operation before "${toolName}" could execute.]`,
+                        output: `[Tool result unavailable: no result was recorded for "${toolName}". Do not assume whether it ran; retry only if the operation is still needed and safe.]`,
                     });
                 }
                 pendingCalls.clear();
@@ -1238,7 +1238,7 @@ export function fixOrphanedToolUse(items: ResponseInputItem[]): ResponseInputIte
             result.push({
                 type: 'function_call_output',
                 call_id: callId,
-                output: `[Tool interrupted: The user stopped the operation before "${toolName}" could execute.]`,
+                output: `[Tool result unavailable: no result was recorded for "${toolName}". Do not assume whether it ran; retry only if the operation is still needed and safe.]`,
             });
         }
     }

--- a/drivers/src/openai/openai_chat_completions.test.ts
+++ b/drivers/src/openai/openai_chat_completions.test.ts
@@ -499,7 +499,7 @@ describe('OpenAIChatCompletionsProtocol', () => {
         expect(completion.finish_reason).toBe('tool_use');
     });
 
-    it('injects synthetic tool results for interrupted prior Chat Completions tool calls', async () => {
+    it('injects neutral synthetic results for orphaned prior Chat Completions tool calls', async () => {
         const model = new TestOpenAIChatCompletionsProtocol({
             id: 'chatcmpl-1',
             object: 'chat.completion',
@@ -534,7 +534,8 @@ describe('OpenAIChatCompletionsProtocol', () => {
             {
                 role: 'tool',
                 tool_call_id: 'call_1',
-                content: '[Tool interrupted: The user stopped the operation before "lookup" could execute.]',
+                content:
+                    '[Tool result unavailable: no result was recorded for "lookup". Do not assume whether it ran; retry only if the operation is still needed and safe.]',
             },
             { role: 'user', content: 'Hello' },
         ]);

--- a/drivers/src/openai/openai_chat_completions.ts
+++ b/drivers/src/openai/openai_chat_completions.ts
@@ -324,18 +324,18 @@ function normalizeOpenAIChatCompletionsFinishReason(
     return reason || undefined;
 }
 
-function toolCallInterruptedMessage(id: string, toolName: string): OpenAIChatCompletionsMessage {
+function toolResultUnavailableMessage(id: string, toolName: string): OpenAIChatCompletionsMessage {
     return {
         role: 'tool',
         tool_call_id: id,
-        content: `[Tool interrupted: The user stopped the operation before "${toolName}" could execute.]`,
+        content: `[Tool result unavailable: no result was recorded for "${toolName}". Do not assume whether it ran; retry only if the operation is still needed and safe.]`,
     };
 }
 
 /**
  * Chat Completions requires every assistant tool call to be followed by a tool
- * response. If a run is stopped mid-tool-execution, synthesize a result so the
- * next request can continue instead of failing provider-side validation.
+ * response. If retries, compaction, or cancellation leave a call unanswered, synthesize
+ * a neutral result so the next request can continue instead of failing provider-side validation.
  */
 export function fixOrphanedOpenAIChatCompletionsToolUse(
     messages: OpenAIChatCompletionsMessage[],
@@ -370,7 +370,7 @@ export function fixOrphanedOpenAIChatCompletionsToolUse(
 
         if (pendingCalls.size > 0) {
             for (const [callId, toolName] of pendingCalls) {
-                result.push(toolCallInterruptedMessage(callId, toolName));
+                result.push(toolResultUnavailableMessage(callId, toolName));
             }
             pendingCalls.clear();
         }
@@ -379,7 +379,7 @@ export function fixOrphanedOpenAIChatCompletionsToolUse(
 
     if (pendingCalls.size > 0) {
         for (const [callId, toolName] of pendingCalls) {
-            result.push(toolCallInterruptedMessage(callId, toolName));
+            result.push(toolResultUnavailableMessage(callId, toolName));
         }
     }
 

--- a/drivers/src/shared/claude-messages.ts
+++ b/drivers/src/shared/claude-messages.ts
@@ -483,7 +483,7 @@ export function fixOrphanedToolUse(messages: MessageParam[]): MessageParam[] {
                         const syntheticResults: ToolResultBlockParam[] = orphaned.map((block) => ({
                             type: 'tool_result',
                             tool_use_id: block.id,
-                            content: `[Tool interrupted: The user stopped the operation before "${block.name}" could execute.]`,
+                            content: `[Tool result unavailable: no result was recorded for "${block.name}". Do not assume whether it ran; retry only if the operation is still needed and safe.]`,
                         }));
                         messages[i + 1] = { ...nextMessage, content: [...syntheticResults, ...nextMessage.content] };
                     }
@@ -491,7 +491,7 @@ export function fixOrphanedToolUse(messages: MessageParam[]): MessageParam[] {
                     const syntheticResults: ToolResultBlockParam[] = toolUseBlocks.map((block) => ({
                         type: 'tool_result',
                         tool_use_id: block.id,
-                        content: `[Tool interrupted: The user stopped the operation before "${block.name}" could execute.]`,
+                        content: `[Tool result unavailable: no result was recorded for "${block.name}". Do not assume whether it ran; retry only if the operation is still needed and safe.]`,
                     }));
                     const textContent: TextBlockParam =
                         typeof nextMessage.content === 'string'

--- a/drivers/test/orphaned-tool-use.test.ts
+++ b/drivers/test/orphaned-tool-use.test.ts
@@ -1,11 +1,11 @@
 /**
  * Unit tests for the fixOrphanedToolUse functions in Claude, Bedrock, and OpenAI drivers.
  *
- * These functions handle the case where an agent is stopped mid-tool-execution,
- * leaving tool_use/function_call blocks without corresponding tool_result/function_call_output blocks.
+ * These functions handle retries, conversation compaction, or cancellation leaving
+ * tool_use/function_call blocks without corresponding tool_result/function_call_output blocks.
  * The LLM APIs require every tool call to have a matching result.
  *
- * Bug context: When user stops an agent while tools are being executed,
+ * Bug context: When execution ends without recording one or more tool results,
  * the conversation has orphaned tool calls. Sending a new message
  * without fixing this causes API errors like:
  * - Anthropic: "tool_use ids were found without tool_result blocks immediately after"
@@ -97,7 +97,8 @@ describe('fixOrphanedToolUse - Claude', () => {
         expect(userContent).toHaveLength(2);
         expect(userContent[0].type).toBe('tool_result');
         expect(userContent[0].tool_use_id).toBe('tool_1');
-        expect(userContent[0].content).toContain('Tool interrupted');
+        expect(userContent[0].content).toContain('Tool result unavailable');
+        expect(userContent[0].content).not.toContain('user stopped');
         expect(userContent[0].content).toContain('search');
         expect(userContent[1].type).toBe('text');
         expect(userContent[1].text).toBe('Actually, stop that and do something else');
@@ -225,11 +226,13 @@ describe('fixOrphanedToolUse - Claude', () => {
 
         expect(lastUserContent[0].type).toBe('tool_result');
         expect(lastUserContent[0].tool_use_id).toBe('toolu_search');
-        expect(lastUserContent[0].content).toContain('user stopped');
+        expect(lastUserContent[0].content).toContain('Tool result unavailable');
+        expect(lastUserContent[0].content).not.toContain('user stopped');
 
         expect(lastUserContent[1].type).toBe('tool_result');
         expect(lastUserContent[1].tool_use_id).toBe('toolu_analyze');
-        expect(lastUserContent[1].content).toContain('user stopped');
+        expect(lastUserContent[1].content).toContain('Tool result unavailable');
+        expect(lastUserContent[1].content).not.toContain('user stopped');
 
         expect(lastUserContent[2].type).toBe('text');
     });
@@ -396,7 +399,8 @@ describe('fixOrphanedToolUse - Bedrock', () => {
         expect(userContent).toHaveLength(2);
         expect(userContent[0].toolResult).toBeDefined();
         expect(userContent[0].toolResult?.toolUseId).toBe('tool_1');
-        expect(userContent[0].toolResult?.content?.[0].text).toContain('Tool interrupted');
+        expect(userContent[0].toolResult?.content?.[0].text).toContain('Tool result unavailable');
+        expect(userContent[0].toolResult?.content?.[0].text).not.toContain('user stopped');
         expect(userContent[0].toolResult?.content?.[0].text).toContain('search');
         expect(userContent[1].text).toBe('Actually, stop that and do something else');
     });
@@ -493,10 +497,12 @@ describe('fixOrphanedToolUse - Bedrock', () => {
         expect(lastUserContent).toHaveLength(3); // 2 synthetic + 1 text
 
         expect(lastUserContent[0].toolResult?.toolUseId).toBe('toolu_search');
-        expect(lastUserContent[0].toolResult?.content?.[0].text).toContain('user stopped');
+        expect(lastUserContent[0].toolResult?.content?.[0].text).toContain('Tool result unavailable');
+        expect(lastUserContent[0].toolResult?.content?.[0].text).not.toContain('user stopped');
 
         expect(lastUserContent[1].toolResult?.toolUseId).toBe('toolu_analyze');
-        expect(lastUserContent[1].toolResult?.content?.[0].text).toContain('user stopped');
+        expect(lastUserContent[1].toolResult?.content?.[0].text).toContain('Tool result unavailable');
+        expect(lastUserContent[1].toolResult?.content?.[0].text).not.toContain('user stopped');
 
         expect(lastUserContent[2].text).toBe('Never mind, do something else instead');
     });
@@ -622,7 +628,8 @@ describe('fixOrphanedToolUse - OpenAI', () => {
         const synthetic = result[2] as OpenAI.Responses.ResponseInputItem.FunctionCallOutput;
         expect(synthetic.type).toBe('function_call_output');
         expect(synthetic.call_id).toBe('fc_1');
-        expect(synthetic.output).toContain('Tool interrupted');
+        expect(synthetic.output).toContain('Tool result unavailable');
+        expect(synthetic.output).not.toContain('user stopped');
         expect(synthetic.output).toContain('ask_user');
 
         expect(result[3]).toEqual({ role: 'user', content: 'Actually, stop that' });
@@ -677,7 +684,8 @@ describe('fixOrphanedToolUse - OpenAI', () => {
         // Synthetic output for fc_2 injected before user message
         expect((result[3] as unknown as Tree).type).toBe('function_call_output');
         expect((result[3] as unknown as Tree).call_id).toBe('fc_2');
-        expect((result[3] as unknown as Tree).output).toContain('Tool interrupted');
+        expect((result[3] as unknown as Tree).output).toContain('Tool result unavailable');
+        expect((result[3] as unknown as Tree).output).not.toContain('user stopped');
 
         expect((result[4] as unknown as Tree).role).toBe('user');
     });
@@ -729,7 +737,8 @@ describe('fixOrphanedToolUse - OpenAI', () => {
         const synthetic = result[4] as OpenAI.Responses.ResponseInputItem.FunctionCallOutput;
         expect(synthetic.type).toBe('function_call_output');
         expect(synthetic.call_id).toBe('fc_ask_user');
-        expect(synthetic.output).toContain('Tool interrupted');
+        expect(synthetic.output).toContain('Tool result unavailable');
+        expect(synthetic.output).not.toContain('user stopped');
         expect(synthetic.output).toContain('ask_user');
 
         // Last user message is preserved


### PR DESCRIPTION
Use provider-neutral synthetic tool results when a prior tool call has no recorded result. This avoids falsely telling models that the user stopped the operation, covers retry and compaction gaps, and warns against unsafe duplicate retries.\n\nVerified with the full llumiverse workspace build, driver lint and type checks, formatting checks, and 59 focused tests across Claude, Bedrock, OpenAI Responses, and OpenAI Chat Completions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and documentation-only behavior in conversation sanitization; no auth or execution path changes, with broad test updates locking the new strings.
> 
> **Overview**
> **Orphaned tool-call repair** now uses the same neutral placeholder everywhere a provider requires a matching tool result: *tool result unavailable*, with guidance not to assume execution and to retry only when still needed and safe. The previous copy implied the **user interrupted** the run, which was wrong for retries, compaction, and other gaps.
> 
> The change is applied in **Bedrock Converse** (`fixOrphanedToolUse`), **OpenAI Responses** (`fixOrphanedToolUse`), **OpenAI Chat Completions** (`toolResultUnavailableMessage` / `fixOrphanedOpenAIChatCompletionsToolUse`), and **shared Claude messages** (`claude-messages.ts`). Comments and tests were updated to describe retries, compaction, and cancellation—not only mid-run stops.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f38eb84afe492769e03f781c8febda93c39b33a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->