### PR TITLE
fix: derive Bedrock Claude limits from model version and strip region prefixes

### DIFF
--- a/common/src/capability/bedrock-models.ts
+++ b/common/src/capability/bedrock-models.ts
@@ -1,3 +1,4 @@
+import { parseClaudeVersion } from '../options/version-parsing.js';
 import type { ModelCapabilities, ModelModalities } from '../types.js';
 
 export type BedrockEndpoint = 'runtime' | 'mantle';
@@ -23,11 +24,18 @@ function isFamilyVersionGte(model: string, family: string, targetMajor: number, 
     return major > targetMajor || (major === targetMajor && minor >= targetMinor);
 }
 
+/**
+ * Geographic prefix carried by cross-region inference IDs (`us.`, `eu.`, `apac.`, `us-gov.`, `global.`).
+ * No publisher segment collides with these, so the prefix can be stripped wherever it appears — not
+ * only inside an inference-profile ARN, since callers also pass the bare `us.<publisher>.<model>` ID.
+ */
+const GEO_PREFIX = /^(?:[a-z]{2}(?:-gov)?|apac|global)\./;
+
 export function normalizeBedrockModelId(model: string): string {
     const normalized = model.toLowerCase();
     const slash = normalized.lastIndexOf('/');
     const modelId = slash === -1 ? normalized : normalized.slice(slash + 1);
-    return normalized.includes('inference-profile/') ? modelId.replace(/^[^.]+\./, '') : modelId;
+    return modelId.replace(GEO_PREFIX, '');
 }
 
 function getModalities(model: string): Pick<BedrockModelKnowledge, 'input' | 'output'> {
@@ -94,28 +102,35 @@ function getLimits(model: string): Pick<BedrockModelKnowledge, 'context_window' 
         return { context_window: 300_000, max_output_tokens: 5_120 };
     }
     if (model.includes('anthropic.claude')) {
-        if (
-            includesAny(model, [
-                'claude-fable-5',
-                'claude-mythos',
-                'claude-sonnet-5',
-                'claude-opus-4-6',
-                'claude-opus-4-7',
-                'claude-opus-4-8',
-            ])
-        ) {
-            // Bedrock enforces an EXCLUSIVE 128K bound for this family: it rejects
-            // max_tokens >= 128000 with "Try again with a maximum tokens value that
-            // is lower than 128000" (same exclusive-bound quirk as Haiku 4.5 below).
-            return { context_window: 1_000_000, max_output_tokens: 127_999 };
+        // Version rules rather than an ID list, so a newly released variant inherits the limits of the
+        // newest understood generation instead of silently reporting no limits at all.
+        const claude = parseClaudeVersion(model);
+        if (claude) {
+            const atLeast = (major: number, minor: number) =>
+                claude.major > major || (claude.major === major && claude.minor >= minor);
+            if (atLeast(4, 7) || (claude.variant === 'opus' && atLeast(4, 6))) {
+                // Bedrock enforces an EXCLUSIVE 128K bound for this family: it rejects
+                // max_tokens >= 128000 with "Try again with a maximum tokens value that
+                // is lower than 128000" (same exclusive-bound quirk as Haiku 4.5 below).
+                return { context_window: 1_000_000, max_output_tokens: 127_999 };
+            }
+            if (claude.variant === 'sonnet' && atLeast(4, 6)) {
+                return { context_window: 1_000_000, max_output_tokens: 65_536 };
+            }
+            if (atLeast(4, 5)) {
+                // Bedrock documents 64K for Haiku 4.5 but rejects max_tokens=64000; its bound is exclusive.
+                return {
+                    context_window: 200_000,
+                    max_output_tokens: claude.variant === 'haiku' ? 63_999 : 65_536,
+                };
+            }
+            if (atLeast(4, 0)) {
+                return {
+                    context_window: 200_000,
+                    max_output_tokens: claude.variant === 'opus' ? 32_000 : 65_536,
+                };
+            }
         }
-        if (model.includes('claude-sonnet-4-6')) return { context_window: 1_000_000, max_output_tokens: 65_536 };
-        // Bedrock documents 64K for Haiku 4.5 but rejects max_tokens=64000; its upper bound is exclusive.
-        if (model.includes('claude-haiku-4-5')) return { context_window: 200_000, max_output_tokens: 63_999 };
-        if (includesAny(model, ['claude-opus-4-5', 'claude-sonnet-4'])) {
-            return { context_window: 200_000, max_output_tokens: 65_536 };
-        }
-        if (model.includes('claude-opus-4-1')) return { context_window: 200_000, max_output_tokens: 32_000 };
         if (model.includes('claude-3-5-haiku')) return { context_window: 200_000, max_output_tokens: 8_192 };
         if (model.includes('claude-3-haiku')) return { context_window: 200_000, max_output_tokens: 4_096 };
     }
@@ -171,7 +186,7 @@ function getLimits(model: string): Pick<BedrockModelKnowledge, 'context_window' 
         return { context_window: 256_000, max_output_tokens: model.includes('super') ? 32_768 : 8_192 };
     }
     if (model.includes('nvidia.nemotron-nano-')) return { context_window: 128_000, max_output_tokens: 8_192 };
