### PR TITLE
test(core): add EventStream unit tests and remove dead code

### DIFF
--- a/core/src/async.ts
+++ b/core/src/async.ts
@@ -15,7 +15,8 @@ export function oneAsyncIterator<T>(value: T): AsyncIterable<T> {
 }
 
 /**
- * Given a ReadableStream of server sent events, tran
+ * Given a ReadableStream of server-sent events, transform each event's data
+ * payload into a {@link CompletionChunkObject} and return the resulting stream.
  */
 export function transformSSEStream(
     stream: ReadableStream<ServerSentEvent>,
@@ -116,27 +117,3 @@ export async function* transformAsyncIterator<T, V>(
         yield transform(value);
     }
 }
-
-//TODO move in a test file
-// const max = 10; let cnt = 0;
-// function feedStream(stream: EventStream<string>) {
-//     setTimeout(() => {
-//         cnt++;
-//         console.log('push: ', cnt, max);
-//         stream.push('event ' + cnt);
-//         if (cnt < max) {
-//             console.log('next: ', cnt, max);
-//             setTimeout(() => feedStream(stream), 1000);
-//         } else {
-//             console.log('end of stream');
-//             stream.close();
-//         }
-//     }, 1000);
-// }
-
-// const stream = new EventStream<string>();
-// feedStream(stream);
-
-// for await (const chunk of stream) {
-//     console.log('++++chunk:', chunk);
-// }

--- a/core/test/event-stream.test.ts
+++ b/core/test/event-stream.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import { EventStream } from '../src/async.js';
+
+async function collect<T>(iter: AsyncIterable<T>): Promise<T[]> {
+    const items: T[] = [];
+    for await (const item of iter) {
+        items.push(item);
+    }
+    return items;
+}
+
+describe('EventStream', () => {
+    it('yields events pushed before iteration starts', async () => {
+        const stream = new EventStream<string>();
+        stream.push('a');
+        stream.push('b');
+        stream.close();
+
+        expect(await collect(stream)).toEqual(['a', 'b']);
+    });
+
+    it('yields events pushed during iteration', async () => {
+        const stream = new EventStream<string>();
+
+        const promise = collect(stream);
+
+        stream.push('x');
+        stream.push('y');
+        stream.close();
+
+        expect(await promise).toEqual(['x', 'y']);
+    });
+
+    it('returns empty for immediately closed stream', async () => {
+        const stream = new EventStream<number>();
+        stream.close();
+
+        expect(await collect(stream)).toEqual([]);
+    });
+
+    it('throws when pushing to a closed stream', () => {
+        const stream = new EventStream<string>();
+        stream.close();
+
+        expect(() => stream.push('late')).toThrow('Cannot push to a closed stream');
+    });
+
+    it('handles interleaved push and consume', async () => {
+        const stream = new EventStream<number>();
+        const results: number[] = [];
+
+        const done = (async () => {
+            for await (const n of stream) {
+                results.push(n);
+            }
+        })();
+
+        stream.push(1);
+        // Give the consumer a tick to process
+        await new Promise((r) => setTimeout(r, 0));
+        stream.push(2);
+        await new Promise((r) => setTimeout(r, 0));
+        stream.push(3);
+        stream.close();
+
+        await done;
+        expect(results).toEqual([1, 2, 3]);
+    });
+
+    it('supports early return from consumer', async () => {
+        const stream = new EventStream<string>();
+        stream.push('first');
+        stream.push('second');
+        stream.push('third');
+
+        const results: string[] = [];
+        for await (const item of stream) {
+            results.push(item);
+            if (item === 'second') break;
+        }
+
+        expect(results).toEqual(['first', 'second']);
+    });
+
+    it('works with typed payloads', async () => {
+        interface Chunk {
+            id: number;
+            text: string;
+        }
+
+        const stream = new EventStream<Chunk>();
+        stream.push({ id: 1, text: 'hello' });
+        stream.push({ id: 2, text: 'world' });
+        stream.close();
+
+        const items = await collect(stream);
+        expect(items).toEqual([
+            { id: 1, text: 'hello' },
+            { id: 2, text: 'world' },
+        ]);
+    });
+});


### PR DESCRIPTION
## Summary

- Add 7 unit tests for `EventStream` (zero coverage → full contract coverage)
- Remove stale commented-out ad-hoc test code from `core/src/async.ts` (tagged `//TODO move in a test file`)
- Fix a truncated JSDoc on `transformSSEStream`

## Why

`EventStream` is the async iterable primitive behind the streaming completion infrastructure (`CompletionStream`, driver streaming paths). It had no dedicated tests — the only verification was a commented-out `setTimeout` loop sitting in the production source file.

## Tests added

| Test | What it verifies |
|------|-----------------|
| `yields events pushed before iteration starts` | Queued delivery (push before consume) |
| `yields events pushed during iteration` | Demand-driven delivery (push while consuming) |
| `returns empty for immediately closed stream` | Zero-event close semantics |
| `throws when pushing to a closed stream` | Guard against post-close writes |
| `handles interleaved push and consume` | Real-world async interleaving |
| `supports early return from consumer` | `break`/`return` inside `for await` |
| `works with typed payloads` | Generic type parameter (`EventStream<T>`) |

## Validation

```
$ pnpm --filter @llumiverse/core exec vitest run test/event-stream.test.ts
 ✓ test/event-stream.test.ts (7 tests) 5ms
 Test Files  1 passed (1)
 Tests       7 passed (7)

$ pnpm --filter @llumiverse/core test
 Test Files  11 passed (11)
 Tests       154 passed (154)
```

Full existing test suite still passes.

Made with [Cursor](https://cursor.com)