### PR TITLE
chore(test): stop dumping provider payloads to test stdout

### DIFF
--- a/core/test/utils.test.ts
+++ b/core/test/utils.test.ts
@@ -36,14 +36,14 @@ describe('Core Utilities', () => {
         const schema = parseJSON(readDataFile('ciia-schema.json')) as object;
         const content: JsonResult[] = [{ type: 'json', value: parseJSON(readDataFile('ciia-data.json')) }];
         const res = validateResult(content, schema);
-        console.debug(res);
+        expect(res).toBeDefined();
     });
 
     test('Validate JSON against complex schema', () => {
         const schema = parseJSON(readDataFile('complex-schema.json')) as object;
         const content: JsonResult[] = [{ type: 'json', value: parseJSON(readDataFile('complex-document.json')) }];
         const res = validateResult(content, schema);
-        console.debug(res);
+        expect(res).toBeDefined();
     });
 
     test('Fail at validating JSON against schema', () => {
@@ -56,35 +56,33 @@ describe('Core Utilities', () => {
         const schema = parseJSON(readDataFile('ciia-schema.json')) as object;
         const content: JsonResult[] = [{ type: 'json', value: parseJSON(readDataFile('ciia-data-wrong-types.json')) }];
         const res = validateResult(content, schema);
-        console.debug(res);
+        expect(res).toBeDefined();
     });
 
     test('JSON parser should validate if date is empty string', () => {
         const schema = parseJSON(readDataFile('ciia-schema.json')) as object;
         const content: JsonResult[] = [{ type: 'json', value: parseJSON(readDataFile('ciia-data-date-empty.json')) }];
         const res = validateResult(content, schema);
-        console.debug(res);
+        expect(res).toBeDefined();
     });
 
     test('JSON parser should validate if date is null', () => {
         const schema = parseJSON(readDataFile('ciia-schema.json')) as object;
         const content: JsonResult[] = [{ type: 'json', value: parseJSON(readDataFile('ciia-data-date-null.json')) }];
         const res = validateResult(content, schema);
-        console.debug(res);
+        expect(res).toBeDefined();
     });
 
     test('JSON parser should not validate if date is wrong', () => {
         const schema = parseJSON(readDataFile('ciia-schema.json')) as object;
         const content: JsonResult[] = [{ type: 'json', value: parseJSON(readDataFile('ciia-data-date-wrong.json')) }];
         expect(() => validateResult(content, schema)).toThrowError(ValidationError);
-        console.debug(content, schema);
     });
 
     test('JSON parser should not validate if date is required but null', () => {
         const schema = parseJSON(readDataFile('ciia-schema-date-required.json')) as object;
         const content: JsonResult[] = [{ type: 'json', value: parseJSON(readDataFile('ciia-data-date-empty.json')) }];
         expect(() => validateResult(content, schema)).toThrowError(ValidationError);
-        console.debug(content, schema);
     });
 
     const dataFiles = fs.readdirSync(new URL('./data', import.meta.url)).filter((f) => f.endsWith('.data.json'));
@@ -94,6 +92,6 @@ describe('Core Utilities', () => {
         const schema = parseJSON(readDataFile(`${base}.schema.json`)) as object;
         const content: JsonResult[] = [{ type: 'json', value: parseJSON(readDataFile(dataFile)) }];
         const res = validateResult(content, schema);
-        console.debug(res);
+        expect(res).toBeDefined();
     });
 });

--- a/drivers/test/api-key-list-models.live.test.ts
+++ b/drivers/test/api-key-list-models.live.test.ts
@@ -17,12 +17,10 @@ describe('List models using API keys', () => {
         for await (const model of pager) {
             models.push(model);
         }
-        console.log(`Gemini API key: found ${models.length} models`);
         expect(models.length).toBeGreaterThan(0);
 
         // Verify we get gemini models
         const geminiModels = models.filter((m) => m.name?.includes('gemini'));
-        console.log(`  of which ${geminiModels.length} are Gemini models`);
         expect(geminiModels.length).toBeGreaterThan(0);
     });
 });

