### PR TITLE
fix(openai): handle schemas outside strict subset

### DIFF
--- a/drivers/src/bedrock-mantle/index.test.ts
+++ b/drivers/src/bedrock-mantle/index.test.ts
@@ -338,7 +338,14 @@ describe('BedrockMantleDriver protocol execution', () => {
                 expect.objectContaining({
                     model,
                     messages: [{ role: 'user', content: 'hello' }],
-                    response_format: expect.objectContaining({ type: 'json_schema' }),
+                    response_format: {
+                        type: 'json_schema',
+                        json_schema: {
+                            name: 'output',
+                            strict: false,
+                            schema: result_schema,
+                        },
+                    },
                 }),
             );
         }
@@ -443,6 +450,11 @@ describe('Bedrock Mantle Responses options', () => {
         const prompt = [
             { type: 'message', role: 'user', content: 'hello' },
         ] satisfies OpenAI.Responses.ResponseInputItem[];
+        const result_schema = {
+            type: 'object' as const,
+            properties: { answer: { type: 'string' as const } },
+            required: ['answer'],
+        };
 
         await driver.requestTextCompletion(prompt, {
             model: 'openai.gpt-5.5',
@@ -452,11 +464,7 @@ describe('Bedrock Mantle Responses options', () => {
                 effort: 'low',
                 verbosity: 'low',
             },
-            result_schema: {
-                type: 'object',
-                properties: { answer: { type: 'string' } },
-                required: ['answer'],
-            },
+            result_schema,
         });
 
         expect(create).toHaveBeenCalledWith(
@@ -467,7 +475,12 @@ describe('Bedrock Mantle Responses options', () => {
                 include: ['reasoning.encrypted_content'],
                 text: expect.objectContaining({
                     verbosity: 'low',
-                    format: expect.objectContaining({ type: 'json_schema', name: 'format_output' }),
+                    format: {
+                        type: 'json_schema',
+                        name: 'format_output',
+                        strict: false,
+                        schema: result_schema,
+                    },
                 }),
             }),
         );

--- a/drivers/src/openai/openai_chat_completions.test.ts
+++ b/drivers/src/openai/openai_chat_completions.test.ts
@@ -1076,6 +1076,8 @@ describe('OpenAIChatCompletionsProtocol', () => {
             result_schema: {
                 type: 'object',
                 properties: { answer: { type: 'string' } },
+                required: ['answer'],
+                additionalProperties: false,
             },
             tools: [
                 {
@@ -1084,6 +1086,8 @@ describe('OpenAIChatCompletionsProtocol', () => {
                     input_schema: {
                         type: 'object',
                         properties: { location: { type: 'string' } },
+                        required: ['location'],
+                        additionalProperties: false,
                     },
                 },
             ],

--- a/drivers/src/openai/schema.test.ts
+++ b/drivers/src/openai/schema.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { formatOpenAISchema } from './schema.js';
+
+describe('formatOpenAISchema', () => {
+    it('adds additionalProperties false to nullable object properties in strict mode', () => {
+        const result = formatOpenAISchema({
+            type: 'object',
+            properties: {
+                suggested_domain: {
+                    type: ['object', 'null'],
+                    properties: {
+                        name: { type: 'string' },
+                    },
+                },
+            },
+        });
+
+        expect(result).toEqual({
+            strict: true,
+            schema: {
+                type: 'object',
+                properties: {
+                    suggested_domain: {
+                        type: ['object', 'null'],
+                        properties: {
+                            name: { type: 'string' },
+                        },
+                        required: ['name'],
+                        additionalProperties: false,
+                    },
+                },
+                required: ['suggested_domain'],
+                additionalProperties: false,
+            },
+        });
+    });
+
+    it('keeps nullable scalar properties in strict mode', () => {
+        const result = formatOpenAISchema({
+            type: 'object',
+            properties: {
+                unit: { type: ['string', 'null'] },
+            },
+        });
+
+        expect(result.strict).toBe(true);
+        expect(result.schema.properties?.unit).toEqual({ type: ['string', 'null'] });
+    });
+});

--- a/drivers/src/openai/schema.test.ts
+++ b/drivers/src/openai/schema.test.ts
@@ -72,11 +72,18 @@ describe('formatOpenAISchema', () => {
         ['unsupported string format', { type: 'string', format: 'uri' }],
         ['unsupported array keyword', { type: 'array', items: { type: 'string' }, uniqueItems: true }],
         ['unsupported composition keyword', { type: 'object', allOf: [{ type: 'object' }] }],
+        ['unsupported union keyword', { oneOf: [{ type: 'string' }, { type: 'number' }] }],
     ])('uses non-strict mode for %s', (_name, schema) => {
-        const result = formatOpenAISchema(schema);
+        const rootSchema = {
+            type: 'object',
+            properties: { value: schema },
+            required: ['value'],
+            additionalProperties: false,
+        } satisfies JSONSchema;
+        const result = formatOpenAISchema(rootSchema);
 
         expect(result.strict).toBe(false);
-        expect(result.schema).toEqual(schema);
+        expect(result.schema).toEqual(rootSchema);
     });
 
     it('keeps supported constraints in strict mode', () => {

--- a/drivers/src/openai/schema.test.ts
+++ b/drivers/src/openai/schema.test.ts
@@ -1,3 +1,4 @@
+import type { JSONSchema } from '@llumiverse/core';
 import { describe, expect, it } from 'vitest';
 import { formatOpenAISchema } from './schema.js';
 
@@ -11,8 +12,12 @@ describe('formatOpenAISchema', () => {
                     properties: {
                         name: { type: 'string' },
                     },
+                    required: ['name'],
+                    additionalProperties: false,
                 },
             },
+            required: ['suggested_domain'],
+            additionalProperties: false,
         });
 
         expect(result).toEqual({
@@ -41,9 +46,105 @@ describe('formatOpenAISchema', () => {
             properties: {
                 unit: { type: ['string', 'null'] },
             },
+            required: ['unit'],
+            additionalProperties: false,
         });
 
         expect(result.strict).toBe(true);
         expect(result.schema.properties?.unit).toEqual({ type: ['string', 'null'] });
+    });
+
+    it('uses non-strict mode instead of narrowing optional fields or extra keys', () => {
+        const schema = {
+            type: 'object',
+            properties: {
+                optional: { type: 'string' },
+            },
+        } satisfies JSONSchema;
+
+        const result = formatOpenAISchema(schema);
+
+        expect(result.strict).toBe(false);
+        expect(result.schema).toEqual(schema);
+    });
+
+    it.each<[string, JSONSchema]>([
+        ['unsupported string format', { type: 'string', format: 'uri' }],
+        ['unsupported array keyword', { type: 'array', items: { type: 'string' }, uniqueItems: true }],
+        ['unsupported composition keyword', { type: 'object', allOf: [{ type: 'object' }] }],
+    ])('uses non-strict mode for %s', (_name, schema) => {
+        const result = formatOpenAISchema(schema);
+
+        expect(result.strict).toBe(false);
+        expect(result.schema).toEqual(schema);
+    });
+
+    it('keeps supported constraints in strict mode', () => {
+        const result = formatOpenAISchema({
+            type: 'object',
+            properties: {
+                email: { type: 'string', format: 'email', pattern: '.*@.*' },
+                values: { type: 'array', items: { type: 'integer' }, minItems: 1, maxItems: 3 },
+            },
+            required: ['email', 'values'],
+            additionalProperties: false,
+        });
+
+        expect(result.strict).toBe(true);
+        expect(result.schema.properties?.email).toEqual({
+            type: 'string',
+            format: 'email',
+            pattern: '.*@.*',
+        });
+    });
+
+    it('normalizes object variants inside anyOf and definitions', () => {
+        const result = formatOpenAISchema({
+            type: 'object',
+            properties: {
+                value: {
+                    anyOf: [
+                        {
+                            type: 'object',
+                            properties: { name: { type: 'string' } },
+                            required: ['name'],
+                            additionalProperties: false,
+                        },
+                        { type: 'null' },
+                    ],
+                },
+            },
+            required: ['value'],
+            additionalProperties: false,
+            $defs: {
+                item: {
+                    type: 'object',
+                    properties: { id: { type: 'string' } },
+                    required: ['id'],
+                    additionalProperties: false,
+                },
+            },
+        });
+
+        expect(result.strict).toBe(true);
+        expect(result.schema.properties?.value).toEqual({
+            anyOf: [
+                {
+                    type: 'object',
+                    properties: { name: { type: 'string' } },
+                    required: ['name'],
+                    additionalProperties: false,
+                },
+                { type: 'null' },
+            ],
+        });
+        expect(result.schema.$defs).toEqual({
+            item: {
+                type: 'object',
+                properties: { id: { type: 'string' } },
+                required: ['id'],
+                additionalProperties: false,
+            },
+        });
     });
 });

--- a/drivers/src/openai/schema.ts
+++ b/drivers/src/openai/schema.ts
@@ -5,6 +5,28 @@ export interface OpenAISchemaFormatResult {
     strict: boolean;
 }
 
+const OPENAI_SUPPORTED_FORMATS = new Set([
+    'date-time',
+    'time',
+    'date',
+    'duration',
+    'email',
+    'hostname',
+    'ipv4',
+    'ipv6',
+    'uuid',
+]);
+
+const OPENAI_SUPPORTED_TYPES = new Set<JSONSchemaTypeName>([
+    'string',
+    'number',
+    'integer',
+    'boolean',
+    'object',
+    'array',
+    'null',
+]);
+
 function hasSchemaType(schema: JSONSchema, type: JSONSchemaTypeName): boolean {
     return Array.isArray(schema.type) ? schema.type.includes(type) : schema.type === type;
 }
@@ -36,20 +58,24 @@ export function limitedSchemaFormat(schema: JSONSchema): JSONSchema {
         }
     }
 
-    if (formattedSchema?.properties) {
-        // Process each property recursively.
-        for (const propName of Object.keys(formattedSchema.properties)) {
-            const property = formattedSchema.properties[propName];
-
-            formattedSchema.properties[propName] = limitedSchemaFormat(property);
-
-            if (hasSchemaType(property, 'array') && property.items && hasSchemaType(property.items, 'object')) {
-                formattedSchema.properties[propName] = {
-                    ...property,
-                    items: limitedSchemaFormat(property.items),
-                };
-            }
-        }
+    if (formattedSchema.properties) {
+        formattedSchema.properties = Object.fromEntries(
+            Object.entries(formattedSchema.properties).map(([name, property]) => [name, limitedSchemaFormat(property)]),
+        );
+    }
+    if (Array.isArray(formattedSchema.anyOf)) {
+        formattedSchema.anyOf = formattedSchema.anyOf.map((variant) => limitedSchemaFormat(variant as JSONSchema));
+    }
+    if (formattedSchema.items && typeof formattedSchema.items === 'object') {
+        formattedSchema.items = limitedSchemaFormat(formattedSchema.items);
+    }
+    if (formattedSchema.$defs && typeof formattedSchema.$defs === 'object') {
+        formattedSchema.$defs = Object.fromEntries(
+            Object.entries(formattedSchema.$defs as Record<string, JSONSchema>).map(([name, definition]) => [
+                name,
+                limitedSchemaFormat(definition),
+            ]),
+        );
     }
 
     return formattedSchema;
@@ -57,9 +83,7 @@ export function limitedSchemaFormat(schema: JSONSchema): JSONSchema {
 
 // For strict mode true.
 export function openAISchemaFormat(schema: JSONSchema, nesting: number = 0): JSONSchema {
-    if (nesting > 5) {
-        throw new Error('OpenAI schema nesting too deep');
-    }
+    if (nesting === 0) validateOpenAIStrictSchema(schema);
 
     const formattedSchema: JSONSchema = { ...schema };
 
@@ -71,35 +95,128 @@ export function openAISchemaFormat(schema: JSONSchema, nesting: number = 0): JSO
         formattedSchema.additionalProperties = false;
     }
 
-    if (formattedSchema?.properties) {
+    if (formattedSchema.properties) {
         // Set all properties as required.
         formattedSchema.required = Object.keys(formattedSchema.properties);
 
         for (const propName of Object.keys(formattedSchema.properties)) {
             const property = formattedSchema.properties[propName];
-
-            // OpenAI strict mode requires all properties to have a type.
-            if (!property?.type) {
-                throw new Error(`Property '${propName}' is missing required 'type' field for OpenAI strict mode`);
-            }
-
             formattedSchema.properties[propName] = openAISchemaFormat(property, nesting + 1);
-
-            if (hasSchemaType(property, 'array') && property.items && hasSchemaType(property.items, 'object')) {
-                formattedSchema.properties[propName] = {
-                    ...property,
-                    items: openAISchemaFormat(property.items, nesting + 1),
-                };
-            }
         }
     }
-    if (
-        hasSchemaType(formattedSchema, 'object') &&
-        (!formattedSchema?.properties || Object.keys(formattedSchema?.properties ?? {}).length === 0)
-    ) {
-        // If no properties are defined, then additionalProperties: true was set or the object would be empty.
-        // OpenAI does not support this on structured output / strict mode.
-        throw new Error('OpenAI does not support empty objects or objects with additionalProperties set to true');
+    if (formattedSchema.items && typeof formattedSchema.items === 'object') {
+        formattedSchema.items = openAISchemaFormat(formattedSchema.items, nesting + 1);
+    }
+    if (Array.isArray(formattedSchema.anyOf)) {
+        formattedSchema.anyOf = formattedSchema.anyOf.map((variant) =>
+            openAISchemaFormat(variant as JSONSchema, nesting + 1),
+        );
+    }
+    if (formattedSchema.$defs && typeof formattedSchema.$defs === 'object') {
+        formattedSchema.$defs = Object.fromEntries(
+            Object.entries(formattedSchema.$defs as Record<string, JSONSchema>).map(([name, definition]) => [
+                name,
+                openAISchemaFormat(definition, nesting + 1),
+            ]),
+        );
     }
     return formattedSchema;
+}
+
+function validateOpenAIStrictSchema(schema: JSONSchema, nesting: number = 0, root: boolean = true): void {
+    if (nesting > 10) {
+        throw new Error('OpenAI schema nesting too deep');
+    }
+
+    const allowedKeys = new Set([
+        'type',
+        'description',
+        'properties',
+        'items',
+        'required',
+        'additionalProperties',
+        'enum',
+        'anyOf',
+        '$defs',
+        '$ref',
+        'pattern',
+        'format',
+        'multipleOf',
+        'maximum',
+        'exclusiveMaximum',
+        'minimum',
+        'exclusiveMinimum',
+        'minItems',
+        'maxItems',
+    ]);
+
+    for (const key of Object.keys(schema)) {
+        if (key !== 'default' && !allowedKeys.has(key)) {
+            throw new Error(`OpenAI strict mode does not support schema keyword '${key}'`);
+        }
+    }
+
+    if (root && (!hasSchemaType(schema, 'object') || schema.anyOf)) {
+        throw new Error('OpenAI strict mode requires the root schema to be an object without anyOf');
+    }
+
+    if (schema.$ref) {
+        return;
+    }
+
+    const types = schema.type === undefined ? [] : Array.isArray(schema.type) ? schema.type : [schema.type];
+    if (types.length === 0 && !schema.anyOf) {
+        throw new Error('OpenAI strict mode requires a type for every schema');
+    }
+    if (types.some((type) => !OPENAI_SUPPORTED_TYPES.has(type))) {
+        throw new Error('OpenAI strict mode does not support one or more schema types');
+    }
+
+    if (
+        schema.format !== undefined &&
+        (!hasSchemaType(schema, 'string') || !OPENAI_SUPPORTED_FORMATS.has(schema.format))
+    ) {
+        throw new Error(`OpenAI strict mode does not support format '${schema.format}'`);
+    }
+
+    if (schema.enum && Array.isArray(schema.enum)) {
+        const values = schema.enum.map((value) => JSON.stringify(value));
+        if (new Set(values).size !== values.length) {
+            throw new Error('OpenAI strict mode does not support duplicate enum values');
+        }
+    }
+
+    if (hasSchemaType(schema, 'object')) {
+        const properties = schema.properties ?? {};
+        if (Object.keys(properties).length === 0 || schema.additionalProperties !== false) {
+            throw new Error('OpenAI strict mode requires non-empty objects with additionalProperties set to false');
+        }
+        const propertyNames = Object.keys(properties);
+        const required = schema.required ?? [];
+        if (required.length !== propertyNames.length || required.some((name) => !propertyNames.includes(name))) {
+            throw new Error('OpenAI strict mode requires every object property to be required');
+        }
+        for (const property of Object.values(properties)) {
+            validateOpenAIStrictSchema(property, nesting + 1, false);
+        }
+    }
+
+    if (hasSchemaType(schema, 'array')) {
+        if (!schema.items || typeof schema.items !== 'object') {
+            throw new Error('OpenAI strict mode requires array items');
+        }
+        validateOpenAIStrictSchema(schema.items, nesting + 1, false);
+    }
+
+    if (Array.isArray(schema.anyOf)) {
+        for (const variant of schema.anyOf) {
+            validateOpenAIStrictSchema(variant as JSONSchema, nesting + 1, false);
+        }
+    }
+
+    if (schema.$defs && typeof schema.$defs === 'object') {
+        for (const definition of Object.values(schema.$defs as Record<string, JSONSchema>)) {
+            validateOpenAIStrictSchema(definition, nesting + 1, false);
+        }
+    }
 }

--- a/drivers/src/openai/schema.ts
+++ b/drivers/src/openai/schema.ts
@@ -2,6 +2,18 @@ import type { JSONSchema, JSONSchemaTypeName } from '@llumiverse/core';
 import type { JSONSchema as OpenAIJSONSchema } from 'openai/lib/jsonschema.js';
 import { forEachJSONSchemaChild, toStrictJsonSchema } from 'openai/lib/transform.js';
 
+const OPENAI_STRICT_STRING_FORMATS = new Set([
+    'date-time',
+    'time',
+    'date',
+    'duration',
+    'email',
+    'hostname',
+    'ipv4',
+    'ipv6',
+    'uuid',
+]);
+
 export interface OpenAISchemaFormatResult {
     schema: JSONSchema;
     strict: boolean;
@@ -71,6 +83,12 @@ function assertOpenAIStrictSchemaContract(schema: JSONSchema): void {
         visited.add(candidate);
 
         const candidateSchema = candidate as JSONSchema;
+        if (candidateSchema.format !== undefined && !OPENAI_STRICT_STRING_FORMATS.has(candidateSchema.format)) {
+            throw new Error(`Unsupported OpenAI strict schema format: ${candidateSchema.format}`);
+        }
+        if (candidateSchema.oneOf !== undefined) {
+            throw new Error('OpenAI strict schemas do not support oneOf');
+        }
         if (hasSchemaType(candidateSchema, 'object') || candidateSchema.properties) {
             const properties = candidateSchema.properties ?? {};
             const propertyNames = Object.keys(properties);

--- a/drivers/src/openai/schema.ts
+++ b/drivers/src/openai/schema.ts
@@ -1,8 +1,12 @@
-import type { JSONSchema } from '@llumiverse/core';
+import type { JSONSchema, JSONSchemaTypeName } from '@llumiverse/core';
 
 export interface OpenAISchemaFormatResult {
     schema: JSONSchema;
     strict: boolean;
+}
+
+function hasSchemaType(schema: JSONSchema, type: JSONSchemaTypeName): boolean {
+    return Array.isArray(schema.type) ? schema.type.includes(type) : schema.type === type;
 }
 
 export function formatOpenAISchema(schema: JSONSchema): OpenAISchemaFormatResult {
@@ -39,7 +43,7 @@ export function limitedSchemaFormat(schema: JSONSchema): JSONSchema {
 
             formattedSchema.properties[propName] = limitedSchemaFormat(property);
 
-            if (property?.type === 'array' && property.items && property.items?.type === 'object') {
+            if (hasSchemaType(property, 'array') && property.items && hasSchemaType(property.items, 'object')) {
                 formattedSchema.properties[propName] = {
                     ...property,
                     items: limitedSchemaFormat(property.items),
@@ -63,7 +67,7 @@ export function openAISchemaFormat(schema: JSONSchema, nesting: number = 0): JSO
     delete formattedSchema.default;
 
     // Additional properties not supported, required to be set.
-    if (formattedSchema?.type === 'object') {
+    if (hasSchemaType(formattedSchema, 'object')) {
         formattedSchema.additionalProperties = false;
     }
 
@@ -81,7 +85,7 @@ export function openAISchemaFormat(schema: JSONSchema, nesting: number = 0): JSO
 
             formattedSchema.properties[propName] = openAISchemaFormat(property, nesting + 1);
 
-            if (property?.type === 'array' && property.items && property.items?.type === 'object') {
+            if (hasSchemaType(property, 'array') && property.items && hasSchemaType(property.items, 'object')) {
                 formattedSchema.properties[propName] = {
                     ...property,
                     items: openAISchemaFormat(property.items, nesting + 1),
@@ -90,7 +94,7 @@ export function openAISchemaFormat(schema: JSONSchema, nesting: number = 0): JSO
         }
     }
     if (
-        formattedSchema?.type === 'object' &&
+        hasSchemaType(formattedSchema, 'object') &&
         (!formattedSchema?.properties || Object.keys(formattedSchema?.properties ?? {}).length === 0)
     ) {
         // If no properties are defined, then additionalProperties: true was set or the object would be empty.

--- a/drivers/src/openai/schema.ts
+++ b/drivers/src/openai/schema.ts
@@ -1,31 +1,11 @@
 import type { JSONSchema, JSONSchemaTypeName } from '@llumiverse/core';
+import type { JSONSchema as OpenAIJSONSchema } from 'openai/lib/jsonschema.js';
+import { forEachJSONSchemaChild, toStrictJsonSchema } from 'openai/lib/transform.js';
 
 export interface OpenAISchemaFormatResult {
     schema: JSONSchema;
     strict: boolean;
 }
-
-const OPENAI_SUPPORTED_FORMATS = new Set([
-    'date-time',
-    'time',
-    'date',
-    'duration',
-    'email',
-    'hostname',
-    'ipv4',
-    'ipv6',
-    'uuid',
-]);
-
-const OPENAI_SUPPORTED_TYPES = new Set<JSONSchemaTypeName>([
-    'string',
-    'number',
-    'integer',
-    'boolean',
-    'object',
-    'array',
-    'null',
-]);
 
 function hasSchemaType(schema: JSONSchema, type: JSONSchemaTypeName): boolean {
     return Array.isArray(schema.type) ? schema.type.includes(type) : schema.type === type;
@@ -33,7 +13,10 @@ function hasSchemaType(schema: JSONSchema, type: JSONSchemaTypeName): boolean {
 
 export function formatOpenAISchema(schema: JSONSchema): OpenAISchemaFormatResult {
     try {
-        return { schema: openAISchemaFormat(schema), strict: true };
+        assertOpenAIStrictSchemaContract(schema);
+        const strictSchema = toStrictJsonSchema(schema as OpenAIJSONSchema) as JSONSchema;
+        removeDefaults(strictSchema);
+        return { schema: strictSchema, strict: true };
     } catch {
         return { schema: limitedSchemaFormat(schema), strict: false };
     }
@@ -81,142 +64,42 @@ export function limitedSchemaFormat(schema: JSONSchema): JSONSchema {
     return formattedSchema;
 }
 
-// For strict mode true.
-export function openAISchemaFormat(schema: JSONSchema, nesting: number = 0): JSONSchema {
-    if (nesting === 0) validateOpenAIStrictSchema(schema);
+function assertOpenAIStrictSchemaContract(schema: JSONSchema): void {
+    const visited = new Set<object>();
+    const visit = (candidate: unknown): void => {
+        if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate) || visited.has(candidate)) return;
+        visited.add(candidate);
 
-    const formattedSchema: JSONSchema = { ...schema };
-
-    // Defaults not supported.
-    delete formattedSchema.default;
-
-    // Additional properties not supported, required to be set.
-    if (hasSchemaType(formattedSchema, 'object')) {
-        formattedSchema.additionalProperties = false;
-    }
-
-    if (formattedSchema.properties) {
-        // Set all properties as required.
-        formattedSchema.required = Object.keys(formattedSchema.properties);
-
-        for (const propName of Object.keys(formattedSchema.properties)) {
-            const property = formattedSchema.properties[propName];
-            formattedSchema.properties[propName] = openAISchemaFormat(property, nesting + 1);
+        const candidateSchema = candidate as JSONSchema;
+        if (hasSchemaType(candidateSchema, 'object') || candidateSchema.properties) {
+            const properties = candidateSchema.properties ?? {};
+            const propertyNames = Object.keys(properties);
+            const required = candidateSchema.required ?? [];
+            if (
+                candidateSchema.additionalProperties !== false ||
+                propertyNames.length === 0 ||
+                required.length !== propertyNames.length ||
+                required.some((name) => !propertyNames.includes(name))
+            ) {
+                throw new Error('Schema changes object optionality or additional properties in OpenAI strict mode');
+            }
         }
-    }
-    if (formattedSchema.items && typeof formattedSchema.items === 'object') {
-        formattedSchema.items = openAISchemaFormat(formattedSchema.items, nesting + 1);
-    }
-    if (Array.isArray(formattedSchema.anyOf)) {
-        formattedSchema.anyOf = formattedSchema.anyOf.map((variant) =>
-            openAISchemaFormat(variant as JSONSchema, nesting + 1),
-        );
-    }
-    if (formattedSchema.$defs && typeof formattedSchema.$defs === 'object') {
-        formattedSchema.$defs = Object.fromEntries(
-            Object.entries(formattedSchema.$defs as Record<string, JSONSchema>).map(([name, definition]) => [
-                name,
-                openAISchemaFormat(definition, nesting + 1),
-            ]),
-        );
-    }
-    return formattedSchema;
+
+        forEachJSONSchemaChild(candidate as OpenAIJSONSchema, [], (child) => visit(child));
+    };
+
+    visit(schema);
 }
 
-function validateOpenAIStrictSchema(schema: JSONSchema, nesting: number = 0, root: boolean = true): void {
-    if (nesting > 10) {
-        throw new Error('OpenAI schema nesting too deep');
-    }
+function removeDefaults(schema: JSONSchema): void {
+    const visited = new Set<object>();
+    const visit = (candidate: unknown): void => {
+        if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate) || visited.has(candidate)) return;
+        visited.add(candidate);
+        const candidateSchema = candidate as JSONSchema;
+        delete candidateSchema.default;
+        forEachJSONSchemaChild(candidate as OpenAIJSONSchema, [], (child) => visit(child));
+    };
 
-    const allowedKeys = new Set([
-        'type',
-        'description',
-        'properties',
-        'items',
-        'required',
-        'additionalProperties',
-        'enum',
-        'anyOf',
-        '$defs',
-        '$ref',
-        'pattern',
-        'format',
-        'multipleOf',
-        'maximum',
-        'exclusiveMaximum',
-        'minimum',
-        'exclusiveMinimum',
-        'minItems',
-        'maxItems',
-    ]);
-
-    for (const key of Object.keys(schema)) {
-        if (key !== 'default' && !allowedKeys.has(key)) {
-            throw new Error(`OpenAI strict mode does not support schema keyword '${key}'`);
-        }
-    }
-
-    if (root && (!hasSchemaType(schema, 'object') || schema.anyOf)) {
-        throw new Error('OpenAI strict mode requires the root schema to be an object without anyOf');
-    }
-
-    if (schema.$ref) {
-        return;
-    }
-
-    const types = schema.type === undefined ? [] : Array.isArray(schema.type) ? schema.type : [schema.type];
-    if (types.length === 0 && !schema.anyOf) {
-        throw new Error('OpenAI strict mode requires a type for every schema');
-    }
-    if (types.some((type) => !OPENAI_SUPPORTED_TYPES.has(type))) {
-        throw new Error('OpenAI strict mode does not support one or more schema types');
-    }
-
-    if (
-        schema.format !== undefined &&
-        (!hasSchemaType(schema, 'string') || !OPENAI_SUPPORTED_FORMATS.has(schema.format))
-    ) {
-        throw new Error(`OpenAI strict mode does not support format '${schema.format}'`);
-    }
-
-    if (schema.enum && Array.isArray(schema.enum)) {
-        const values = schema.enum.map((value) => JSON.stringify(value));
-        if (new Set(values).size !== values.length) {
-            throw new Error('OpenAI strict mode does not support duplicate enum values');
-        }
-    }
-
-    if (hasSchemaType(schema, 'object')) {
-        const properties = schema.properties ?? {};
-        if (Object.keys(properties).length === 0 || schema.additionalProperties !== false) {
-            throw new Error('OpenAI strict mode requires non-empty objects with additionalProperties set to false');
-        }
-        const propertyNames = Object.keys(properties);
-        const required = schema.required ?? [];
-        if (required.length !== propertyNames.length || required.some((name) => !propertyNames.includes(name))) {
-            throw new Error('OpenAI strict mode requires every object property to be required');
-        }
-        for (const property of Object.values(properties)) {
-            validateOpenAIStrictSchema(property, nesting + 1, false);
-        }
-    }
-
-    if (hasSchemaType(schema, 'array')) {
-        if (!schema.items || typeof schema.items !== 'object') {
-            throw new Error('OpenAI strict mode requires array items');
-        }
-        validateOpenAIStrictSchema(schema.items, nesting + 1, false);
-    }
-
-    if (Array.isArray(schema.anyOf)) {
-        for (const variant of schema.anyOf) {
-            validateOpenAIStrictSchema(variant as JSONSchema, nesting + 1, false);
-        }
-    }
-
-    if (schema.$defs && typeof schema.$defs === 'object') {
-        for (const definition of Object.values(schema.$defs as Record<string, JSONSchema>)) {
-            validateOpenAIStrictSchema(definition, nesting + 1, false);
-        }
-    }
+    visit(schema);
 }

--- a/drivers/src/vertexai/models/openai_chat_completions.test.ts
+++ b/drivers/src/vertexai/models/openai_chat_completions.test.ts
@@ -326,6 +326,8 @@ describe('OpenAIChatCompletionsModelDefinition', () => {
             result_schema: {
                 type: 'object',
                 properties: { answer: { type: 'string' } },
+                required: ['answer'],
+                additionalProperties: false,
             },
         };
 

--- a/drivers/src/vertexai/models/openai_chat_completions.test.ts
+++ b/drivers/src/vertexai/models/openai_chat_completions.test.ts
@@ -292,16 +292,16 @@ describe('OpenAIChatCompletionsModelDefinition', () => {
         ]);
     });
 
-    it('uses response_format with normalized JSON schema for structured Vertex MaaS output', async () => {
+    it('uses strict response_format for structured Vertex GPT output', async () => {
         const modelDef = new OpenAIChatCompletionsModelDefinition({
-            modelName: 'zai-org/glm-5-maas',
+            modelName: 'openai/gpt-oss-120b-maas',
             region: 'global',
         });
         const post = vi.fn(async () => ({
             id: 'chatcmpl-1',
             object: 'chat.completion',
             created: 1,
-            model: 'zai-org/glm-5-maas',
+            model: 'openai/gpt-oss-120b-maas',
             choices: [
                 {
                     index: 0,
@@ -321,7 +321,7 @@ describe('OpenAIChatCompletionsModelDefinition', () => {
             messages: [{ role: 'user', content: 'Hello' }],
         };
         const options: ExecutionOptions = {
-            model: 'locations/global/publishers/zai-org/models/glm-5-maas',
+            model: 'locations/global/publishers/openai/models/gpt-oss-120b-maas',
             model_options: { _option_id: 'text-fallback' },
             result_schema: {
                 type: 'object',


### PR DESCRIPTION
## Summary
- Use the installed OpenAI SDK strict-schema transformer and JSON Schema type instead of maintaining a local keyword/type validator.
- Add compatibility guards for the documented strict string-format subset and raw oneOf schemas that the low-level SDK transformer does not reject.
- Preserve schemas that would be semantically narrowed by strictification and send them with native json_schema strict:false.
- Apply the behavior at the shared OpenAI-compatible protocol layer, including Vertex AI GPT-OSS and Bedrock Mantle GPT/GPT-OSS routes.
- Keep native provider protocols on their own structured-output schema contracts.
- Cover nullable objects, nested anyOf/$defs, optional fields, additional properties, unsupported formats, uniqueItems, unsupported composition keywords, and hosted GPT routing.

## Why
OpenAI Structured Outputs requires a supported JSON Schema subset. Unsupported constraints such as format: uri and uniqueItems can cause provider errors when sent with strict:true. The installed openai@6.49.0 SDK provides the structural strict-schema transformer and maintained unsupported-keyword handling; llumiverse supplies the two missing API compatibility checks for formats and oneOf.

The user-provided schema remains the contract: strict-mode normalization is used only when the original schema already declares all object fields required and additionalProperties:false. Otherwise the original constraints are retained in the non-strict native JSON Schema request.

Hosted GPT models using OpenAI-compatible Responses or Chat Completions share this behavior. Native provider APIs retain their provider-specific schema handling.

References:
- [OpenAI Structured Outputs](https://developers.openai.com/api/docs/guides/structured-outputs)
- [Vertex AI structured output for open models](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/capabilities/structured-output)
- [Amazon Bedrock structured outputs](https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html)

## Test Plan
- [x] pnpm lint
- [x] pnpm typecheck:test
- [x] pnpm build
- [x] pnpm test --exclude **/*.live.test.ts
- [x] pnpm test src/vertexai/models/openai_chat_completions.test.ts src/bedrock-mantle/index.test.ts src/bedrock/structured-output.test.ts src/openai/schema.test.ts src/openai/openai_chat_completions.test.ts src/openai/responses-reasoning.test.ts