### PR TITLE
feat: support xAI image generation

### DIFF
--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -13,5 +13,6 @@ export * from './options/openai.js';
 export * from './options/shared-parsing.js';
 export * from './options/version-parsing.js';
 export * from './options/vertexai.js';
+export * from './options/xai.js';
 export * from './options.js';
 export * from './types.js';

--- a/common/src/model-directory.ts
+++ b/common/src/model-directory.ts
@@ -93,6 +93,9 @@ function inferFamily(model: string): { family: string; source_provider?: string 
         return { family: 'embedding' };
     }
     if (/(?:prompt-guard|moderation|safeguard)/.test(normalized)) return { family: 'moderation' };
+    if (normalized.includes('grok') && normalized.includes('image')) {
+        return { family: 'image', source_provider: 'xai' };
+    }
     if (normalized.includes('gpt-image') || normalized.includes('dall-e') || normalized.includes('imagen-')) {
         return { family: 'image', source_provider: normalized.includes('imagen') ? 'google' : 'openai' };
     }

--- a/common/src/options.ts
+++ b/common/src/options.ts
@@ -8,6 +8,7 @@ import { getGroqOptions } from './options/groq.js';
 import { getMistralOptions } from './options/mistral.js';
 import { getAzureOpenAiOptions, getOpenAiCompatibleOptions, getOpenAiOptions } from './options/openai.js';
 import { getVertexAiOptions } from './options/vertexai.js';