-    if (model.startsWith('openai.gpt-5')) return { context_window: 272_000 };
+    if (isFamilyVersionGte(model, 'openai.gpt-', 5)) return { context_window: 272_000 };
     if (model.includes('openai.gpt-oss')) return { context_window: 128_000, max_output_tokens: 16_384 };
     if (model.includes('qwen3-235b')) return { context_window: 256_000, max_output_tokens: 8_192 };
     if (model.includes('qwen3-32b')) return { context_window: 32_000, max_output_tokens: 8_192 };

--- a/common/src/options/bedrock.test.ts
+++ b/common/src/options/bedrock.test.ts
@@ -3,7 +3,7 @@ import { getBedrockModelKnowledge } from '../capability/bedrock-models.js';
 import { getModelCapabilities } from '../capability.js';
 import { getOptions } from '../options.js';
 import { OptionType, Providers } from '../types.js';
-import { getBedrockOptions } from './bedrock.js';
+import { getBedrockOptions, getMaxTokensLimitBedrock } from './bedrock.js';
 import { getBedrockMantleProtocol } from './bedrock_mantle.js';
 import { getContextWindowSize } from './context-windows.js';
 import { getClaudeMaxTokensLimit } from './shared-parsing.js';
@@ -262,6 +262,52 @@ describe('Bedrock Mantle metadata', () => {
         expect(getBedrockModelKnowledge(model)).toMatchObject({
             context_window: contextWindow,
             max_output_tokens: maxOutputTokens,
+        });
+    });
+
+    it.each([
+        ['anthropic.claude-opus-5-v1:0', 1_000_000, 127_999],
+        ['anthropic.claude-fable-5-v1:0', 1_000_000, 127_999],
+        ['anthropic.claude-sonnet-5-20260701-v1:0', 1_000_000, 127_999],
+        ['anthropic.claude-mythos-preview-v1:0', 1_000_000, 127_999],
+        ['anthropic.claude-opus-4-8-v1:0', 1_000_000, 127_999],
+        ['anthropic.claude-haiku-4-7-v1:0', 1_000_000, 127_999],
+        ['anthropic.claude-opus-4-6-v1:0', 1_000_000, 127_999],
+        ['anthropic.claude-sonnet-4-6-v1:0', 1_000_000, 65_536],
+        ['anthropic.claude-haiku-4-5-20251001-v1:0', 200_000, 63_999],
+        ['anthropic.claude-opus-4-5-v1:0', 200_000, 65_536],
+        ['anthropic.claude-sonnet-4-20250514-v1:0', 200_000, 65_536],
+        ['anthropic.claude-opus-4-1-20250805-v1:0', 200_000, 32_000],
+    ] as const)('derives Claude limits from the model version for %s', (model, contextWindow, maxOutputTokens) => {
+        expect(getBedrockModelKnowledge(model)).toMatchObject({
+            context_window: contextWindow,
+            max_output_tokens: maxOutputTokens,
+        });
+    });
+
+    it('keeps Bedrock max_tokens below the exclusive 128K bound for the current Claude generation', () => {
+        expect(getMaxTokensLimitBedrock('anthropic.claude-opus-5-v1:0')).toBe(127_999);
+        expect(getMaxTokensLimitBedrock('anthropic.claude-fable-5-v1:0')).toBe(127_999);
+    });
+
+    it('resolves model knowledge through cross-region inference prefixes', () => {
+        expect(getBedrockModelKnowledge('us.anthropic.claude-opus-5-v1:0')).toMatchObject({
+            context_window: 1_000_000,
+            max_output_tokens: 127_999,
+        });
+        expect(getBedrockModelKnowledge('eu.openai.gpt-5.6-sol-v1:0')).toMatchObject({
+            context_window: 272_000,
+            input: { image: true },
+        });
+        expect(getBedrockModelKnowledge('apac.amazon.nova-pro-v1:0').context_window).toBe(300_000);
+        expect(getModelCapabilities('us.openai.gpt-5.6-sol-v1:0', Providers.bedrock_mantle).input.image).toBe(true);
+    });
+
+    it('inherits Mantle GPT context limits for later majors', () => {
+        expect(getBedrockModelKnowledge('openai.gpt-6-v1:0').context_window).toBe(272_000);
+        expect(getBedrockModelKnowledge('openai.gpt-oss-120b')).toMatchObject({
+            context_window: 128_000,
+            max_output_tokens: 16_384,
         });
     });
 

