### PR TITLE
chore(deps, security): harden CI audits

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -52,9 +52,26 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
-          cache: "pnpm"
+          package-manager-cache: false
+      - name: Locate pnpm store
+        id: pnpm-store
+        shell: bash
+        run: echo "path=$(pnpm store path --silent)" >> "${GITHUB_OUTPUT}"
+      - name: Restore pnpm store cache
+        id: pnpm-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: pnpm-store-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: pnpm-store-${{ runner.os }}-${{ runner.arch }}-
       - name: Install workspace dependencies
         run: pnpm install
+      - name: Save pnpm store cache
+        if: github.event_name == 'push' && steps.pnpm-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ steps.pnpm-cache.outputs.cache-primary-key }}
       - name: Build workspace
         run: pnpm build
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,10 +43,27 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24.18.0
-          cache: pnpm
+          package-manager-cache: false
+      - name: Locate pnpm store
+        id: pnpm-store
+        shell: bash
+        run: echo "path=$(pnpm store path --silent)" >> "${GITHUB_OUTPUT}"
+      - name: Restore pnpm store cache
+        id: pnpm-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: pnpm-store-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: pnpm-store-${{ runner.os }}-${{ runner.arch }}-
       - name: Validate Renovate config
         run: pnpm run ci:renovate
       - name: Install workspace dependencies
         run: pnpm install --frozen-lockfile
+      - name: Save pnpm store cache
+        if: github.event_name == 'push' && steps.pnpm-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ steps.pnpm-cache.outputs.cache-primary-key }}
       - name: Check codebase
         run: pnpm check

--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -66,9 +66,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: "pnpm"
 
-      # Ensure npm 11.5.1 or later is installed
-      - name: Update npm
-        run: npm install -g npm@latest
+      # Node.js 24 ships with npm 11.5.1 or later, as required for trusted publishing.
       - name: Verify npm version
         run: npm --version
 

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Run zizmor
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: uvx zizmor@1.24.1 --no-exit-codes --persona=auditor --format=sarif .github > results.sarif
+        run: uvx zizmor@1.29.0 --no-exit-codes --persona=auditor --format=sarif .github > results.sarif
 
       - name: Upload SARIF
         if: ${{ !cancelled() }}

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -3,6 +3,17 @@
   // Default label applied to every Renovate PR (matches studio/composableai).
   // The automerge workflow's eligibility gate requires this label.
   "labels": ["dependencies"],
+  "customManagers": [
+    {
+      "description": "Update the zizmor version pinned in its GitHub Actions workflow",
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/zizmor\\.ya?ml$/"],
+      "matchStrings": ["uvx\\s+zizmor@(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)"],
+      "depNameTemplate": "zizmor",
+      "datasourceTemplate": "pypi",
+      "versioningTemplate": "pep440"
+    }
+  ],
   // Bypass the 7-day minimum release age for security fixes.
   "vulnerabilityAlerts": {
     "enabled": true,


### PR DESCRIPTION
## Summary
- upgrade zizmor from 1.24.1 to 1.29.0 and let Renovate track the PyPI release
- restore the pnpm store for every CI run while limiting cache writes to trusted push events
- remove the ad-hoc global npm upgrade from publishing and use the npm version bundled with Node.js 24

## Test Plan
- [x] `pnpm audit`
- [x] `pnpm lint:actions`
- [x] `pnpm run ci:renovate`
- [x] `uvx zizmor@1.29.0 --persona=auditor .github`
