### PR TITLE
chore: run CI on pull requests

### DIFF
--- a/.github/workflows/backport-automerge.yaml
+++ b/.github/workflows/backport-automerge.yaml
@@ -44,7 +44,7 @@ jobs:
         )
       }}
     if: |
-      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.event == 'pull_request' &&
       startsWith(github.event.workflow_run.head_branch, 'backport-')
     runs-on: ubuntu-latest
     environment: renovate-automerge
@@ -171,14 +171,12 @@ jobs:
           )
 
           for workflow in "${required_workflows[@]}"; do
-            runs_json="$(gh run list \
-              --repo "$REPO" \
-              --workflow "$workflow" \
-              --branch "$HEAD_BRANCH" \
-              --commit "$HEAD_SHA" \
-              --json databaseId,status,conclusion,event,headSha,url \
-              --limit 20)"
-            run_json="$(jq -c --arg sha "$HEAD_SHA" '[.[] | select(.headSha == $sha and .event == "push")] | sort_by(.databaseId) | last // empty' <<< "$runs_json")"
+            runs_json="$(gh api --method GET \
+              "repos/${REPO}/actions/workflows/${workflow}/runs" \
+              -f branch="$HEAD_BRANCH" -f event=pull_request -f head_sha="$HEAD_SHA" -f per_page=20)"
+            run_json="$(jq -c --arg sha "$HEAD_SHA" --argjson pr "$pr_number" \
+              '[.workflow_runs[] | select(.head_sha == $sha and any(.pull_requests[]?; .number == $pr))] | sort_by(.id) | last // empty' \
+              <<< "$runs_json")"
 
             if [[ -z "$run_json" ]]; then
               echo "Waiting for $workflow to run for $HEAD_SHA."
@@ -187,7 +185,7 @@ jobs:
 
             status="$(jq -r '.status' <<< "$run_json")"
             conclusion="$(jq -r '.conclusion // ""' <<< "$run_json")"
-            url="$(jq -r '.url' <<< "$run_json")"
+            url="$(jq -r '.html_url' <<< "$run_json")"
 
             if [[ "$status" != "completed" ]]; then
               echo "Waiting for $workflow to complete for $HEAD_SHA: $url"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,7 +2,19 @@ name: (test) Build and test
 
 on:
   push:
+    branches:
+      - main
+      - preview
+      - "release/**"
+      - "production/**"
+      - "hotfix**"
+      - "repo-dispatch**"
+  pull_request:
+    types: [opened, reopened, synchronize]
   workflow_dispatch:
+
+env:
+  COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
 # Cancel superseded runs on the same branch (latest push wins).
 concurrency:
@@ -16,6 +28,7 @@ jobs:
   build-and-test:
     name: Build and test
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     # Scopes provider API keys (OPENAI, MISTRAL, GROQ, TOGETHER, etc.) to a
     # dedicated environment (zizmor: secrets-outside-env).
     environment: build
@@ -29,6 +42,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ env.COMMIT_SHA }}
           persist-credentials: false
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -85,7 +99,7 @@ jobs:
   notify-repo-composableai:
     name: Notify vertesia/composableai of new commit
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/preview' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/heads/repo-dispatch')
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/preview' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/heads/repo-dispatch'))
     needs:
       - build-and-test
     # Scopes the cross-repo dispatch token to a dedicated environment.

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,7 +16,7 @@ on:
 env:
   COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
-# Cancel superseded runs on the same branch (latest push wins).
+# Cancel superseded runs for the same event ref (latest push or PR update wins).
 concurrency:
   group: build-and-test-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,19 @@ name: (lint) Lint codebase
 
 on:
   push:
+    branches:
+      - main
+      - preview
+      - "release/**"
+      - "production/**"
+      - "hotfix**"
+      - "repo-dispatch**"
+  pull_request:
+    types: [opened, reopened, synchronize]
   workflow_dispatch:
+
+env:
+  COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
 # Cancel superseded runs on the same branch (latest push wins).
 concurrency:
@@ -20,6 +32,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ env.COMMIT_SHA }}
           persist-credentials: false
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ on:
 env:
   COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
-# Cancel superseded runs on the same branch (latest push wins).
+# Cancel superseded runs for the same event ref (latest push or PR update wins).
 concurrency:
   group: lint-${{ github.ref }}
   cancel-in-progress: true
@@ -32,6 +32,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ env.COMMIT_SHA }}
           persist-credentials: false
       - name: Install pnpm

--- a/.github/workflows/release-automerge.yaml
+++ b/.github/workflows/release-automerge.yaml
@@ -33,7 +33,7 @@ jobs:
   approve-and-merge:
     name: Approve and merge eligible release-cut bump PR
     if: |
