### PR TITLE
chore(deps): patch vulnerable nanoid

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,7 @@ overrides:
   vite: ^8.0.16
   brace-expansion@>=3.0.0 <5.0.8: 5.0.9
   fast-uri@>=3.0.0 <3.1.4: 3.1.5
+  nanoid@<3.3.17: 3.3.18
   postcss@<8.5.18: ^8.5.18
   protobufjs@<=7.6.4: 7.6.5
 
@@ -1538,8 +1539,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3467,7 +3468,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   node-domexception@1.0.0: {}
 
@@ -3526,7 +3527,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,6 +38,8 @@ overrides:
   vite: ^8.0.16
   "brace-expansion@>=3.0.0 <5.0.8": 5.0.9
   "fast-uri@>=3.0.0 <3.1.4": 3.1.5
+  # GHSA-2v37-7h3g-55p8: zero-sized custom generators can loop indefinitely.
+  "nanoid@<3.3.17": 3.3.18
   # GHSA path traversal in sourceMappingURL auto-loading. Reached via vitest > vite > postcss.
   "postcss@<8.5.18": ^8.5.18
   protobufjs@<=7.6.4: 7.6.5


### PR DESCRIPTION
## Summary
- redirect vulnerable nanoid releases below 3.3.17 to 3.3.18
- refresh the lockfile so Vitest and Vite resolve the patched PostCSS dependency

## Test Plan
- [x] pnpm audit
- [x] pnpm lint
- [x] pnpm build
- [x] pnpm typecheck:test
- [x] pnpm test