### PR TITLE
fix: carry tool-result attachments to OpenAI Responses and Gemini

### DIFF
--- a/core/src/conversation-utils.ts
+++ b/core/src/conversation-utils.ts
@@ -177,6 +177,32 @@ function isOpenAIBase64ImageBlock(obj: unknown): boolean {
     return typeof imgUrl.url === 'string' && imgUrl.url.startsWith('data:image/') && imgUrl.url.includes(';base64,');
 }
 
+function isBase64DataUrl(value: unknown, prefix = 'data:'): boolean {
+    return typeof value === 'string' && value.startsWith(prefix) && value.includes(';base64,');
+}
+
+/**
+ * Check if an object is an OpenAI Responses image block: { type: "input_image", image_url: "data:image/...;base64,..." }.
+ *
+ * Distinct from the Chat Completions `image_url` block above - the Responses API keeps the data
+ * URL in a plain string field. Without this, the generic string walker would blank the URL in
+ * place and leave behind an `input_image` block the API rejects.
+ */
+function isOpenAIResponsesBase64ImageBlock(obj: unknown): boolean {
+    if (typeof obj !== 'object' || obj === null) return false;
+    const o = obj as Record<string, unknown>;
+    return o.type === 'input_image' && isBase64DataUrl(o.image_url, 'data:image/');
+}
+
+/**
+ * Check if an object is an OpenAI Responses file block: { type: "input_file", file_data: "data:...;base64,..." }
+ */
+function isOpenAIResponsesBase64FileBlock(obj: unknown): boolean {
+    if (typeof obj !== 'object' || obj === null) return false;
+    const o = obj as Record<string, unknown>;
+    return o.type === 'input_file' && isBase64DataUrl(o.file_data);
+}
+
 /**
  * Check if an object is an Anthropic base64 image block: { type: "image", source: { type: "base64", data: "...", media_type: "..." } }
  */