+import { getXAIOptions } from './options/xai.js';
 import { type ModelOptions, type ModelOptionsInfo, Providers } from './types.js';
 
 export function getOptions(model: string, provider?: Providers, options?: ModelOptions): ModelOptionsInfo {
@@ -35,10 +36,11 @@ export function getOptions(model: string, provider?: Providers, options?: ModelO
         case Providers.mistralai:
             return getMistralOptions(model, options, resolveModelProfile(model, provider));
         case Providers.togetherai:
-        case Providers.xai:
             // These transports intentionally use the OpenAI-compatible option IDs because their request builders
             // implement that wire surface; the resolved profile removes provider/model-specific unsupported effort.
             return getOpenAiCompatibleOptions(model, options, resolveModelProfile(model, provider));
+        case Providers.xai:
+            return getXAIOptions(model, options, resolveModelProfile(model, provider));
         case Providers.azure_foundry:
             return getAzureFoundryOptions(model, options);
         default:

--- a/common/src/options/xai.test.ts
+++ b/common/src/options/xai.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { resolveModelProfile } from '../model-directory.js';
+import { ModelOptionsSchema } from '../schemas/model-options.js';
+import { Providers } from '../types.js';
+import { getXAIOptions, isXAIGrokImageModel } from './xai.js';
+
+describe('xAI options', () => {
+    it.each(['grok-2-image-1212', 'grok-imagine-image', 'grok-imagine-image-quality', 'grok-imagine-image-2.0'])(
+        'recognizes the Grok image family for %s',
+        (model) => {
+            expect(isXAIGrokImageModel(model)).toBe(true);
+            expect(resolveModelProfile(model, Providers.xai)).toMatchObject({
+                family: 'image',
+                source_provider: 'xai',
+                capabilities: {
+                    input: { text: true, image: true },
+                    output: { image: true },
+                    tool_support: false,
+                },
+            });
+        },
+    );
+
+    it('exposes the xAI image API controls for current and future Imagine models', () => {
+        expect(getXAIOptions('grok-imagine-image-2.0')).toMatchObject({
+            _option_id: 'xai-grok-image',
+            options: expect.arrayContaining([
+                expect.objectContaining({ name: 'aspect_ratio' }),
+                expect.objectContaining({ name: 'resolution' }),
+                expect.objectContaining({ name: 'quality', default: 'medium' }),
+                expect.objectContaining({ name: 'response_format' }),
+                expect.objectContaining({ name: 'n', min: 1, max: 10 }),
+            ]),
+        });
+    });
+
+    it('keeps OpenAI-compatible text options for Grok language models', () => {
+        expect(getXAIOptions('grok-4.5')._option_id).toBe('openai-text');
+    });
+
+    it('validates the published image options and batch limit', () => {
+        expect(
+            ModelOptionsSchema.safeParse({
+                _option_id: 'xai-grok-image',
+                aspect_ratio: '19.5:9',
+                resolution: '2k',
+                quality: 'low',
+                response_format: 'b64_json',
+                n: 10,
+            }).success,
+        ).toBe(true);
+        expect(ModelOptionsSchema.safeParse({ _option_id: 'xai-grok-image', n: 11 }).success).toBe(false);
+        expect(ModelOptionsSchema.safeParse({ _option_id: 'xai-grok-image', quality: 'high' }).success).toBe(false);
+    });
+
+    it('only exposes the quality control for Image 2.0', () => {
+        expect(getXAIOptions('grok-imagine-image').options).not.toEqual(
+            expect.arrayContaining([expect.objectContaining({ name: 'quality' })]),
+        );
+    });
+});

--- a/common/src/options/xai.ts
+++ b/common/src/options/xai.ts
@@ -1,0 +1,83 @@
+import type { z } from 'zod';
+import { type ModelProfile, resolveModelProfile } from '../model-directory.js';
+import type { XAIGrokImageOptionsSchema } from '../schemas/model-options.js';
+import { type ModelOptionInfoItem, type ModelOptions, type ModelOptionsInfo, OptionType, Providers } from '../types.js';
+import { getOpenAiCompatibleOptions } from './openai.js';
+
+export type XAIGrokImageOptions = z.infer<typeof XAIGrokImageOptionsSchema>;
+
+export function isXAIGrokImageModel(model: string): boolean {
+    const modelId = (model.split('/').pop() ?? model).toLowerCase();
+    return modelId.includes('grok') && modelId.includes('image');
+}
+
+export function getXAIOptions(
+    model: string,
+    options?: ModelOptions,
+    profile: ModelProfile = resolveModelProfile(model, Providers.xai),
+): ModelOptionsInfo {
+    if (!isXAIGrokImageModel(model)) {
+        return getOpenAiCompatibleOptions(model, options, profile);
+    }
+
+    const imageOptions: ModelOptionInfoItem[] = [
+        {
+            name: 'aspect_ratio',
+            type: OptionType.enum,
+            enum: {
+                Auto: 'auto',
+                Square: '1:1',
+                Widescreen: '16:9',
+                Portrait: '9:16',
+                Landscape: '4:3',
+                'Portrait 3:4': '3:4',
+                Photo: '3:2',
+                'Portrait 2:3': '2:3',
+                Banner: '2:1',
+                'Portrait 1:2': '1:2',
+                Smartphone: '19.5:9',
+                'Portrait 9:19.5': '9:19.5',
+                Ultrawide: '20:9',
+                'Portrait 9:20': '9:20',
+            },
+            default: 'auto',
+            description: 'The aspect ratio of generated images.',
+        },
+        {
+            name: 'resolution',
+            type: OptionType.enum,
+            enum: { '1K': '1k', '2K': '2k' },
+            default: '1k',
+            description: 'The output resolution of generated images.',
+        },
+        ...(model.split('/').pop()?.toLowerCase() === 'grok-imagine-image-2.0'
+            ? [
+                  {
+                      name: 'quality',
+                      type: OptionType.enum,
+                      enum: { Low: 'low', Medium: 'medium' },
+                      default: 'medium',
+                      description: 'The generation quality. Supported by Grok Imagine Image 2.0.',
+                  } satisfies ModelOptionInfoItem,
+              ]
+            : []),
+        {
+            name: 'response_format',
+            type: OptionType.enum,
+            enum: { URL: 'url', 'Base64 JSON': 'b64_json' },
+            default: 'url',
+            description: 'The format used to return generated images.',
+        },
+        {
+            name: 'n',
+            type: OptionType.numeric,
+            min: 1,
+            max: 10,
+            default: 1,
+            integer: true,
+            description: 'The number of images to generate.',
+        },
+    ];
+
+    return { _option_id: 'xai-grok-image', options: imageOptions };
+}

--- a/common/src/schemas/model-options.test.ts
+++ b/common/src/schemas/model-options.test.ts
@@ -61,6 +61,7 @@ describe('ModelOptionsSchema', () => {
             'OpenAiTextOptions',
             'OpenAiDalleOptions',
             'OpenAiGptImageOptions',
+            'XAIGrokImageOptions',
             'GroqOptions',
             'MistralTextOptions',
         ]);

--- a/common/src/schemas/model-options.ts
+++ b/common/src/schemas/model-options.ts
@@ -1,8 +1,7 @@
 import { z } from 'zod';
 import { ImagenMaskMode, ImagenTaskType, ThinkingLevel } from '../options/vertexai.js';
 
-// Runtime schemas for `ModelOptions` — the union of every driver's per-model options — and its
-// twenty-five members.
+// Runtime schemas for `ModelOptions` — the union of every driver's per-model options.
 //
 // These are the SINGLE definition of each option set. The OpenAPI document publishes them, AJV
 // enforces them, and the public TypeScript types in `../options/*` are `z.infer` of them, so there

--- a/common/src/schemas/model-options.ts
+++ b/common/src/schemas/model-options.ts
@@ -344,6 +344,36 @@ export const OpenAiGptImageOptionsSchema = z
     })
     .meta({ id: 'OpenAiGptImageOptions' });
 