--- a/common/src/options/bedrock_mantle.ts
+++ b/common/src/options/bedrock_mantle.ts
@@ -1,5 +1,5 @@
 import type { z } from 'zod';
-import { getBedrockModelKnowledge } from '../capability/bedrock-models.js';
+import { getBedrockModelKnowledge, normalizeBedrockModelId } from '../capability/bedrock-models.js';
 import type {
     BedrockMantleChatCompletionsOptionsSchema,
     BedrockMantleClaudeOptionsSchema,
@@ -74,7 +74,7 @@ function supportsImageInput(model: string): boolean {
 }
 
 export function getBedrockMantleProtocol(model: string): BedrockMantleProtocol | undefined {
-    const normalized = model.toLowerCase();
+    const normalized = normalizeBedrockModelId(model);
     const publisher = getPublisher(normalized);
 
     if (publisher === 'anthropic' && normalized.includes('.claude-')) return 'messages';
@@ -100,7 +100,7 @@ export function getBedrockMantleProtocol(model: string): BedrockMantleProtocol |
 }
 
 export function getBedrockMantleModelInfo(model: string): BedrockMantleModelInfo | undefined {
-    const normalized = model.toLowerCase();
+    const normalized = normalizeBedrockModelId(model);
     const protocol = getBedrockMantleProtocol(normalized);
     if (!protocol) return undefined;
     const publisher = getPublisher(normalized);
@@ -118,7 +118,7 @@ export type BedrockMantleModelFamily = 'openai' | 'grok';
 
 export function getBedrockMantleModelFamily(model: string): BedrockMantleModelFamily | undefined {
     if (getBedrockMantleProtocol(model) !== 'responses') return undefined;
-    const normalized = model.toLowerCase();
+    const normalized = normalizeBedrockModelId(model);
     if (normalized.startsWith('openai.')) return 'openai';
     if (normalized.startsWith('xai.grok-')) return 'grok';
     return undefined;
@@ -137,7 +137,7 @@ function maxTokensOption(model: string): ModelOptionInfoItem {
 }
 
 function getResponsesOptions(model: string): ModelOptionsInfo {
-    const normalized = model.toLowerCase();
+    const normalized = normalizeBedrockModelId(model);
     const isGrok = normalized.startsWith('xai.grok-');
     const reasoningEffortEnum: Record<string, string> = isGrok
         ? { none: 'none', low: 'low', medium: 'medium', high: 'high' }


### PR DESCRIPTION
## Summary

Two gaps in the Bedrock model-knowledge table (`common/src/capability/bedrock-models.ts`), both of the same class: a rule keyed on an exact string instead of on the model family.

**Claude limits were an exact-ID list.** It named `claude-opus-4-6/4-7/4-8`, `claude-sonnet-5`, `claude-fable-5` and `claude-mythos`, so `claude-opus-5` matched nothing and reported neither a context window nor an output limit. `getMaxTokensLimitBedrock` then fell through to the generic Claude limit of 128,000 — which Bedrock rejects for this generation, since its bound is exclusive ("Try again with a maximum tokens value that is lower than 128000"). Replaced with version rules, so a newly released variant inherits the newest understood generation instead of silently reporting no limits.

**Cross-region prefixes were only stripped inside an ARN.** `normalizeBedrockModelId` stripped the geographic segment only when the ID came from an `inference-profile/` ARN, so a bare `us.openai.gpt-5.6-sol-v1:0` missed every `startsWith()` rule: no context window, no image modality, and — because `getPublisher()` read `"us"` — no Bedrock Mantle protocol, options or capabilities at all. The prefix is now stripped wherever it appears (`us.`, `eu.`, `apac.`, `us-gov.`, `global.`; no publisher segment collides with those), and the Mantle option lookups normalize through the same helper. As a side effect the ARN path no longer strips the first segment unconditionally, so an application-inference-profile ARN keeps its `anthropic.`/`openai.` publisher.

Two smaller fixes of the same kind:

- Mantle GPT context is now a family-version rule, so a later major (`openai.gpt-6`) inherits 272K instead of reporting nothing.
- Opus 4.0 gets Opus 4.1's limits; it previously matched no entry.

No limit changes for any model that the ID list already covered — the version rules reproduce the existing values, and the test matrix pins each of them.

## Test Plan

- [x] `cd common && pnpm lint` — clean
- [x] `cd common && pnpm typecheck:test` — clean
- [x] `cd common && pnpm test` — 166 passed (11 files)
- [x] `pnpm build` (workspace root) — 4/4 tasks
- [x] `cd drivers && pnpm exec vitest run --exclude '**/*.live.test.ts'` — 465 passed, 17 skipped
- [ ] Live provider tests not run (no change to request construction; this touches metadata only)

New coverage in `common/src/options/bedrock.test.ts`: the Claude version matrix (12 IDs, including every member of the old exact list, so the preserved values are pinned), the exclusive 128K max-tokens bound for `opus-5`/`fable-5`, knowledge resolution through cross-region prefixes, and Mantle GPT major inheritance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata and option/capability lookup only; no request-path changes. Wrong limits could mislead UI or cause avoidable Bedrock rejections until fixed.
> 
> **Overview**
> Fixes Bedrock **model metadata** (context windows, `max_tokens` caps, modalities, Mantle protocol routing) where rules were tied to exact model strings instead of families.
> 
> **Cross-region IDs:** `normalizeBedrockModelId` now strips geographic prefixes (`us.`, `eu.`, `apac.`, `us-gov.`, `global.`) on any ID, not only inside `inference-profile/` ARNs. Bare `us.<publisher>.<model>` IDs now resolve limits and capabilities correctly; Mantle paths use the same normalizer so publisher/protocol detection no longer treats `us` as the publisher.
> 
> **Claude limits:** Anthropic limits move from a fixed ID list to `parseClaudeVersion` thresholds so new variants (e.g. Opus/Fable 5) inherit generation-appropriate limits, including Bedrock’s **exclusive** 128K output cap (`127_999`). Opus 4.0+ gets explicit 4.x tier rules; GPT context on Mantle uses family version (`openai.gpt-` ≥ 5) so later majors inherit 272K.
> 
> Tests pin the Claude version matrix, exclusive max-tokens behavior, prefixed IDs, and GPT major inheritance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8e254fcaeb2bee9d19fa9b23c473d2305ea5045. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->