@@ -470,6 +496,13 @@ function stripBase64ImagesFromConversationInternal(
             if (isOpenAIBase64ImageBlock(item)) {
                 return { type: 'text', text: IMAGE_PLACEHOLDER };
             }
+            // Same for the OpenAI Responses shapes, in a message's content or a tool result's output
+            if (isOpenAIResponsesBase64ImageBlock(item)) {
+                return { type: 'input_text', text: IMAGE_PLACEHOLDER };
+            }
+            if (isOpenAIResponsesBase64FileBlock(item)) {
+                return { type: 'input_text', text: DOCUMENT_PLACEHOLDER };
+            }
             // Replace entire Gemini inlineData blocks with text blocks
             if (isGeminiInlineDataBlock(item)) {
                 return { text: IMAGE_PLACEHOLDER };
@@ -607,6 +640,8 @@ function shouldPreserveMediaPayload(obj: unknown): boolean {
     // Preserved base64 media payloads for OpenAI, Gemini, and Anthropic/Claude.
     if (
         isOpenAIBase64ImageBlock(obj) ||
+        isOpenAIResponsesBase64ImageBlock(obj) ||
+        isOpenAIResponsesBase64FileBlock(obj) ||
         isGeminiInlineDataBlock(obj) ||
         isAnthropicBase64ImageBlock(obj) ||
         isAnthropicBase64DocumentBlock(obj)

--- a/core/test/conversation-strip.test.ts
+++ b/core/test/conversation-strip.test.ts
@@ -286,6 +286,73 @@ describe('stripBase64ImagesFromConversation', () => {
         expect(result.messages[0].content[0].image_url.url).toBe('https://example.com/image.jpg');
     });
 
+    test('should replace an OpenAI Responses input_image block with a text block', () => {
+        // The Responses API keeps the data URL in a plain string field. Blanking that string in
+        // place would leave an `input_image` block carrying a non-URL, which the API rejects.
+        const input = {
+            input: [
+                {
+                    type: 'message',
+                    content: [{ type: 'input_image', image_url: 'data:image/png;base64,abc123', detail: 'auto' }],
+                },
+            ],
+        };
+
+        const result = stripBase64ImagesFromConversation(input, FORCE_STRIP) as Tree;
+        expect(result.input[0].content[0]).toEqual({ type: 'input_text', text: IMAGE_PLACEHOLDER });
+    });
+
+    test('should replace an input_image carried by a tool result output', () => {
+        const input = {
+            input: [
+                {
+                    type: 'function_call_output',
+                    call_id: 'call_1',
+                    output: [
+                        { type: 'input_text', text: '{"artifact_path":"out/plot.png"}' },
+                        { type: 'input_image', image_url: 'data:image/png;base64,abc123', detail: 'auto' },
+                    ],
+                },
+            ],
+        };
+
+        const result = stripBase64ImagesFromConversation(input, FORCE_STRIP) as Tree;
+        expect(result.input[0].output).toEqual([
+            { type: 'input_text', text: '{"artifact_path":"out/plot.png"}' },
+            { type: 'input_text', text: IMAGE_PLACEHOLDER },
+        ]);
+    });
+
+    test('should replace an OpenAI Responses input_file block with a document placeholder', () => {
+        const input = {
+            input: [
+                {
+                    type: 'message',
+                    content: [
+                        { type: 'input_file', filename: 'report.pdf', file_data: 'data:application/pdf;base64,abc123' },
+                    ],
+                },
+            ],
+        };
+
+        const result = stripBase64ImagesFromConversation(input, FORCE_STRIP) as Tree;
+        expect(result.input[0].content[0]).toEqual({ type: 'input_text', text: DOCUMENT_PLACEHOLDER });
+    });
+
+    test('should leave an input_image referencing a remote URL alone', () => {
+        const input = {
+            input: [
+                {
+                    type: 'message',
+                    content: [{ type: 'input_image', image_url: 'https://example.com/image.jpg', detail: 'auto' }],
+                },
+            ],
+        };
+
+        const result = stripBase64ImagesFromConversation(input, FORCE_STRIP) as Tree;
+        expect(result.input[0].content[0].image_url).toBe('https://example.com/image.jpg');
+    });
+
     test('should handle null and undefined', () => {
         expect(stripBase64ImagesFromConversation(null)).toBeNull();
         expect(stripBase64ImagesFromConversation(undefined)).toBeUndefined();
@@ -741,6 +808,27 @@ describe('truncateLargeTextInConversation', () => {
 
         expect(result.messages[0].content.length).toBeLessThan(50000);
         expect(result.messages[0].content).toContain(TEXT_TRUNCATED_MARKER);
+    });
+
+    test('should leave OpenAI Responses media blocks intact', () => {
+        // A truncated base64 payload is a corrupt one - these blocks have to survive whole.
+        const imageBlock = {
+            type: 'input_image',
+            image_url: `data:image/png;base64,${'a'.repeat(50000)}`,
+            detail: 'auto',
+        };
+        const fileBlock = {
+            type: 'input_file',
+            filename: 'report.pdf',
+            file_data: `data:application/pdf;base64,${'b'.repeat(50000)}`,
+        };
+        const input = {
+            input: [{ type: 'function_call_output', call_id: 'call_1', output: [imageBlock, fileBlock] }],
+        };
+
+        const result = truncateLargeTextInConversation(input, { textMaxTokens: 10000 }) as Tree;
+
+        expect(result.input[0].output).toEqual([imageBlock, fileBlock]);
     });
 
     test('should preserve conversation metadata during truncation', () => {

--- a/drivers/src/openai/openai_format.test.ts
+++ b/drivers/src/openai/openai_format.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Unit tests for the Responses API prompt formatter, focused on attachments carried by a
+ * tool result.
+ *
+ * A tool can hand back an image (a chart it rendered, a screenshot, an artifact it promoted
+ * into the conversation). The Responses API represents that as a content list on
+ * `function_call_output`; emitting only the text drops the image with no error, and the model
+ * then insists it cannot see what it just asked for.
+ */
+
+import { type DataSource, type PromptOptions, PromptRole, type PromptSegment } from '@llumiverse/common';
+import { describe, expect, it, vi } from 'vitest';
+import { formatOpenAILikeMultimodalPrompt } from './openai_format.js';
+
+const OPTIONS = { model: 'gpt-5.6' } as unknown as PromptOptions;
+
+function source(name: string, mimeType: string | undefined, bytes = [1, 2, 3]): DataSource {
+    return {
+        name,
+        mime_type: mimeType as string,
+        getStream: vi.fn().mockResolvedValue(
+            new ReadableStream({
+                start(controller) {
+                    controller.enqueue(new Uint8Array(bytes));
+                    controller.close();
+                },
+            }),
+        ),
+        getURL: vi.fn(),
+        getURI: vi.fn(),
+    } as unknown as DataSource;
+}
+
+function toolSegment(files?: DataSource[], content = '{"artifact_path":"out/plot.png"}'): PromptSegment {
+    return { role: PromptRole.tool, tool_use_id: 'call_1', content, files } as unknown as PromptSegment;
+}
+
+function functionCallOutput(prompt: Awaited<ReturnType<typeof formatOpenAILikeMultimodalPrompt>>) {
+    const item = prompt.find((i) => 'type' in i && i.type === 'function_call_output');
+    if (!item) throw new Error('no function_call_output in prompt');
+    return item as { call_id: string; output: string | Array<Record<string, unknown>> };
+}
+
+describe('formatOpenAILikeMultimodalPrompt - tool result attachments', () => {
+    it('emits an image attached to a tool result as an input_image content part', async () => {
+        const prompt = await formatOpenAILikeMultimodalPrompt(
+            [toolSegment([source('plot.png', 'image/png')])],
+            OPTIONS,
+        );
+
+        const output = functionCallOutput(prompt).output;
+        expect(Array.isArray(output)).toBe(true);
+        expect(output).toEqual([
+            { type: 'input_text', text: '{"artifact_path":"out/plot.png"}' },
+            { type: 'input_image', image_url: 'data:image/png;base64,AQID', detail: 'auto' },
+        ]);
+    });
+
+    it('keeps the tool text first so the result reads before its attachments', async () => {
+        const prompt = await formatOpenAILikeMultimodalPrompt(
+            [toolSegment([source('a.png', 'image/png'), source('b.png', 'image/png')])],
+            OPTIONS,
+        );
+
+        const output = functionCallOutput(prompt).output as Array<Record<string, unknown>>;
+        expect(output.map((part) => part.type)).toEqual(['input_text', 'input_image', 'input_image']);
+    });
+
+    it('keeps the plain-string output when the tool result has no attachments', async () => {
+        const prompt = await formatOpenAILikeMultimodalPrompt([toolSegment()], OPTIONS);
+
+        expect(functionCallOutput(prompt).output).toBe('{"artifact_path":"out/plot.png"}');
+    });
+
+    it('omits the text part when a tool returns an attachment and no text', async () => {
+        const prompt = await formatOpenAILikeMultimodalPrompt(
+            [toolSegment([source('plot.png', 'image/png')], '')],
+            OPTIONS,
+        );
+
+        expect(functionCallOutput(prompt).output).toEqual([
+            { type: 'input_image', image_url: 'data:image/png;base64,AQID', detail: 'auto' },
+        ]);
+    });
+
+    it('skips a media type the API cannot carry instead of mislabelling it as an image', async () => {
+        // The tool-result attachment resolver lets audio/video through; sending either as
+        // `input_image` is rejected by the API, which would fail the whole turn.
+        const prompt = await formatOpenAILikeMultimodalPrompt(
+            [toolSegment([source('clip.mp4', 'video/mp4')])],
+            OPTIONS,
+        );
+
+        expect(functionCallOutput(prompt).output).toBe('{"artifact_path":"out/plot.png"}');
+    });
+
+    it('still requires a tool_use_id', async () => {
+        const segments = [{ role: PromptRole.tool, content: 'result' }] as unknown as PromptSegment[];
+
+        await expect(formatOpenAILikeMultimodalPrompt(segments, OPTIONS)).rejects.toThrow(/tool use id/i);
+    });
+});
+
+describe('formatOpenAILikeMultimodalPrompt - attachment types', () => {
+    it('maps a PDF to input_file rather than input_image', async () => {
+        const segments = [
+            { role: PromptRole.user, content: 'Read this', files: [source('report.pdf', 'application/pdf')] },
+        ] as unknown as PromptSegment[];
+
+        const prompt = await formatOpenAILikeMultimodalPrompt(segments, OPTIONS);
+
+        expect(prompt[0]).toMatchObject({
+            content: [
+                {
+                    type: 'input_file',
+                    filename: 'report.pdf',
+                    file_data: 'data:application/pdf;base64,AQID',
+                },
+                { type: 'input_text', text: 'Read this' },
+            ],
+        });
+    });
+
+    it('inlines a text attachment as text', async () => {
+        const segments = [
+            { role: PromptRole.user, content: 'Read this', files: [source('notes.txt', 'text/plain', [104, 105])] },
+        ] as unknown as PromptSegment[];
+
+        const prompt = await formatOpenAILikeMultimodalPrompt(segments, OPTIONS);
+
+        expect(prompt[0]).toMatchObject({
+            content: [
+                { type: 'input_text', text: 'hi' },
+                { type: 'input_text', text: 'Read this' },
+            ],
+        });
+    });
+
+    it('assumes an image when the attachment has no mime type', async () => {
+        const segments = [
+            { role: PromptRole.user, content: 'Look', files: [source('unknown', undefined)] },
+        ] as unknown as PromptSegment[];
+
+        const prompt = await formatOpenAILikeMultimodalPrompt(segments, OPTIONS);
+
+        expect(prompt[0]).toMatchObject({
+            content: [
+                { type: 'input_image', image_url: 'data:image/jpeg;base64,AQID', detail: 'auto' },
+                { type: 'input_text', text: 'Look' },
+            ],
+        });
+    });
+});

--- a/drivers/src/openai/openai_format.ts
+++ b/drivers/src/openai/openai_format.ts
@@ -1,8 +1,8 @@
 // This file is used by multiple drivers
 // to format prompts in a way that is compatible with OpenAI's API.
 
-import { type PromptOptions, PromptRole, type PromptSegment } from '@llumiverse/common';
-import { readStreamAsBase64 } from '@llumiverse/core';
+import { type DataSource, type PromptOptions, PromptRole, type PromptSegment } from '@llumiverse/common';
+import { readStreamAsBase64, readStreamAsString } from '@llumiverse/core';
 import type OpenAI from 'openai';
 import { truncateDataUrlForDebug } from '../shared/debug-prompt.js';
 
@@ -18,6 +18,37 @@ function isResponseInputContent(value: unknown): value is ResponseInputContent {
         'type' in value &&
         (value.type === 'input_text' || value.type === 'input_image' || value.type === 'input_file')
     );
+}
+
+/**
+ * Map an attachment to the Responses content part that carries it. Types the API has no
+ * representation for (audio, video) are skipped rather than mislabelled as an image, which
+ * the API rejects outright. A missing mime type keeps the historical image assumption.
+ */
+async function fileToInputContent(file: DataSource): Promise<ResponseInputContent | undefined> {
+    const mimeType = file.mime_type;
+    if (!mimeType || mimeType.startsWith('image/')) {
+        return {
+            type: 'input_image',
+            image_url: `data:${mimeType || 'image/jpeg'};base64,${await readStreamAsBase64(await file.getStream())}`,
+            detail: 'auto',
+        };
+    }
+    if (mimeType === 'application/pdf') {
+        return {
+            type: 'input_file',
+            filename: file.name,
+            file_data: `data:${mimeType};base64,${await readStreamAsBase64(await file.getStream())}`,
+        };
+    }
+    if (mimeType.startsWith('text/')) {
+        return { type: 'input_text', text: await readStreamAsString(await file.getStream()) };
+    }
+    return undefined;
+}
+
+function inputTextParts(parts: ResponseInputContent[]): OpenAI.Responses.ResponseInputText[] {
+    return parts.filter((part): part is OpenAI.Responses.ResponseInputText => part.type === 'input_text');
 }
 
 function isEasyInputMessageWithInputContent(
@@ -94,20 +125,17 @@ export async function formatOpenAILikeMultimodalPrompt(
     const others: ResponseInputItem[] = [];
 
     for (const msg of segments) {
-        const parts: ResponseInputContent[] = [];
+        const fileParts: ResponseInputContent[] = [];
 
         //generate the parts based on PromptSegment
         if (msg.files) {
             for (const file of msg.files) {
-                const stream = await file.getStream();
-                const data = await readStreamAsBase64(stream);
-                parts.push({
-                    type: 'input_image',
-                    image_url: `data:${file.mime_type || 'image/jpeg'};base64,${data}`,
-                    detail: 'auto',
-                });
+                const part = await fileToInputContent(file);
+                if (part) fileParts.push(part);
             }
         }
+
+        const parts: ResponseInputContent[] = [...fileParts];
 
         if (msg.content) {
             parts.push({
@@ -118,9 +146,7 @@ export async function formatOpenAILikeMultimodalPrompt(
 
         if (msg.role === PromptRole.system) {
             // For system messages, filter to only text parts
-            const textParts = parts.filter(
-                (part): part is OpenAI.Responses.ResponseInputText => part.type === 'input_text',
-            );
+            const textParts = inputTextParts(parts);
             const textContent = textParts.length === 1 && !msg.files ? textParts[0].text : textParts;
             const systemMsg: EasyInputMessage = {
                 type: 'message',
@@ -144,13 +170,10 @@ export async function formatOpenAILikeMultimodalPrompt(
                 });
             }
         } else if (msg.role === PromptRole.safety) {
-            const textParts = parts.filter(
-                (part): part is OpenAI.Responses.ResponseInputText => part.type === 'input_text',
-            );
             const safetyMsg: EasyInputMessage = {
                 type: 'message',
                 role: 'system',
-                content: textParts,
+                content: inputTextParts(parts),
             };
 
             if (Array.isArray(safetyMsg.content)) {
@@ -164,10 +187,19 @@ export async function formatOpenAILikeMultimodalPrompt(
             if (!msg.tool_use_id) {
                 throw new Error('Tool use id is required for tool messages');
             }
+            // A tool result can carry attachments - an image a tool rendered or promoted into the
+            // conversation, a document it fetched. The Responses API accepts those as a content
+            // list on `function_call_output`; emitting only the text would silently drop them and
+            // leave the model insisting it cannot see the image it just asked for.
             const toolOutputMsg: OpenAI.Responses.ResponseInputItem.FunctionCallOutput = {
                 type: 'function_call_output',
                 call_id: msg.tool_use_id,
-                output: msg.content || '',
+                // The tool's own output reads first, then its attachments. With no attachments,
+                // keep the plain-string form the API has always accepted.
+                output:
+                    fileParts.length > 0
+                        ? [...(msg.content ? [{ type: 'input_text' as const, text: msg.content }] : []), ...fileParts]
+                        : msg.content || '',
             };
             others.push(toolOutputMsg);
         } else if (msg.role !== PromptRole.negative && msg.role !== PromptRole.mask) {

--- a/drivers/src/vertexai/models/gemini-tool-result-files.test.ts
+++ b/drivers/src/vertexai/models/gemini-tool-result-files.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Unit tests for attachments carried by a Gemini tool result.
+ *
+ * A tool can hand back an image (a chart it rendered, a screenshot, an artifact it promoted
+ * into the conversation). Gemini carries those as `FunctionResponse.parts`; sending the JSON
+ * response alone drops them with no error, and the model then insists it cannot see what it
+ * just asked for.
+ */
+
+import type { Content } from '@google/genai';
+import { type DataSource, type ExecutionOptions, PromptRole, type PromptSegment } from '@llumiverse/core';
+import { describe, expect, it, vi } from 'vitest';
+import type { VertexAIDriver } from '../index.js';
+import { GeminiModelDefinition } from './gemini.js';
+
+const OPTIONS = { model: 'gemini-3-pro' } as unknown as ExecutionOptions;
+
+function source(uri: string, mimeType = 'image/jpeg', bytes = [1, 2, 3]): DataSource {
+    return {
+        name: 'page.jpg',
+        mime_type: mimeType,
+        getStream: vi.fn().mockResolvedValue(
+            new ReadableStream({
+                start(controller) {
+                    controller.enqueue(new Uint8Array(bytes));
+                    controller.close();
+                },
+            }),
+        ),
+        getURL: vi.fn(),
+        getURI: vi.fn().mockResolvedValue(uri),
+    } as unknown as DataSource;
+}
+
+function toolSegment(files?: DataSource[]): PromptSegment {
+    return {
+        role: PromptRole.tool,
+        tool_use_id: 'view_image',
+        content: '{"artifact_path":"out/plot.png"}',
+        files,
+    } as unknown as PromptSegment;
+}
+
+async function createPrompt(segments: PromptSegment[]): Promise<Content[]> {
+    const definition = new GeminiModelDefinition('gemini-3-pro');
+    const { contents } = await definition.createPrompt(null as unknown as VertexAIDriver, segments, OPTIONS);
+    return contents;
+}
+
+describe('Gemini tool result attachments', () => {
+    it('inlines an image attached to a tool result as a functionResponse part', async () => {
+        const contents = await createPrompt([toolSegment([source('https://signed.example/plot.png')])]);
+
+        expect(contents[0].parts?.[0].functionResponse).toEqual({
+            name: 'view_image',
+            response: { artifact_path: 'out/plot.png' },
+            parts: [{ inlineData: { data: 'AQID', mimeType: 'image/jpeg' } }],
+        });
+    });
+
+    it('passes a Cloud Storage attachment by URI instead of inlining it', async () => {
+        const file = source('gs://bucket/agents/run-1/out/plot.png');
+        const contents = await createPrompt([toolSegment([file])]);
+
+        expect(contents[0].parts?.[0].functionResponse?.parts).toEqual([
+            { fileData: { fileUri: 'gs://bucket/agents/run-1/out/plot.png', mimeType: 'image/jpeg' } },
+        ]);
+        expect(file.getStream).not.toHaveBeenCalled();
+    });
+
+    it('leaves the functionResponse untouched when the tool result has no attachments', async () => {
+        const contents = await createPrompt([toolSegment()]);
+
+        expect(contents[0].parts?.[0].functionResponse).toEqual({
+            name: 'view_image',
+            response: { artifact_path: 'out/plot.png' },
+        });
+        expect(contents[0].parts?.[0].functionResponse).not.toHaveProperty('parts');
+    });
+
+    it('keeps carrying attachments on user turns', async () => {
+        const segments = [
+            { role: PromptRole.user, content: 'Look', files: [source('https://signed.example/page.jpg')] },
+        ] as unknown as PromptSegment[];
+
+        const contents = await createPrompt(segments);
+
+        expect(contents[0].parts).toEqual([{ text: 'Look' }, { inlineData: { data: 'AQID', mimeType: 'image/jpeg' } }]);
+    });
+});

--- a/drivers/src/vertexai/models/gemini.ts
+++ b/drivers/src/vertexai/models/gemini.ts
@@ -4,6 +4,7 @@ import {
     FinishReason,
     FunctionCallingConfigMode,
     type FunctionDeclaration,
+    type FunctionResponsePart,
     type GenerateContentConfig,
     type GenerateContentParameters,
     type GenerateContentResponseUsageMetadata,
@@ -21,6 +22,7 @@ import {
     type AIModel,
     type Completion,
     type CompletionResult,
+    type DataSource,
     type DriverCompletionStream,
     type ExecutionOptions,
     type ExecutionTokenUsage,
@@ -512,11 +514,20 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
                 if (!msg.tool_use_id) {
                     throw new Error('Tool response missing tool_use_id');
                 }
+                // A tool result can carry attachments - typically an image the tool rendered or
+                // promoted into the conversation. Gemini takes those as `FunctionResponse.parts`;
+                // sending the JSON response alone drops them and leaves the model unable to see
+                // what it just asked for.
+                const responseParts: FunctionResponsePart[] = [];
+                for (const f of msg.files ?? []) {
+                    responseParts.push(await fileToMediaPart(f));
+                }
                 // Build functionResponse part with optional thought_signature for Gemini thinking models
                 const functionResponsePart: Part = {
                     functionResponse: {
                         name: msg.tool_use_id,
                         response: formatFunctionResponse(msg.content || ''),
+                        ...(responseParts.length > 0 && { parts: responseParts }),
                     },
                     // Include thought_signature if provided (required for Gemini 2.5+/3.0+ thinking models)
                     thoughtSignature: msg.thought_signature,
@@ -538,28 +549,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
                 // File content handling
                 if (msg.files) {
                     for (const f of msg.files) {
-                        const fileUri = await f.getURI();
-                        const isGsUri =
-                            fileUri.startsWith('gs://') || fileUri.startsWith('https://storage.googleapis.com/');
-
-                        if (isGsUri) {
-                            parts.push({
-                                fileData: {
-                                    fileUri,
-                                    mimeType: f.mime_type,
-                                },
-                            });
-                        } else {
-                            // Inline data handling
-                            const stream = await f.getStream();
-                            const data = await readStreamAsBase64(stream);
-                            parts.push({
-                                inlineData: {
-                                    data,
-                                    mimeType: f.mime_type,
-                                },
-                            });
-                        }
+                        parts.push(await fileToMediaPart(f));
                     }
                 }
 
@@ -1161,6 +1151,24 @@ function storeSystemInConversation(conversation: unknown, system: Content | unde
         return { ...(conversation as object), [SYSTEM_KEY]: system };
     }
     return conversation;
+}
+
+/**
+ * Media reference shape shared by `Part` and `FunctionResponsePart`, so the same attachment
+ * mapping serves both a user turn and a tool result. Files already in Google Cloud Storage are
+ * passed by URI; anything else is inlined as base64.
+ */
+type GeminiMediaPart =
+    | { fileData: { fileUri: string; mimeType?: string } }
+    | { inlineData: { data: string; mimeType?: string } };
+
+async function fileToMediaPart(file: DataSource): Promise<GeminiMediaPart> {
+    const fileUri = await file.getURI();
+    if (fileUri.startsWith('gs://') || fileUri.startsWith('https://storage.googleapis.com/')) {
+        return { fileData: { fileUri, mimeType: file.mime_type } };
+    }
+    const data = await readStreamAsBase64(await file.getStream());
+    return { inlineData: { data, mimeType: file.mime_type } };
 }
 
 /**


### PR DESCRIPTION
## Problem

An agent tool can return an image — a chart it rendered, a screenshot, an artifact it promoted into the conversation. `PromptSegment.files` carries those on the `PromptRole.tool` segment.

Four formatters attach them to the tool result. Two silently dropped them:

| Formatter | Before |
| --- | --- |
| `shared/claude-messages.ts` | ✅ `collectFileBlocks` into `tool_result.content` |
| `bedrock/converse.ts` | ✅ `processFileToToolContentBlock` |
| `openai/openai_chat_completions.ts` | ✅ `image_url` parts on the `role: 'tool'` message |
| `mistral/index.ts` | ✅ parts built before the tool branch |
| **`openai/openai_format.ts`** (Responses API) | ❌ `output: msg.content` only |
| **`vertexai/models/gemini.ts`** | ❌ `functionResponse` from the JSON response only |

`openai_format.ts` was the worse of the two: it had already downloaded and base64-encoded every attachment into `parts`, then discarded the array in the tool branch.

Symptom on the affected providers: a tool returns an image, the model receives the JSON metadata and no picture and **no error**, and answers that it cannot see the attachment. Reproduced on GPT-5.6 (`openai/index.ts` → `formatOpenAILikeMultimodalPrompt`); the same path serves the xAI and Azure Foundry drivers.

## Fix

Both APIs support this natively, so neither side needs a workaround:

- **Responses API** — `FunctionCallOutput.output` is typed `string | Array<ResponseInputTextContent | ResponseInputImageContent | ResponseInputFileContent>`. Attachments now go out as a content list, text first. With no attachments the output stays a plain string, exactly as before.
- **Gemini** — `FunctionResponse.parts` takes `FunctionResponsePart[]` with `inlineData` or `fileData`. The key is only added when the tool result actually carries files, so an ordinary tool result is byte-identical to before. The user-turn and tool-result file mapping now share one helper (GCS URIs by reference, everything else inlined).

Two supporting changes fall out of enabling that path:

- **Responses attachment mapping is now mime-aware.** Every file used to become `input_image` regardless of type. The tool-result attachment resolver passes audio and video through, and either as `input_image` is rejected by the API — that would have turned a silent drop into a failed turn. Images stay images, PDFs become `input_file`, `text/*` is inlined, anything else is skipped.
- **`stripBase64ImagesFromConversation` now recognises the Responses block shapes.** They keep their data URL in a plain string field rather than a nested object, so the generic string walker would have blanked the URL in place and left an `input_image` block carrying `[Image removed from conversation history]` — which the API rejects. They are now replaced whole, and preserved from text truncation like the other providers' media blocks. Without this, an image-returning tool on GPT would have worked for `stripImagesAfterTurns` turns and then broken the run.

## Tests

New: `drivers/src/openai/openai_format.test.ts` (9), `drivers/src/vertexai/models/gemini-tool-result-files.test.ts` (4). Extended: `core/test/conversation-strip.test.ts` (+5).

Coverage: image attached to a tool result becomes a content part; text ordered before attachments; no-attachment results keep the plain-string output; no-text results omit the empty text part; unsupported media is skipped rather than mislabelled; GCS attachments pass by URI without being streamed; PDF/text/no-mime mapping; strip replaces the Responses image and file blocks whole in both message content and tool output; remote-URL images are left alone; truncation leaves Responses media blocks intact.

## Verification

Run from the repo root, the packages' own declared scripts:

- `pnpm build` — 4/4 successful
- `cd core && pnpm lint` / `cd drivers && pnpm lint` — clean
- `cd core && pnpm typecheck:test` / `cd drivers && pnpm typecheck:test` — clean
- `pnpm format:check` — clean
- `pnpm exec vitest run --exclude '**/*.live.test.ts'` — **73 files, 936 passed, 17 skipped**

Not run: `*.live.test.ts`. The Gemini side is therefore covered by unit tests against the `@google/genai` types but has not been exercised against a live Vertex endpoint; the OpenAI side is the one reproduced from a real failing run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes multimodal prompt shaping and conversation pruning on provider-critical paths; behavior is well covered by new tests but affects live model requests for tool results with files.
> 
> **Overview**
> **Tool-result attachments** on `PromptSegment.files` are no longer dropped for **OpenAI Responses** (`function_call_output` as a content list, text first; plain string when there are no files) or **Gemini** (`FunctionResponse.parts` with shared `fileToMediaPart` for GCS vs inlined media).
> 
> **OpenAI Responses formatting** now maps attachments by MIME type (`input_image`, `input_file`, inlined `text/*`, skip unsupported audio/video) instead of treating every file as an image.
> 
> **Conversation utilities** recognize Responses `input_image` / `input_file` blocks for whole-block base64 stripping and truncation protection so deferred image stripping does not leave API-invalid partial blocks.
> 
> New unit tests cover OpenAI Responses tool attachments, Gemini tool `functionResponse` parts, and extended `conversation-strip` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 283a39720dbc2606793749f3f69a9f3f4490877d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->