+// ===== xai =====
+
+export const XAIGrokImageOptionsSchema = z
+    .strictObject({
+        _option_id: z.literal('xai-grok-image'),
+        aspect_ratio: z
+            .enum([
+                '1:1',
+                '16:9',
+                '9:16',
+                '4:3',
+                '3:4',
+                '3:2',
+                '2:3',
+                '2:1',
+                '1:2',
+                '19.5:9',
+                '9:19.5',
+                '20:9',
+                '9:20',
+                'auto',
+            ])
+            .optional(),
+        resolution: z.enum(['1k', '2k']).optional(),
+        quality: z.enum(['low', 'medium']).optional(),
+        response_format: z.enum(['url', 'b64_json']).optional(),
+        n: z.number().int().min(1).max(10).optional(),
+    })
+    .meta({ id: 'XAIGrokImageOptions' });
+
 // ===== vertexai =====
 
 export const ImagenOptionsSchema = z
@@ -464,6 +494,7 @@ export const ModelOptionsSchema = z
         OpenAiTextOptionsSchema,
         OpenAiDalleOptionsSchema,
         OpenAiGptImageOptionsSchema,
+        XAIGrokImageOptionsSchema,
         GroqOptionsSchema,
         MistralTextOptionsSchema,
     ])

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -445,11 +445,7 @@ export abstract class OpenAIResponsesDriverBase extends OpenAICompatibleDriverBa
 
     protected canStream(_options: ExecutionOptions): Promise<boolean> {
         // Image generation models don't support streaming
-        if (
-            _options.model.includes('dall-e') ||
-            _options.model.includes('gpt-image') ||
-            _options.model.includes('chatgpt-image')
-        ) {
+        if (this.isImageModel(_options.model)) {
             return Promise.resolve(false);
         }
 

--- a/drivers/src/xai/index.test.ts
+++ b/drivers/src/xai/index.test.ts
@@ -1,37 +1,161 @@
-import { Providers } from '@llumiverse/core';
+import { type ExecutionOptions, PromptRole, Providers } from '@llumiverse/core';
 import type { FetchClient } from '@vertesia/api-fetch-client';
+import type OpenAI from 'openai';
 import { describe, expect, it, vi } from 'vitest';
 import { xAIDriver } from './index.js';
 
 describe('xAI model listing', () => {
     it('uses verified catalog capabilities instead of runtime modality claims', async () => {
         const driver = new xAIDriver({ apiKey: 'test-key' });
-        const get = vi.fn(async () => ({
-            models: [
-                {
-                    id: 'grok-4.3',
-                    owned_by: 'xAI',
-                    input_modalities: ['audio'],
-                    output_modalities: ['video'],
-                },
-                {
-                    id: 'text-embedding-future',
-                    owned_by: 'xAI',
-                    input_modalities: ['text'],
-                    output_modalities: ['embedding'],
-                },
-            ],
-        }));
+        const get = vi.fn(async (path: string) => {
+            if (path === '/image-generation-models') {
+                return {
+                    models: [
+                        {
+                            id: 'grok-imagine-image-2.0',
+                            owned_by: 'xAI',
+                            version: '2.0.0',
+                            input_modalities: ['text', 'image'],
+                            output_modalities: ['image'],
+                        },
+                    ],
+                };
+            }
+            return {
+                models: [
+                    {
+                        id: 'grok-4.3',
+                        owned_by: 'xAI',
+                        input_modalities: ['audio'],
+                        output_modalities: ['video'],
+                    },
+                    {
+                        id: 'text-embedding-future',
+                        owned_by: 'xAI',
+                        input_modalities: ['text'],
+                        output_modalities: ['embedding'],
+                    },
+                ],
+            };
+        });
         driver.xai_service = { get } as unknown as FetchClient;
 
-        expect(await driver.listModels()).toEqual([
-            expect.objectContaining({
-                id: 'grok-4.3',
-                provider: Providers.xai,
-                input_modalities: ['text', 'image'],
-                output_modalities: ['text'],
-                tool_support: true,
-            }),
+        expect(await driver.listModels()).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    id: 'grok-4.3',
+                    provider: Providers.xai,
+                    input_modalities: ['text', 'image'],
+                    output_modalities: ['text'],
+                    tool_support: true,
+                }),
+                expect.objectContaining({
+                    id: 'grok-imagine-image-2.0',
+                    provider: Providers.xai,
+                    type: 'image',
+                    input_modalities: ['text', 'image'],
+                    output_modalities: ['image'],
+                    tool_support: false,
+                }),
+            ]),
+        );
+        expect(get).toHaveBeenCalledWith('/language-models');
+        expect(get).toHaveBeenCalledWith('/image-generation-models');
+    });
+
+    it('keeps language models visible when the API key cannot list image models', async () => {
+        const driver = new xAIDriver({ apiKey: 'test-key' });
+        const get = vi.fn(async (path: string) => {
+            if (path === '/image-generation-models') throw new Error('Forbidden');
+            return { models: [{ id: 'grok-4.5', owned_by: 'xAI' }] };
+        });
+        driver.xai_service = { get } as unknown as FetchClient;
+
+        await expect(driver.listModels()).resolves.toEqual([
+            expect.objectContaining({ id: 'grok-4.5', provider: Providers.xai }),
         ]);
+    });
+});
+
+describe('xAI image generation', () => {
+    it('routes all Grok image-family models through the image API', () => {
+        const driver = new xAIDriver({ apiKey: 'test-key' });
+
+        expect(driver.isImageModel('grok-2-image-1212')).toBe(true);
+        expect(driver.isImageModel('grok-imagine-image-quality')).toBe(true);
+        expect(driver.isImageModel('grok-imagine-image-2.0')).toBe(true);
+        expect(driver.isImageModel('grok-4.3')).toBe(false);
+    });
+
+    it('sends xAI generation options and returns URL and base64 images', async () => {
+        const driver = new xAIDriver({ apiKey: 'test-key' });
+        const post = vi.fn(async () => ({
+            data: [
+                { url: 'https://example.com/image.jpeg', mime_type: 'image/jpeg' },
+                { b64_json: 'aW1hZ2U=', mime_type: 'image/jpeg' },
+            ],
+        }));
+        driver.xai_service = { post } as unknown as FetchClient;
+        const prompt = await driver.createPrompt([{ role: PromptRole.user, content: 'A lighthouse in a storm' }], {
+            model: 'grok-imagine-image-2.0',
+        });
+        const options: ExecutionOptions = {
+            model: 'grok-imagine-image-2.0',
+            model_options: {
+                _option_id: 'xai-grok-image',
+                aspect_ratio: '16:9',
+                resolution: '2k',
+                quality: 'low',
+                response_format: 'b64_json',
+                n: 2,
+            },
+        };
+
+        await expect(driver.requestImageGeneration(prompt, options)).resolves.toEqual({
+            result: [
+                { type: 'image', value: 'https://example.com/image.jpeg' },
+                { type: 'image', value: 'data:image/jpeg;base64,aW1hZ2U=' },
+            ],
+        });
+        expect(post).toHaveBeenCalledWith('/images/generations', {
+            payload: {
+                model: 'grok-imagine-image-2.0',
+                prompt: 'A lighthouse in a storm',
+                aspect_ratio: '16:9',
+                resolution: '2k',
+                quality: 'low',
+                response_format: 'b64_json',
+                n: 2,
+            },
+        });
+    });
+
+    it('uses the edits endpoint when the prompt contains reference images', async () => {
+        const driver = new xAIDriver({ apiKey: 'test-key' });
+        const post = vi.fn(async () => ({ data: [{ url: 'https://example.com/edit.jpeg' }] }));
+        driver.xai_service = { post } as unknown as FetchClient;
+        const prompt: OpenAI.Responses.ResponseInputItem[] = [
+            {
+                type: 'message',
+                role: 'user',
+                content: [
+                    { type: 'input_text', text: 'Turn this into a pencil sketch' },
+                    { type: 'input_image', image_url: 'data:image/png;base64,aW1hZ2U=', detail: 'auto' },
+                ],
+            },
+        ];
+
+        await driver.requestImageGeneration(prompt, { model: 'grok-imagine-image-quality' });
+
+        expect(post).toHaveBeenCalledWith('/images/edits', {
+            payload: {
+                model: 'grok-imagine-image-quality',
+                prompt: 'Turn this into a pencil sketch',
+                image: {
+                    type: 'image_url',
+                    url: 'data:image/png;base64,aW1hZ2U=',
+                },
+            },
+        });
     });
 });