-      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.event == 'pull_request' &&
       startsWith(github.event.workflow_run.head_branch, 'release-bump-')
     runs-on: ubuntu-latest
     environment: renovate-automerge
@@ -173,14 +173,12 @@ jobs:
           )
 
           for workflow in "${required_workflows[@]}"; do
-            runs_json="$(gh run list \
-              --repo "$REPO" \
-              --workflow "$workflow" \
-              --branch "$HEAD_BRANCH" \
-              --commit "$HEAD_SHA" \
-              --json databaseId,status,conclusion,event,headSha,url \
-              --limit 20)"
-            run_json="$(jq -c --arg sha "$HEAD_SHA" '[.[] | select(.headSha == $sha and .event == "push")] | sort_by(.databaseId) | last // empty' <<< "$runs_json")"
+            runs_json="$(gh api --method GET \
+              "repos/${REPO}/actions/workflows/${workflow}/runs" \
+              -f branch="$HEAD_BRANCH" -f event=pull_request -f head_sha="$HEAD_SHA" -f per_page=20)"
+            run_json="$(jq -c --arg sha "$HEAD_SHA" --argjson pr "$pr_number" \
+              '[.workflow_runs[] | select(.head_sha == $sha and any(.pull_requests[]?; .number == $pr))] | sort_by(.id) | last // empty' \
+              <<< "$runs_json")"
 
             if [[ -z "$run_json" ]]; then
               echo "Waiting for $workflow to run for $HEAD_SHA."
@@ -189,7 +187,7 @@ jobs:
 
             status="$(jq -r '.status' <<< "$run_json")"
             conclusion="$(jq -r '.conclusion // ""' <<< "$run_json")"
-            url="$(jq -r '.url' <<< "$run_json")"
+            url="$(jq -r '.html_url' <<< "$run_json")"
 
             if [[ "$status" != "completed" ]]; then
               echo "Waiting for $workflow to complete for $HEAD_SHA: $url"

--- a/.github/workflows/renovate-automerge.yaml
+++ b/.github/workflows/renovate-automerge.yaml
@@ -20,7 +20,7 @@ jobs:
   approve-and-merge:
     name: Approve and merge eligible Renovate PR
     if: |
-      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.event == 'pull_request' &&
       startsWith(github.event.workflow_run.head_branch, 'renovate/')
     runs-on: ubuntu-latest
     environment: renovate-automerge
@@ -175,14 +175,12 @@ jobs:
           )
 
           for workflow in "${required_workflows[@]}"; do
-            runs_json="$(gh run list \
-              --repo "$REPO" \
-              --workflow "$workflow" \
-              --branch "$HEAD_BRANCH" \
-              --commit "$HEAD_SHA" \
-              --json databaseId,status,conclusion,event,headSha,url \
-              --limit 20)"
-            run_json="$(jq -c --arg sha "$HEAD_SHA" '[.[] | select(.headSha == $sha and .event == "push")] | sort_by(.databaseId) | last // empty' <<< "$runs_json")"
+            runs_json="$(gh api --method GET \
+              "repos/${REPO}/actions/workflows/${workflow}/runs" \
+              -f branch="$HEAD_BRANCH" -f event=pull_request -f head_sha="$HEAD_SHA" -f per_page=20)"
+            run_json="$(jq -c --arg sha "$HEAD_SHA" --argjson pr "$pr_number" \
+              '[.workflow_runs[] | select(.head_sha == $sha and any(.pull_requests[]?; .number == $pr))] | sort_by(.id) | last // empty' \
+              <<< "$runs_json")"
 
             if [[ -z "$run_json" ]]; then
               echo "Waiting for $workflow to run for $HEAD_SHA."
@@ -191,7 +189,7 @@ jobs:
 
             status="$(jq -r '.status' <<< "$run_json")"
             conclusion="$(jq -r '.conclusion // ""' <<< "$run_json")"
-            url="$(jq -r '.url' <<< "$run_json")"
+            url="$(jq -r '.html_url' <<< "$run_json")"
 
             if [[ "$status" != "completed" ]]; then
               echo "Waiting for $workflow to complete for $HEAD_SHA: $url"


### PR DESCRIPTION
## Summary
- Run build and lint CI directly for opened, reopened, and synchronized pull requests while retaining protected-branch push coverage.
- Check out the immutable pull-request head commit and keep provider-backed builds unavailable to forks.
- Make Renovate, release, and backport automerge require pull-request workflow runs pinned to the exact head SHA.
- Keep cross-repository notifications limited to push events.

## Test Plan
- [x] actionlint -shellcheck= on all changed workflows
- [x] git diff origin/main..HEAD --check
- [x] Verified workflow-run queries filter by immutable head SHA and PR number