--- a/drivers/test/assertions.ts
+++ b/drivers/test/assertions.ts
@@ -27,14 +27,10 @@ export async function assertStreamingCompletionOk(stream: CompletionStream, json
     const out: string[] = [];
     for await (const chunk of stream) {
         out.push(chunk);
-        console.log(chunk);
     }
-    console.log(out.join(''));
     const r = stream.completion as ExecutionResponse;
     const jsonObject = jsonMode ? extractAndParseJSON(out.join('')) : undefined;
     const jsonResult = jsonMode ? parseCompletionResultsToJson(r.result) : undefined;
-    console.log(jsonObject);
-    console.log(jsonResult);
     if (jsonMode) {
         expect(jsonResult).toStrictEqual(jsonObject);
     }

--- a/drivers/test/image-gen.live.test.ts
+++ b/drivers/test/image-gen.live.test.ts
@@ -47,12 +47,9 @@ describe.concurrent.each(drivers)('Driver $name', ({ name, driver, models }) => 
         expect(res).toBeDefined();
         expect(res).toHaveProperty('textToImageParams');
         expect(res).toHaveProperty('taskType');
-        console.log(res);
     });
 
     test.each(models)(`${name}: text to image generation`, { timeout: 300 * 1000 }, async (model) => {
-        console.log(`Testing model ${model}`);
-
         const options: ExecutionOptions = {
             model: model,
             output_modality: Modalities.image,
@@ -73,8 +70,6 @@ describe.concurrent.each(drivers)('Driver $name', ({ name, driver, models }) => 
     });
 
     test.each(models)(`${name}: text to image guidance`, { timeout: 300 * 1000 }, async (model) => {
-        console.log(`Testing model ${model}`);
-
         const options: ExecutionOptions = {
             model: model,
             output_modality: Modalities.image,

--- a/drivers/test/model-smoke.live.test.ts
+++ b/drivers/test/model-smoke.live.test.ts
@@ -240,7 +240,6 @@ describe.each(selectedDrivers)('Driver $name', ({ name, driver, models }) => {
     test(`${name}: list models`, { timeout: TIMEOUT, retry: 1 }, async () => {
         const r = await driver.listModels();
         fetchedModels = r;
-        console.log(r);
         expect(r.length).toBeGreaterThan(0);
     });
 
@@ -261,7 +260,6 @@ describe.each(selectedDrivers)('Driver $name', ({ name, driver, models }) => {
 
     test.each(models)(`${name}: execute prompt on %s`, { timeout: TIMEOUT, retry: 2 }, async (model) => {
         const r = await driver.execute(testPrompt_color, getTestOptions(model));
-        console.log(`Result for execute ${model}`, JSON.stringify(r));
         assertCompletionOk(r, model, driver);
     });
 
@@ -276,8 +274,7 @@ describe.each(selectedDrivers)('Driver $name', ({ name, driver, models }) => {
                 ...getTestOptions(model),
                 result_schema: testSchema_color,
             });
-            const out = await assertStreamingCompletionOk(r, true);
-            console.log(`Result for streaming with schema ${model}`, JSON.stringify(out));
+            await assertStreamingCompletionOk(r, true);
         },
     );
 
@@ -328,7 +325,6 @@ describe.each(selectedDrivers)('Driver $name', ({ name, driver, models }) => {
 
             const isMultiModal = fetchedModels?.find((r) => r.id === model)?.is_multimodal;
 
-            console.log(`${model} is multimodal: ${isMultiModal}`);
             if (!isMultiModal) return;
 
             const r = await driver.execute(testPrompt_describeImage, {
@@ -340,7 +336,6 @@ describe.each(selectedDrivers)('Driver $name', ({ name, driver, models }) => {
                 },
                 result_schema: testSchema_animalDescription,
             });
-            console.log('Result', r);
             assertCompletionOk(r);
         },
     );


### PR DESCRIPTION
## Problem

The live test job printed **~4,200 lines** of provider payloads per run. Sources, worst first:

- `assertions.ts` — `console.log(chunk)` **per streaming chunk**, plus the joined output and both parsed JSON objects, on every streaming assertion.
- `model-smoke.live.test.ts` — the full model catalog per driver (`console.log(r)` in `list models`), the full JSON of every execute result, the full JSON of every streaming result, a multimodal banner per model, and the raw result object.
- `api-key-list-models.live.test.ts`, `image-gen.live.test.ts` — model counts, per-model banners, a payload dump.

None of it is read unless something fails, and by then vitest already prints the assertion diff — the dumps just bury it. Locating the actual failure in a run means scrolling past thousands of lines of model catalog.

## What was kept

Output that carries real signal stays:

- the per-provider `console.warn('X tests are skipped: <VAR> is not set')` notices — they explain why a suite didn't run
- `tools.live.test.ts` `console.error` on a missing tool result — fires only on failure
- `samples.ts` warn when the image fixture fetch falls back to the local copy
- `image-gen.live.test.ts` "Saving image to `<path>`" — names a side effect on disk

## `core/test/utils.test.ts`

This one runs in the **functional** suite, so it cost output on every CI run, not just live ones. Eight cases dumped their validation result.

Six of them had no assertion at all — the `console.debug(res)` was doing duty as the check, so the test only failed if `validateResult` threw. Those now assert `expect(res).toBeDefined()`, which is what "validate this without throwing" was meant to express. The two that already assert a throw simply lose the dump.

## Verification

From the repo root, the packages' own declared scripts:

- `pnpm build` — 4/4 successful
- `cd core && pnpm lint` / `cd drivers && pnpm lint` — clean
- `cd core && pnpm typecheck:test` / `cd drivers && pnpm typecheck:test` — clean
- `pnpm format:check` — clean
- `pnpm exec vitest run --exclude '**/*.live.test.ts'` — **73 files, 936 passed, 17 skipped**

Live tests not run locally; CI on this PR exercises them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code paths; assertions are slightly stricter but still only require defined validation results on success.
> 
> **Overview**
> **Cuts thousands of lines of test noise** by removing `console.log` / `console.debug` dumps from live driver tests and shared streaming helpers, while keeping warnings and failure-oriented logging (skipped suites, image save paths, etc.).
> 
> In **`core/test/utils.test.ts`**, schema validation cases that only printed results now **`expect(res).toBeDefined()`** so success is asserted explicitly instead of implied by lack of throw; throw-only cases lose redundant debug output.
> 
> Live suites (**`model-smoke`**, **`assertions`**, **`api-key-list-models`**, **`image-gen`**) no longer log full model catalogs, per-chunk stream output, or JSON payloads on every pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b01c2456d89e342c58ef26144bb1f63cd3ed7446. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->