--- a/drivers/src/xai/index.test.ts
+++ b/drivers/src/xai/index.test.ts
@@ -130,6 +130,41 @@ describe('xAI image generation', () => {
         });
     });
 
+    it('falls back from streaming to the image generation endpoint for Image 2.0', async () => {
+        const driver = new xAIDriver({ apiKey: 'test-key' });
+        const post = vi.fn(async () => ({ data: [{ url: 'https://example.com/image.jpeg' }] }));
+        driver.xai_service = { post } as unknown as FetchClient;
+        const options: ExecutionOptions = {
+            model: 'grok-imagine-image-2.0',
+            model_options: {
+                _option_id: 'xai-grok-image',
+                aspect_ratio: '1:1',
+                resolution: '2k',
+                quality: 'medium',
+                response_format: 'url',
+                n: 1,
+            },
+        };
+
+        const stream = await driver.stream([{ role: PromptRole.user, content: 'A lighthouse in a storm' }], options);
+        const chunks: string[] = [];
+        for await (const chunk of stream) chunks.push(chunk);
+
+        expect(chunks).toEqual(['[Image: https://ex...]']);
+        expect(stream.completion?.result).toEqual([{ type: 'image', value: 'https://example.com/image.jpeg' }]);
+        expect(post).toHaveBeenCalledWith('/images/generations', {
+            payload: {
+                model: 'grok-imagine-image-2.0',
+                prompt: 'A lighthouse in a storm',
+                aspect_ratio: '1:1',
+                resolution: '2k',
+                quality: 'medium',
+                response_format: 'url',
+                n: 1,
+            },
+        });
+    });
+
     it('uses the edits endpoint when the prompt contains reference images', async () => {
         const driver = new xAIDriver({ apiKey: 'test-key' });
         const post = vi.fn(async () => ({ data: [{ url: 'https://example.com/edit.jpeg' }] }));

--- a/drivers/src/xai/index.ts
+++ b/drivers/src/xai/index.ts
@@ -1,17 +1,25 @@
 import {
     type AIModel,
+    type Completion,
+    type CompletionResult,
     type DriverOptions,
+    type ExecutionOptions,
     getModelCapabilities,
     isEmbeddingModel,
+    isXAIGrokImageModel,
+    ModelType,
     modelModalitiesToArray,
     type PromptOptions,
     type PromptSegment,
     Providers,
+    type XAIGrokImageOptions,
 } from '@llumiverse/core';
 import { FetchClient } from '@vertesia/api-fetch-client';
 import OpenAI from 'openai';
 import { OpenAIResponsesDriverBase } from '../openai/index.js';
 import { formatOpenAILikeMultimodalPrompt, type OpenAIPromptFormatterOptions } from '../openai/openai_format.js';
+
+type ResponseInputItem = OpenAI.Responses.ResponseInputItem;
 
 export interface xAiDriverOptions extends DriverOptions {
     apiKey: string;
@@ -67,12 +75,85 @@ export class xAIDriver extends OpenAIResponsesDriverBase {
     // The base class implementation properly handles tool_calls extraction.
     // xAI's API is OpenAI-compatible and returns tool_calls in the same format.
 
+    override isImageModel(model: string): boolean {
+        return isXAIGrokImageModel(model);
+    }
+
+    async requestImageGeneration(prompt: ResponseInputItem[], options: ExecutionOptions): Promise<Completion> {
+        this.logger.debug(`[${this.provider}] Generating image with model ${options.model}`);
+
+        const { promptText, images } = extractImageRequest(prompt);
+        const modelOptions = options.model_options as XAIGrokImageOptions | undefined;
+        const payload: XAIImageRequest = {
+            model: options.model,
+            prompt: promptText,
+            ...(modelOptions?.aspect_ratio && { aspect_ratio: modelOptions.aspect_ratio }),
+            ...(modelOptions?.resolution && { resolution: modelOptions.resolution }),
+            ...(modelOptions?.quality && { quality: modelOptions.quality }),
+            ...(modelOptions?.response_format && { response_format: modelOptions.response_format }),
+            ...(modelOptions?.n && { n: modelOptions.n }),
+        };
+
+        if (images.length === 1) {
+            payload.image = images[0];
+        } else if (images.length > 1) {
+            payload.images = images;
+        }
+
+        try {
+            const endpoint = images.length > 0 ? '/images/edits' : '/images/generations';
+            const response = await this.xai_service.post<XAIImageResponse>(endpoint, { payload });
+            const results: CompletionResult[] = [];
+
+            for (const image of response.data ?? []) {
+                if (image.b64_json) {
+                    results.push({
+                        type: 'image',
+                        value: `data:${image.mime_type ?? 'image/jpeg'};base64,${image.b64_json}`,
+                    });
+                } else if (image.url) {
+                    results.push({ type: 'image', value: image.url });
+                }
+            }
+
+            return { result: results };
+        } catch (error: unknown) {
+            this.logger.error({ error }, `[${this.provider}] Image generation failed`);
+            const generationError = error instanceof Error ? error : new Error(String(error));
+            const errorCode =
+                (error as { code?: unknown })?.code === 'content_policy_violation'
+                    ? 'content_policy_violation'
+                    : 'validation_error';
+            return {
+                result: [],
+                error: {
+                    message: generationError.message,
+                    code: errorCode,
+                },
+            };
+        }
+    }
+
     async listModels(): Promise<AIModel[]> {
-        const lm = (await this.xai_service.get('/language-models')) as xAIModelResponse;
+        const [languageResult, imageResult] = await Promise.allSettled([
+            this.xai_service.get<xAILanguageModelResponse>('/language-models'),
+            this.xai_service.get<xAIImageModelResponse>('/image-generation-models'),
+        ]);
+        if (languageResult.status === 'rejected' && imageResult.status === 'rejected') {
+            throw languageResult.reason;
+        }
+        if (languageResult.status === 'rejected') {
+            this.logger.warn({ error: languageResult.reason }, '[xai] Failed to list language models');
+        }
+        if (imageResult.status === 'rejected') {
+            this.logger.warn({ error: imageResult.reason }, '[xai] Failed to list image generation models');
+        }
+        const languageModels = languageResult.status === 'fulfilled' ? languageResult.value.models : [];
+        const imageModels = imageResult.status === 'fulfilled' ? imageResult.value.models : [];
 
         // xAI listing modalities have been incomplete and occasionally describe endpoint artifacts rather than the
         // language-model execution path. Prefer the curated family directory and use runtime data for availability.
-        const models = lm.models
+        const models = languageModels
             .filter((model) => !isEmbeddingModel(model, this.provider))
             .map((model) => {
                 const capabilities = getModelCapabilities(model.id, this.provider);
@@ -94,22 +175,99 @@ export class xAIDriver extends OpenAIResponsesDriverBase {
                 } satisfies AIModel;
             });
 
-        return models;
+        const images = imageModels.map((model) => {
+            const capabilities = getModelCapabilities(model.id, this.provider);
+            const inputModalities = modelModalitiesToArray(capabilities.input);
+            const outputModalities = modelModalitiesToArray(capabilities.output);
+            return {
+                id: model.id,
+                provider: this.provider,
+                name: model.id,
+                description: `${model.id} by ${model.owned_by}`,
+                version: model.version,
+                owner: model.owned_by,
+                type: ModelType.Image,
+                can_stream: false,
+                is_multimodal: inputModalities.length > 1,
+                input_modalities: inputModalities,
+                output_modalities: outputModalities,
+                tool_support: false,
+                tags: [
+                    ...inputModalities.map((modality) => `i:${modality}`),
+                    ...outputModalities.map((modality) => `o:${modality}`),
+                ],
+            } satisfies AIModel;
+        });
+
+        return [...models, ...images].sort((a, b) => a.id.localeCompare(b.id));
     }
 }
 
-interface xAIModelResponse {
-    models: xAIModel[];
+function extractImageRequest(prompt: ResponseInputItem[]): { promptText: string; images: XAIImageInput[] } {
+    const text: string[] = [];
+    const images: XAIImageInput[] = [];
+
+    for (const item of prompt) {
+        if (!('content' in item)) continue;
+        if (typeof item.content === 'string') {
+            text.push(item.content);
+            continue;
+        }
+        if (!Array.isArray(item.content)) continue;
+
+        for (const part of item.content) {
+            if (part.type === 'input_text') {
+                text.push(part.text);
+            } else if (part.type === 'input_image') {
+                if (part.image_url) {
+                    images.push({ type: 'image_url', url: part.image_url });
+                } else if (part.file_id) {
+                    images.push({ file_id: part.file_id });
+                }
+            }
+        }
+    }
+
+    return { promptText: text.join('\n').trim(), images };
 }
 
-interface xAIModel {
-    completion_text_token_price: number;
-    created: number;
+interface xAILanguageModelResponse {
+    models: xAILanguageModel[];
+}
+
+interface xAILanguageModel {
     id: string;
-    input_modalities: string[];
-    object: string;
-    output_modalities: string[];
     owned_by: string;
-    prompt_image_token_price: number;
-    prompt_text_token_price: number;
+}
+
+interface xAIImageModelResponse {
+    models: xAIImageModel[];
+}
+
+interface xAIImageModel {
+    id: string;
+    owned_by: string;
+    version: string;
+}
+
+type XAIImageInput = { file_id: string } | { type: 'image_url'; url: string };
+
+interface XAIImageRequest {
+    aspect_ratio?: XAIGrokImageOptions['aspect_ratio'];
+    image?: XAIImageInput;
+    images?: XAIImageInput[];
+    model: string;
+    n?: number;
+    prompt: string;
+    quality?: XAIGrokImageOptions['quality'];
+    resolution?: XAIGrokImageOptions['resolution'];
+    response_format?: XAIGrokImageOptions['response_format'];
+}
+
+interface XAIImageResponse {
+    data?: Array<{
+        b64_json?: string;
+        mime_type?: string;
+        url?: string;
+    }>;
 }


### PR DESCRIPTION
## Summary

- route Grok image-family models through the xAI Images API for generation and editing
- discover image models from `/v1/image-generation-models` alongside language models
- expose and validate xAI image controls, including the Image 2.0-only `quality` option
- support the exact `grok-imagine-image-2.0` API model ID and future Grok image IDs through family matching

## Official API contract

Validated against xAI’s Image Generation guide, Images REST reference, Models REST reference, and the Grok Imagine Image 2 announcement. The implementation covers generation/edit endpoints, text and image inputs, image output, URL/base64 responses, `n` (1–10), all documented aspect ratios, 1K/2K resolution, and Image 2.0 `quality` (`low`/`medium`).

## Verification

- `pnpm build`
- `pnpm --filter @llumiverse/common typecheck:test`
- `pnpm --filter @llumiverse/drivers typecheck:test`
- `pnpm --filter @llumiverse/common test` (232 passed)
- `pnpm --filter @llumiverse/drivers test` (502 passed, 19 skipped)
- `pnpm --filter @llumiverse/common lint`
- `pnpm --filter @llumiverse/drivers lint`