### PR TITLE
fix(core): stop rejecting valid completions after a schema's first use

### DIFF
--- a/core/src/validation.test.ts
+++ b/core/src/validation.test.ts
@@ -16,4 +16,35 @@ describe('validateResult', () => {
             { type: 'thoughts', value: 'second thought' },
         ]);
     });
+
+    // A stored result schema is deserialized into a new object on every execution, so an `$id` that
+    // is already in the shared Ajv registry used to throw `schema with key or id "..." already
+    // exists` from the second execution onward.
+    it('validates repeatedly against an equal schema carrying the same $id', () => {
+        const schema = () => ({
+            $id: 'https://example.test/schemas/photo-observation.json',
+            type: 'object',
+            properties: { answer: { type: 'string' } },
+            required: ['answer'],
+        });
+        const result: CompletionResult[] = [{ type: 'text', value: '{"answer":"ok"}' }];
+
+        for (let attempt = 0; attempt < 3; attempt++) {
+            expect(validateResult(result, schema())).toEqual([{ type: 'json', value: { answer: 'ok' } }]);
+        }
+    });
+
+    it('applies the newest definition when a schema is edited but keeps its $id', () => {
+        const id = 'https://example.test/schemas/edited.json';
+        const result: CompletionResult[] = [{ type: 'text', value: '{"answer":"ok"}' }];
+
+        expect(validateResult(result, { $id: id, type: 'object' })).toEqual([
+            { type: 'json', value: { answer: 'ok' } },
+        ]);
+
+        // Same $id, stricter definition: the new requirement must be enforced, not the cached one.
+        expect(() => validateResult(result, { $id: id, type: 'object', required: ['missing'] })).toThrow(
+            /must have required property/,
+        );
+    });
 });

--- a/core/src/validation.ts
+++ b/core/src/validation.ts
@@ -1,5 +1,5 @@
 import type { CompletionResult, JSONValue, ResultValidationError } from '@llumiverse/common';
-import { Ajv } from 'ajv';
+import { Ajv, type ValidateFunction } from 'ajv';
 import addFormats from 'ajv-formats';
 import { extractAndParseJSON } from './json.js';
 import { resolveField } from './resolver.js';
@@ -18,6 +18,28 @@ addFormats(ajv);
 
 function errorMessage(error: unknown): string {
     return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Compile `schema` against the shared Ajv instance without tripping over its `$id` registry.
+ *
+ * `ajv.compile()` registers a schema under its `$id` and caches compiled validators by object
+ * identity. A stored result schema is deserialized into a *fresh* object on every execution, so the
+ * second execution of any interaction whose schema declares an `$id` reached Ajv as an unknown
+ * object claiming an already-taken id and threw `schema with key or id "..." already exists`. That
+ * turned every such run into a `validation_error` on output the model had produced correctly.
+ *
+ * Dropping the previous registration first — rather than reusing the cached validator — keeps the
+ * newest definition authoritative, because a schema can be edited between executions while keeping
+ * its `$id`. `removeSchema` is a no-op when nothing is registered, and it also bounds the registry
+ * at one entry per id instead of leaking one per execution.
+ */
+function compileSchema(schema: object): ValidateFunction {
+    const id = (schema as { $id?: unknown }).$id;
+    if (typeof id === 'string' && id) {
+        ajv.removeSchema(id);
+    }
+    return ajv.compile(schema);
 }
 
 function getRequiredFields(schemaField: unknown): string[] {
@@ -73,7 +95,7 @@ export function validateResult(data: CompletionResult[], schema: object): Comple
         throw new Error('Data to validate must be an array');
     }
 
-    const validate = ajv.compile(schema);
+    const validate = compileSchema(schema);
     const valid = validate(json);
 
     if (!valid && validate.errors) {


### PR DESCRIPTION
## Summary

`validateResult` compiled the result schema against the module-level `Ajv` singleton. `ajv.compile()`
registers a schema under its `$id` and caches compiled validators by object identity — and a stored
result schema is deserialized into a **fresh object** on every execution. So the second and every
later execution of an interaction whose schema declares an `$id` reached Ajv as an unknown object
claiming an already-taken id:

```
schema with key or id "https://example.test/schemas/photo-observation.json" already exists
```

That threw out of `validateResult`, so completions the model had produced **correctly** were reported
as `validation_error`. Only the first execution after a process start succeeded.

The compile now goes through a helper that drops any prior registration for the same `$id` first.
Evicting rather than reusing the cached validator is deliberate: a schema can be edited between
executions while keeping its `$id`, so the newest definition has to win. `removeSchema` is a no-op
when nothing is registered, and it bounds the registry at one entry per id instead of leaking one
entry per execution.

Schemas without an `$id` are unaffected — they never collided.

## Test Plan

Two regression tests added in `core/src/validation.test.ts`, both confirmed to **fail before** this
change with the error above:

- validates repeatedly against an equal-but-fresh schema object carrying the same `$id` (loops 3×)
- applies the newest definition when a schema is edited but keeps its `$id`

- [x] `pnpm lint` — 20 files, clean
- [x] `pnpm build`
- [x] `pnpm exec vitest run` — 149 passed (10 files)
