### PR TITLE
feat(vertexai): add Gemini Omni video generation

### DIFF
--- a/common/src/capability.test.ts
+++ b/common/src/capability.test.ts
@@ -69,6 +69,17 @@ describe('xAI Grok tool capabilities', () => {
     });
 });
 
+describe('Gemini Omni video capabilities', () => {
+    it('exposes only text/image input and video output', () => {
+        expect(getModelCapabilities('gemini-omni-flash-preview', Providers.vertexai)).toEqual({
+            input: { text: true, image: true, video: false, audio: false, embed: false },
+            output: { text: false, image: false, video: true, audio: false, embed: false },
+            tool_support: false,
+            tool_support_streaming: false,
+        });
+    });
+});
+
 describe('supportsToolUse streaming default', () => {
     it('falls back to tool_support when tool_support_streaming is unset', () => {
         // Vertex Grok records tool_support but not tool_support_streaming

--- a/common/src/capability.ts
+++ b/common/src/capability.ts
@@ -9,6 +9,15 @@ export function getModelCapabilities(model: string, provider: Providers): ModelC
             model = parts.slice(2).join('/');
         }
     }
+    const modelName = model.split('/').pop()?.toLowerCase();
+    if (provider === 'vertexai' && modelName === 'gemini-omni-flash-preview') {
+        return {
+            input: { text: true, image: true, video: false, audio: false, embed: false },
+            output: { text: false, image: false, video: true, audio: false, embed: false },
+            tool_support: false,
+            tool_support_streaming: false,
+        };
+    }
     const capabilities = resolveModelProfile(model, provider).capabilities;
     // The platform accepts audio/video inputs but cannot return those modalities yet. Keep source output metadata in
     // the directory so enabling output support later only requires removing this execution-path mask.

--- a/common/src/options/vertexai.ts
+++ b/common/src/options/vertexai.ts
@@ -3,6 +3,7 @@ import { resolveModelProfile } from '../model-directory.js';
 import type {
     ImagenOptionsSchema,
     VertexAIClaudeOptionsSchema,
+    VertexAIGeminiOmniVideoOptionsSchema,
     VertexAIGeminiOptionsSchema,
     VertexAIGrokOptionsSchema,
 } from '../schemas/model-options.js';
@@ -38,13 +39,19 @@ import { hasSamplingParameterRestriction, isGeminiModelVersionGte } from './vers
 export type ImagenOptions = z.infer<typeof ImagenOptionsSchema>;
 export type VertexAIClaudeOptions = z.infer<typeof VertexAIClaudeOptionsSchema>;
 export type VertexAIGeminiOptions = z.infer<typeof VertexAIGeminiOptionsSchema>;
+export type VertexAIGeminiOmniVideoOptions = z.infer<typeof VertexAIGeminiOmniVideoOptionsSchema>;
 export type VertexAIGrokOptions = z.infer<typeof VertexAIGrokOptionsSchema>;
 
 // Union type of all VertexAI options
 /**
  * @discriminator _option_id
  */
-export type VertexAIOptions = ImagenOptions | VertexAIClaudeOptions | VertexAIGeminiOptions | VertexAIGrokOptions;
+export type VertexAIOptions =
+    | ImagenOptions
+    | VertexAIClaudeOptions
+    | VertexAIGeminiOptions
+    | VertexAIGeminiOmniVideoOptions
+    | VertexAIGrokOptions;
 
 export enum ImagenTaskType {
     TEXT_IMAGE = 'TEXT_IMAGE',
@@ -94,6 +101,38 @@ export function isFlexSupportedGeminiModel(model: string): boolean {
 }
 
 export function getVertexAiOptions(model: string, option?: ModelOptions): ModelOptionsInfo {
+    if (model.split('/').pop() === 'gemini-omni-flash-preview') {
+        return {
+            _option_id: 'vertexai-gemini-omni-video',
+            options: [
+                {
+                    name: 'task',
+                    type: OptionType.enum,
+                    enum: {
+                        'Text to video': 'text_to_video',
+                        'Image to video': 'image_to_video',
+                        'Reference images to video': 'reference_to_video',
+                    },
+                    description: 'Video generation task. Image inputs require an explicit image task.',
+                },
+                {
+                    name: 'aspect_ratio',
+                    type: OptionType.enum,
+                    enum: { Landscape: '16:9', Portrait: '9:16' },
+                    description: 'Aspect ratio of the generated video.',
+                },
+                {
+                    name: 'duration_seconds',
+                    type: OptionType.numeric,
+                    min: 3,
+                    max: 10,
+                    default: 5,
+                    integer: true,
+                    description: 'Duration of the generated video in seconds.',
+                },
+            ],
+        };
+    }
     if (model.includes('imagen-')) {
         return getImagenOptions(model, option);
     } else if (model.includes('gemini')) {

--- a/common/src/schemas/completion.test.ts
+++ b/common/src/schemas/completion.test.ts
@@ -8,4 +8,11 @@ describe('CompletionResultSchema', () => {
             value: 'Reasoning summary',
         });
     });
+
+    it('accepts a provider-neutral video result', () => {
+        expect(CompletionResultSchema.parse({ type: 'video', value: 'gs://bucket/video.mp4' })).toEqual({
+            type: 'video',
+            value: 'gs://bucket/video.mp4',
+        });
+    });
 });

--- a/common/src/schemas/completion.ts
+++ b/common/src/schemas/completion.ts
@@ -116,8 +116,18 @@ export const ImageResultSchema = z
     .strictObject({ type: z.literal('image'), value: z.string() })
     .meta({ id: 'ImageResult' });
 
+export const VideoResultSchema = z
+    .strictObject({ type: z.literal('video'), value: z.string() })
+    .meta({ id: 'VideoResult' });
+
 export const CompletionResultSchema = z
-    .discriminatedUnion('type', [TextResultSchema, ThoughtsResultSchema, JsonResultSchema, ImageResultSchema])
+    .discriminatedUnion('type', [
+        TextResultSchema,
+        ThoughtsResultSchema,
+        JsonResultSchema,
+        ImageResultSchema,
+        VideoResultSchema,
+    ])
     .meta({ id: 'CompletionResult' });
 
 export const ExecutionTokenUsageSchema = z

--- a/common/src/schemas/model-options.test.ts
+++ b/common/src/schemas/model-options.test.ts
@@ -22,6 +22,28 @@ const emitted = z.toJSONSchema(ModelOptionsSchema, { target: 'draft-2020-12', io
 const MEMBERS = (emitted.oneOf ?? emitted.anyOf ?? []).map((member) => member.$ref.replace('#/$defs/', ''));
 
 describe('ModelOptionsSchema', () => {
+    it('validates strict Gemini Omni video option boundaries', () => {
+        expect(
+            ModelOptionsSchema.safeParse({
+                _option_id: 'vertexai-gemini-omni-video',
+                task: 'reference_to_video',
+                aspect_ratio: '16:9',
+                duration_seconds: 3,
+            }).success,
+        ).toBe(true);
+        expect(
+            ModelOptionsSchema.safeParse({ _option_id: 'vertexai-gemini-omni-video', duration_seconds: 10 }).success,
+        ).toBe(true);
+        expect(
+            ModelOptionsSchema.safeParse({ _option_id: 'vertexai-gemini-omni-video', duration_seconds: 2 }).success,
+        ).toBe(false);
+        expect(
+            ModelOptionsSchema.safeParse({ _option_id: 'vertexai-gemini-omni-video', duration_seconds: 5.5 }).success,
+        ).toBe(false);
+        expect(ModelOptionsSchema.safeParse({ _option_id: 'vertexai-gemini-omni-video', unknown: true }).success).toBe(
+            false,
+        );
+    });
     it('is the only definition of the union — the public type is inferred from it', () => {
         // Vacuous as an equality, and that is the point: `ModelOptions` in `../types.js` IS
         // `z.infer` of this schema, so there is no second declaration for it to disagree with. The
@@ -43,6 +65,7 @@ describe('ModelOptionsSchema', () => {
             'ImagenOptions',
             'VertexAIClaudeOptions',
             'VertexAIGeminiOptions',
+            'VertexAIGeminiOmniVideoOptions',
             'VertexAIGrokOptions',
             'NovaCanvasOptions',
             'BedrockConverseOptions',

--- a/common/src/schemas/model-options.ts
+++ b/common/src/schemas/model-options.ts
@@ -426,6 +426,15 @@ export const VertexAIGeminiOptionsSchema = z
     })
     .meta({ id: 'VertexAIGeminiOptions' });
 
+export const VertexAIGeminiOmniVideoOptionsSchema = z
+    .strictObject({
+        _option_id: z.literal('vertexai-gemini-omni-video'),
+        task: z.enum(['text_to_video', 'image_to_video', 'reference_to_video']).optional(),
+        aspect_ratio: z.enum(['16:9', '9:16']).optional(),
+        duration_seconds: z.number().int().min(3).max(10).optional(),
+    })
+    .meta({ id: 'VertexAIGeminiOmniVideoOptions' });
+
 export const VertexAIGrokOptionsSchema = z
     .strictObject({
         _option_id: z.literal('vertexai-grok'),
@@ -446,6 +455,7 @@ export const ModelOptionsSchema = z
         ImagenOptionsSchema,
         VertexAIClaudeOptionsSchema,
         VertexAIGeminiOptionsSchema,
+        VertexAIGeminiOmniVideoOptionsSchema,
         VertexAIGrokOptionsSchema,
         NovaCanvasOptionsSchema,
         BedrockConverseOptionsSchema,

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -362,7 +362,7 @@ export class LlumiverseError extends Error {
 // ============== Result Types ===============
 
 export interface BaseResult {
-    type: 'text' | 'thoughts' | 'json' | 'image';
+    type: 'text' | 'thoughts' | 'json' | 'image' | 'video';
     value: unknown;
 }
 
@@ -387,10 +387,15 @@ export interface ImageResult extends BaseResult {
     value: string; // base64 data url or real url
 }
 
+export interface VideoResult extends BaseResult {
+    type: 'video';
+    value: string;
+}
+
 /**
  * @discriminator type
  */
-export type CompletionResult = TextResult | ThoughtsResult | JsonResult | ImageResult;
+export type CompletionResult = TextResult | ThoughtsResult | JsonResult | ImageResult | VideoResult;
 
 //Internal structure used in driver implementation.
 export interface CompletionChunkObject {
@@ -612,6 +617,11 @@ export interface ExecutionOptionsBase extends PromptOptions {
 }
 
 export interface ExecutionOptions extends ExecutionOptionsBase {
+    /**
+     * Provider output prefix for generated media. This is prepared internally and is intentionally
+     * absent from StatelessExecutionOptions so API callers cannot select an arbitrary bucket.
+     */
+    output_storage_uri?: string;
     /**
      * Available tools for the request
      */

--- a/core/src/CompletionStream.thoughts.test.ts
+++ b/core/src/CompletionStream.thoughts.test.ts
@@ -15,7 +15,15 @@ import { AbstractDriver } from './Driver.js';
 class ThoughtsStreamDriver extends AbstractDriver<DriverOptions, string> {
     provider = 'test';
 
-    async requestTextCompletion(): Promise<Completion> {
+    async requestTextCompletion(prompt: string): Promise<Completion> {
+        if (prompt === 'video') {
+            return {
+                result: [
+                    { type: 'video', value: 'gs://bucket/one.mp4' },
+                    { type: 'video', value: 'gs://bucket/two.mp4' },
+                ],
+            };
+        }
         return {
             result: [
                 { type: 'thoughts', value: 'reason-fallback' },
@@ -26,6 +34,15 @@ class ThoughtsStreamDriver extends AbstractDriver<DriverOptions, string> {
 
     async requestTextCompletionStream(prompt: string): Promise<DriverCompletionStream> {
         const nativeAssistant = { role: 'assistant', id: prompt };
+        if (prompt === 'video') {
+            return {
+                async *[Symbol.asyncIterator]() {
+                    yield { result: [{ type: 'video', value: 'gs://bucket/one.mp4' }] };
+                    yield { result: [{ type: 'video', value: 'gs://bucket/two.mp4' }], finish_reason: 'stop' };
+                },
+                finalizeConversation: () => nativeAssistant,
+            };
+        }
         return {
             async *[Symbol.asyncIterator]() {
                 yield { result: [{ type: 'thoughts', value: 'reason-' }] };
@@ -96,5 +113,30 @@ describe('DefaultCompletionStream thoughts', () => {
 
         expect(streams[0].completion?.conversation).toEqual({ role: 'assistant', id: 'left' });
         expect(streams[1].completion?.conversation).toEqual({ role: 'assistant', id: 'right' });
+    });
+
+    it('keeps streamed video results discrete', async () => {
+        const driver = new ThoughtsStreamDriver({});
+        const stream = new DefaultCompletionStream(driver, 'video', { model: 'test' });
+
+        const visible: string[] = [];
+        for await (const chunk of stream) visible.push(chunk);
+
+        expect(visible).toEqual(['\n[Video: gs://bucket/one.mp4]\n', '\n[Video: gs://bucket/two.mp4]\n']);
+        expect(stream.completion?.result).toEqual([
+            { type: 'video', value: 'gs://bucket/one.mp4' },
+            { type: 'video', value: 'gs://bucket/two.mp4' },
+        ]);
+    });
+
+    it('preserves video results through fallback streaming', async () => {
+        const driver = new ThoughtsStreamDriver({});
+        const stream = new FallbackCompletionStream(driver, 'video', { model: 'test' });
+
+        const visible: string[] = [];
+        for await (const chunk of stream) visible.push(chunk);
+
+        expect(visible).toEqual(['[Video: gs://bucket/one.mp4][Video: gs://bucket/two.mp4]']);
+        expect(stream.completion?.result).toHaveLength(2);
     });
 });

--- a/core/src/CompletionStream.ts
+++ b/core/src/CompletionStream.ts
@@ -406,7 +406,8 @@ export class DefaultCompletionStream<PromptT = unknown> extends ManagedCompletio
                                             }
                                             break;
                                         case 'image':
-                                            // Images are discrete results and must retain their original boundaries.
+                                        case 'video':
+                                            // Media outputs are discrete results and must retain their original boundaries.
                                             accumulatedResults.push(result);
                                             break;
                                     }
@@ -439,6 +440,8 @@ export class DefaultCompletionStream<PromptT = unknown> extends ManagedCompletio
                                                     : String(r.value).slice(0, 10);
                                             return `\n[Image: ${truncatedValue}...]\n`;
                                         }
+                                        case 'video':
+                                            return `\n[Video: ${r.value}]\n`;
                                         default: {
                                             const _exhaustive: never = r;
                                             return String(_exhaustive);
@@ -598,6 +601,8 @@ export class FallbackCompletionStream<PromptT = unknown> extends ManagedCompleti
                                 typeof r.value === 'string' ? r.value.slice(0, 10) : String(r.value).slice(0, 10);
                             return `[Image: ${truncatedValue}...]`;
                         }
+                        case 'video':
+                            return `[Video: ${r.value}]`;
                         default: {
                             const _exhaustive: never = r;
                             return String(_exhaustive);

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -1064,6 +1064,8 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
                     case 'image':
                         // Skip images in conversation - they're in the result
                         return '';
+                    case 'video':
+                        return '';
                     default: {
                         const _exhaustive: never = r;
                         return String(_exhaustive);

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -864,6 +864,8 @@ function completionResultsToText(completionResults: CompletionResult[] | undefin
                 case 'image':
                     // Skip images in conversation - they're in the result
                     return '';
+                case 'video':
+                    return '';
                 default: {
                     const _exhaustive: never = r;
                     return String(_exhaustive);

--- a/drivers/src/vertexai/index.test.ts
+++ b/drivers/src/vertexai/index.test.ts
@@ -26,6 +26,7 @@ class TestVertexAIDriver extends VertexAIDriver {
                     return [
                         [
                             { name: 'publishers/google/models/gemini-4-future' },
+                            { name: 'publishers/google/models/gemini-omni-flash-preview' },
                             { name: 'publishers/google/models/gemini-live-future' },
                             { name: 'publishers/google/models/gemini-4-tts' },
                         ],
@@ -52,6 +53,18 @@ describe('VertexAIDriver listModels', () => {
 
         expect(modelIds).toContain('locations/global/publishers/xai/models/grok-4.1');
         expect(modelIds).not.toContain('publishers/xai/models/grok-4.1');
+    });
+
+    it('lists Gemini Omni only with its global location id', async () => {
+        const models = await new TestVertexAIDriver().listModels();
+        const omniModels = models.filter((model) => model.id.includes('gemini-omni-flash-preview'));
+
+        expect(omniModels).toEqual([
+            expect.objectContaining({
+                id: 'locations/global/publishers/google/models/gemini-omni-flash-preview',
+                name: 'Global gemini-omni-flash-preview',
+            }),
+        ]);
     });
 
     it('uses supported actions to keep only models executable by the implemented Google paths', async () => {

--- a/drivers/src/vertexai/index.ts
+++ b/drivers/src/vertexai/index.ts
@@ -36,6 +36,7 @@ import { generateVertexAiEmbeddings } from './embeddings/embed.js';
 import { ANTHROPIC_REGIONS, NON_GLOBAL_ANTHROPIC_MODELS } from './models/claude.js';
 import { formatGeminiDebugPrompt } from './models/gemini.js';
 import { formatImagenDebugPrompt, ImagenModelDefinition, type ImagenPrompt } from './models/imagen.js';
+import { GEMINI_OMNI_VIDEO_MODEL, type OmniVideoPrompt } from './models/omni-video.js';
 import { getModelDefinition, trimModelName } from './models.js';
 import { getListedVertexOpenMaaSModels } from './open-maas-models.js';
 
@@ -69,7 +70,12 @@ function isClaudeStreamingPrompt(prompt: unknown): prompt is ClaudeStreamingProm
 }
 
 //General Prompt type for VertexAI
-export type VertexAIPrompt = ImagenPrompt | GenerateContentPrompt | ClaudePrompt | OpenAIChatCompletionsPrompt;
+export type VertexAIPrompt =
+    | ImagenPrompt
+    | OmniVideoPrompt
+    | GenerateContentPrompt
+    | ClaudePrompt
+    | OpenAIChatCompletionsPrompt;
 
 export { trimModelName };
 
@@ -230,6 +236,10 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
         return client;
     }
 
+    public getRequestTimeoutMs(httpTimeout?: HttpTimeoutOptions): number {
+        return this.getDriverRequestTimeoutMs(httpTimeout);
+    }
+
     public async getAnthropicClient(
         region: string = this.options.region,
         httpTimeout?: HttpTimeoutOptions,
@@ -350,6 +360,9 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
         if ('messages' in prompt) {
             return prompt;
         }
+        if ('text' in prompt && 'images' in prompt) {
+            return prompt;
+        }
         return formatImagenDebugPrompt(prompt);
     }
 
@@ -414,6 +427,8 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
                         return typeof r.value === 'string' ? r.value : JSON.stringify(r.value);
                     case 'image':
                         // Skip images in conversation - they're in the result
+                        return '';
+                    case 'video':
                         return '';
                     default: {
                         const _exhaustive: never = r;
@@ -516,6 +531,8 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
                     case 'json':
                         return typeof r.value === 'string' ? r.value : JSON.stringify(r.value);
                     case 'image':
+                        return '';
+                    case 'video':
                         return '';
                     default: {
                         const _exhaustive: never = r;
@@ -641,7 +658,7 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
                 ],
                 /** Additional models not in the listings, but we want to include.
                  * TODO: Remove once available in listing API. */
-                additional: ['imagen-3.0-fast-generate-001'],
+                additional: ['imagen-3.0-fast-generate-001', 'gemini-omni-flash-preview'],
             },
             anthropic: {
                 families: ['claude'],
@@ -740,7 +757,7 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
                     })
                     .map((model) => {
                         const rawModelId = model.name ?? '';
-                        const isGlobalOnlyPublisher = publisher === 'xai';
+                        const isGlobalOnlyPublisher = isGlobalOnlyPublisherModel(publisher, rawModelId);
                         const listedModelId = isGlobalOnlyPublisher ? `locations/global/${rawModelId}` : rawModelId;
                         const modelMetadata = resolveModelListingMetadata(listedModelId, Providers.vertexai);
                         return {
@@ -829,11 +846,12 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
 
             // Add additional models that are not in the listing
             for (const additionalModel of publisherConfig[publisher as Publisher].additional) {
-                const publisherModelName = `publishers/${publisher}/models/${additionalModel}`;
+                const rawModelId = `publishers/${publisher}/models/${additionalModel}`;
+                const isGlobalOnlyPublisher = isGlobalOnlyPublisherModel(publisher, rawModelId);
                 const modelMetadata = resolveModelListingMetadata(additionalModel, Providers.vertexai);
                 models.push({
-                    id: publisherModelName,
-                    name: additionalModel,
+                    id: isGlobalOnlyPublisher ? `locations/global/${rawModelId}` : rawModelId,
+                    name: isGlobalOnlyPublisher ? `Global ${additionalModel}` : additionalModel,
                     provider: 'vertexai',
                     owner: publisher,
                     ...modelMetadata,
@@ -887,8 +905,13 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
     }
 }
 
+function isGlobalOnlyPublisherModel(publisher: string, modelId: string): boolean {
+    return publisher === 'xai' || (publisher === 'google' && modelId.endsWith(`/models/${GEMINI_OMNI_VIDEO_MODEL}`));
+}
+
 function isExecutableGoogleModel(model: Model): boolean {
     const modelName = (model.name ?? '').toLowerCase();
+    if (modelName.endsWith('/gemini-omni-flash-preview') || modelName === 'gemini-omni-flash-preview') return true;
     // Intentional execution-path allow-list: Vertex uses separate methods for embeddings, Live/TTS, music and video.
     // This driver currently implements generateContent and generateImages. Unknown actions are excluded only when
     // Google supplies them; absent action metadata falls back to the known-family/name policy above.

--- a/drivers/src/vertexai/models.ts
+++ b/drivers/src/vertexai/models.ts
@@ -10,6 +10,7 @@ import type {
 import type { VertexAIDriver, VertexAIPrompt } from './index.js';
 import { ClaudeModelDefinition } from './models/claude.js';
 import { GeminiModelDefinition } from './models/gemini.js';
+import { GEMINI_OMNI_VIDEO_MODEL, GeminiOmniVideoModelDefinition } from './models/omni-video.js';
 import { OpenAIChatCompletionsModelDefinition } from './models/openai_chat_completions.js';
 import { getVertexOpenMaaSRequestModel } from './open-maas-models.js';
 
@@ -81,6 +82,10 @@ export function getModelDefinition(model: string): ModelDefinition {
                 extraBody: openMaaSModel.extraBody,
             });
         }
+    }
+
+    if (modelName === GEMINI_OMNI_VIDEO_MODEL) {
+        return new GeminiOmniVideoModelDefinition();
     }
 
     if (publisher === 'xai') {

--- a/drivers/src/vertexai/models/omni-video.test.ts
+++ b/drivers/src/vertexai/models/omni-video.test.ts
@@ -210,13 +210,15 @@ describe('GeminiOmniVideoModelDefinition', () => {
     });
 
     it.each([
-        ['in_progress', true],
-        ['incomplete', true],
-        ['requires_action', false],
-        ['cancelled', false],
-        ['budget_exceeded', false],
-        ['failed', undefined],
-    ] as const)('classifies interaction status %s with retryable=%s', async (status, retryable) => {
+        ['in_progress', undefined, true],
+        ['incomplete', undefined, true],
+        ['requires_action', undefined, false],
+        ['cancelled', undefined, false],
+        ['budget_exceeded', undefined, false],
+        ['failed', [{ code: 'RESOURCE_EXHAUSTED', message: 'Try later' }], true],
+        ['failed', [{ code: 'PERMISSION_DENIED', message: 'Forbidden' }], false],
+        ['failed', [{ code: 'UNKNOWN', message: 'Unknown failure' }], undefined],
+    ] as const)('classifies interaction status %s errors %j with retryable=%s', async (status, errors, retryable) => {
         const definition = new GeminiOmniVideoModelDefinition();
         const prompt = await definition.createPrompt(
             {} as VertexAIDriver,
@@ -226,7 +228,7 @@ describe('GeminiOmniVideoModelDefinition', () => {
         let thrown: unknown;
         try {
             await definition.requestTextCompletion(
-                driverWithResponse({ id: 'interaction-1', status }).driver,
+                driverWithResponse({ id: 'interaction-1', status, errors }).driver,
                 prompt,
                 options(),
             );

--- a/drivers/src/vertexai/models/omni-video.test.ts
+++ b/drivers/src/vertexai/models/omni-video.test.ts
@@ -27,6 +27,7 @@ function options(overrides: Partial<ExecutionOptions> = {}): ExecutionOptions {
 
 function completedResponse(...uris: string[]) {
     return {
+        id: 'interaction-1',
         status: 'completed',
         usage: { total_tokens: 9, total_input_tokens: 3, total_output_tokens: 6 },
         steps: [
@@ -187,20 +188,57 @@ describe('GeminiOmniVideoModelDefinition', () => {
         ).rejects.toThrow(message);
     });
 
-    it('classifies cancellation, timeout and gateway timeout as terminal', () => {
+    it('keeps deliberate cancellation terminal and delegates transport failures to shared retry handling', () => {
         const definition = new GeminiOmniVideoModelDefinition();
+        const context = {
+            provider: 'vertexai',
+            model: GEMINI_OMNI_VIDEO_MODEL,
+            operation: 'execute' as const,
+        };
+        const cancellation = Object.assign(new Error('cancelled'), { name: 'AbortError' });
+        const formatted = definition.formatLlumiverseError({} as VertexAIDriver, cancellation, context);
+
+        expect(formatted).toBeInstanceOf(LlumiverseError);
+        expect(formatted.retryable).toBe(false);
+
         for (const error of [
-            Object.assign(new Error('cancelled'), { name: 'AbortError' }),
             Object.assign(new Error('timed out'), { name: 'TimeoutError' }),
             Object.assign(new Error('gateway timeout'), { status: 504 }),
         ]) {
-            const formatted = definition.formatLlumiverseError({} as VertexAIDriver, error, {
-                provider: 'vertexai',
-                model: GEMINI_OMNI_VIDEO_MODEL,
-                operation: 'execute',
-            });
-            expect(formatted).toBeInstanceOf(LlumiverseError);
-            expect(formatted.retryable).toBe(false);
+            expect(() => definition.formatLlumiverseError({} as VertexAIDriver, error, context)).toThrow(error);
         }
+    });
+
+    it.each([
+        ['in_progress', true],
+        ['incomplete', true],
+        ['requires_action', false],
+        ['cancelled', false],
+        ['budget_exceeded', false],
+        ['failed', undefined],
+    ] as const)('classifies interaction status %s with retryable=%s', async (status, retryable) => {
+        const definition = new GeminiOmniVideoModelDefinition();
+        const prompt = await definition.createPrompt(
+            {} as VertexAIDriver,
+            [{ role: PromptRole.user, content: 'prompt' }],
+            options(),
+        );
+        let thrown: unknown;
+        try {
+            await definition.requestTextCompletion(
+                driverWithResponse({ id: 'interaction-1', status }).driver,
+                prompt,
+                options(),
+            );
+        } catch (error) {
+            thrown = error;
+        }
+
+        const formatted = definition.formatLlumiverseError({} as VertexAIDriver, thrown, {
+            provider: 'vertexai',
+            model: GEMINI_OMNI_VIDEO_MODEL,
+            operation: 'execute',
+        });
+        expect(formatted.retryable).toBe(retryable);
     });
 });

--- a/drivers/src/vertexai/models/omni-video.test.ts
+++ b/drivers/src/vertexai/models/omni-video.test.ts
@@ -1,0 +1,206 @@
+import { type DataSource, type ExecutionOptions, LlumiverseError, PromptRole } from '@llumiverse/core';
+import { describe, expect, it, vi } from 'vitest';
+import type { VertexAIDriver } from '../index.js';
+import { getModelDefinition } from '../models.js';
+import { GEMINI_OMNI_VIDEO_MODEL, GeminiOmniVideoModelDefinition } from './omni-video.js';
+
+const OUTPUT_PREFIX = 'gs://project-bucket/runs/run-1/media/';
+
+function image(uri = 'gs://project-bucket/input/frame.png', mimeType = 'image/png'): DataSource {
+    return {
+        name: 'frame.png',
+        mime_type: mimeType,
+        getURI: vi.fn().mockResolvedValue(uri),
+        getURL: vi.fn(),
+        getStream: vi.fn(),
+    };
+}
+
+function options(overrides: Partial<ExecutionOptions> = {}): ExecutionOptions {
+    return {
+        model: GEMINI_OMNI_VIDEO_MODEL,
+        model_options: { _option_id: 'vertexai-gemini-omni-video' },
+        output_storage_uri: OUTPUT_PREFIX,
+        ...overrides,
+    };
+}
+
+function completedResponse(...uris: string[]) {
+    return {
+        status: 'completed',
+        usage: { total_tokens: 9, total_input_tokens: 3, total_output_tokens: 6 },
+        steps: [
+            { type: 'thought', summary: [{ type: 'text', text: 'hidden' }] },
+            {
+                type: 'model_output',
+                content: uris.map((uri) => ({ type: 'video', uri, mime_type: 'video/mp4' })),
+            },
+        ],
+    };
+}
+
+function driverWithResponse(response: unknown) {
+    const post = vi.fn().mockResolvedValue(response);
+    const getFetchClientForRegion = vi.fn(() => ({ post }));
+    const getRequestTimeoutMs = vi.fn(() => 900_000);
+    return {
+        driver: { getFetchClientForRegion, getRequestTimeoutMs } as unknown as VertexAIDriver,
+        getFetchClientForRegion,
+        getRequestTimeoutMs,
+        post,
+    };
+}
+
+describe('GeminiOmniVideoModelDefinition', () => {
+    it('routes the exact model to the dedicated non-streaming definition', () => {
+        const definition = getModelDefinition('publishers/google/models/gemini-omni-flash-preview');
+
+        expect(definition).toBeInstanceOf(GeminiOmniVideoModelDefinition);
+        expect(definition.model).toMatchObject({ type: 'video', can_stream: false });
+    });
+
+    it('constructs a text-to-video request with defaults and the global beta endpoint', async () => {
+        const definition = new GeminiOmniVideoModelDefinition();
+        const prompt = await definition.createPrompt(
+            {} as VertexAIDriver,
+            [
+                { role: PromptRole.system, content: 'Cinematic' },
+                { role: PromptRole.user, content: 'A fox in snow' },
+            ],
+            options(),
+        );
+        const stub = driverWithResponse(completedResponse(`${OUTPUT_PREFIX}video.mp4`));
+
+        const completion = await definition.requestTextCompletion(stub.driver, prompt, options());
+
+        expect(stub.getFetchClientForRegion).toHaveBeenCalledWith('global', 'v1beta1');
+        expect(stub.post).toHaveBeenCalledWith('interactions', {
+            payload: {
+                model: GEMINI_OMNI_VIDEO_MODEL,
+                input: [{ type: 'text', text: 'Cinematic\nA fox in snow' }],
+                response_format: [{ type: 'video', delivery: 'uri', gcs_uri: OUTPUT_PREFIX, duration: '5s' }],
+                generation_config: { video_config: { task: 'text_to_video' } },
+            },
+            signal: undefined,
+            timeoutMs: 900_000,
+        });
+        expect(completion).toEqual({
+            result: [{ type: 'video', value: `${OUTPUT_PREFIX}video.mp4` }],
+            token_usage: { total: 9, prompt: 3, result: 6 },
+            finish_reason: 'stop',
+        });
+    });
+
+    it('maps a GCS first frame without reading its bytes', async () => {
+        const source = image();
+        const definition = new GeminiOmniVideoModelDefinition();
+        const configured = options({
+            model_options: {
+                _option_id: 'vertexai-gemini-omni-video',
+                task: 'image_to_video',
+                aspect_ratio: '9:16',
+                duration_seconds: 10,
+            },
+        });
+        const prompt = await definition.createPrompt(
+            {} as VertexAIDriver,
+            [{ role: PromptRole.user, content: 'Animate this', files: [source] }],
+            configured,
+        );
+        const stub = driverWithResponse(completedResponse(`${OUTPUT_PREFIX}one.mp4`, `${OUTPUT_PREFIX}two.mp4`));
+
+        const completion = await definition.requestTextCompletion(stub.driver, prompt, configured);
+
+        expect(source.getURI).toHaveBeenCalledOnce();
+        expect(source.getStream).not.toHaveBeenCalled();
+        expect(stub.post.mock.calls[0]?.[1]).toMatchObject({
+            payload: {
+                input: [
+                    { type: 'text', text: 'Animate this' },
+                    { type: 'image', uri: 'gs://project-bucket/input/frame.png', mime_type: 'image/png' },
+                ],
+                response_format: [expect.objectContaining({ aspect_ratio: '9:16', duration: '10s' })],
+                generation_config: { video_config: { task: 'image_to_video' } },
+            },
+        });
+        expect(completion.result).toHaveLength(2);
+    });
+
+    it('accepts one to three reference images and requires an explicit image task', async () => {
+        const definition = new GeminiOmniVideoModelDefinition();
+        const references = [image('gs://inputs/1.png'), image('gs://inputs/2.png'), image('gs://inputs/3.png')];
+        const configured = options({
+            model_options: { _option_id: 'vertexai-gemini-omni-video', task: 'reference_to_video' },
+        });
+
+        const prompt = await definition.createPrompt(
+            {} as VertexAIDriver,
+            [{ role: PromptRole.user, content: 'Use these', files: references }],
+            configured,
+        );
+
+        expect(prompt.images).toHaveLength(3);
+        await expect(
+            definition.createPrompt(
+                {} as VertexAIDriver,
+                [{ role: PromptRole.user, content: 'Use this', files: [image()] }],
+                options(),
+            ),
+        ).rejects.toThrow('requires an explicit');
+    });
+
+    it.each([
+        ['empty prompt', [{ role: PromptRole.user, content: '  ' }], options(), 'non-empty'],
+        [
+            'unsupported MIME type',
+            [{ role: PromptRole.user, content: 'prompt', files: [image('gs://inputs/a.gif', 'image/gif')] }],
+            options({ model_options: { _option_id: 'vertexai-gemini-omni-video', task: 'image_to_video' } }),
+            'MIME type',
+        ],
+        [
+            'non-GCS image',
+            [{ role: PromptRole.user, content: 'prompt', files: [image('https://example.com/a.png')] }],
+            options({ model_options: { _option_id: 'vertexai-gemini-omni-video', task: 'image_to_video' } }),
+            'GCS object URI',
+        ],
+    ])('rejects %s', async (_name, segments, configured, message) => {
+        await expect(
+            new GeminiOmniVideoModelDefinition().createPrompt({} as VertexAIDriver, segments, configured),
+        ).rejects.toThrow(message);
+    });
+
+    it.each([
+        [{ status: 'in_progress' }, 'did not complete'],
+        [completedResponse(), 'without a video'],
+        [completedResponse('gs://foreign-bucket/video.mp4'), 'outside the requested output prefix'],
+        [completedResponse('https://example.com/video.mp4'), 'invalid GCS video URI'],
+    ])('rejects incomplete or invalid provider output', async (response, message) => {
+        const definition = new GeminiOmniVideoModelDefinition();
+        const prompt = await definition.createPrompt(
+            {} as VertexAIDriver,
+            [{ role: PromptRole.user, content: 'prompt' }],
+            options(),
+        );
+
+        await expect(
+            definition.requestTextCompletion(driverWithResponse(response).driver, prompt, options()),
+        ).rejects.toThrow(message);
+    });
+
+    it('classifies cancellation, timeout and gateway timeout as terminal', () => {
+        const definition = new GeminiOmniVideoModelDefinition();
+        for (const error of [
+            Object.assign(new Error('cancelled'), { name: 'AbortError' }),
+            Object.assign(new Error('timed out'), { name: 'TimeoutError' }),
+            Object.assign(new Error('gateway timeout'), { status: 504 }),
+        ]) {
+            const formatted = definition.formatLlumiverseError({} as VertexAIDriver, error, {
+                provider: 'vertexai',
+                model: GEMINI_OMNI_VIDEO_MODEL,
+                operation: 'execute',
+            });
+            expect(formatted).toBeInstanceOf(LlumiverseError);
+            expect(formatted.retryable).toBe(false);
+        }
+    });
+});

--- a/drivers/src/vertexai/models/omni-video.ts
+++ b/drivers/src/vertexai/models/omni-video.ts
@@ -1,3 +1,4 @@
+import type { Interactions } from '@google/genai';
 import {
     type AIModel,
     type Completion,
@@ -28,29 +29,20 @@ export interface OmniVideoPrompt {
     images: OmniVideoImageInput[];
 }
 
-interface OmniInteractionResponse {
-    status?: string;
-    error?: unknown;
-    usage?: {
-        total_tokens?: number;
-        total_input_tokens?: number;
-        total_output_tokens?: number;
-    };
-    steps?: Array<{
-        type?: string;
-        content?: Array<{
-            type?: string;
-            uri?: string;
-            mime_type?: string;
-            data?: unknown;
-        }>;
-    }>;
-}
-
 class OmniVideoTerminalError extends Error {
     constructor(message: string) {
         super(message);
         this.name = 'OmniVideoTerminalError';
+    }
+}
+
+class OmniVideoInteractionError extends Error {
+    constructor(
+        message: string,
+        readonly retryable: boolean | undefined,
+    ) {
+        super(message);
+        this.name = 'OmniVideoInteractionError';
     }
 }
 
@@ -85,11 +77,14 @@ function resolveTask(options: VertexAIGeminiOmniVideoOptions | undefined, imageC
     return task;
 }
 
-function parseVideoResults(response: OmniInteractionResponse, outputPrefix: string) {
+function parseVideoResults(response: Interactions.Interaction, outputPrefix: string) {
     if (response.status !== 'completed') {
-        const details = response.error ? `: ${JSON.stringify(response.error)}` : '';
-        throw new OmniVideoTerminalError(
-            `Gemini Omni video interaction did not complete (status: ${response.status ?? 'missing'})${details}`,
+        const details = response.errors?.length ? `: ${JSON.stringify(response.errors)}` : '';
+        const permanent = new Set(['requires_action', 'cancelled', 'budget_exceeded']);
+        const transient = new Set(['queued', 'in_progress', 'incomplete']);
+        throw new OmniVideoInteractionError(
+            `Gemini Omni video interaction did not complete (status: ${response.status})${details}`,
+            permanent.has(response.status) ? false : transient.has(response.status) ? true : undefined,
         );
     }
 
@@ -116,15 +111,6 @@ function parseVideoResults(response: OmniInteractionResponse, outputPrefix: stri
         }
         return { type: 'video' as const, value: part.uri };
     });
-}
-
-function statusCode(error: unknown): number | undefined {
-    if (!error || typeof error !== 'object') return undefined;
-    const candidate = error as { code?: unknown; status?: unknown; statusCode?: unknown };
-    for (const value of [candidate.code, candidate.status, candidate.statusCode]) {
-        if (typeof value === 'number') return value;
-    }
-    return undefined;
 }
 
 export class GeminiOmniVideoModelDefinition implements ModelDefinition<OmniVideoPrompt> {
@@ -193,15 +179,16 @@ export class GeminiOmniVideoModelDefinition implements ModelDefinition<OmniVideo
             duration: `${modelOptions?.duration_seconds ?? 5}s`,
             ...(modelOptions?.aspect_ratio ? { aspect_ratio: modelOptions.aspect_ratio } : {}),
         };
+        const payload = {
+            model: GEMINI_OMNI_VIDEO_MODEL,
+            input: [{ type: 'text' as const, text: prompt.text }, ...prompt.images],
+            response_format: [responseFormat],
+            generation_config: { video_config: { task } },
+        } satisfies Interactions.CreateModelInteractionParamsNonStreaming;
         const response = await driver
             .getFetchClientForRegion('global', 'v1beta1')
-            .post<OmniInteractionResponse>('interactions', {
-                payload: {
-                    model: GEMINI_OMNI_VIDEO_MODEL,
-                    input: [{ type: 'text', text: prompt.text }, ...prompt.images],
-                    response_format: [responseFormat],
-                    generation_config: { video_config: { task } },
-                },
+            .post<Interactions.Interaction>('interactions', {
+                payload,
                 signal,
                 timeoutMs: driver.getRequestTimeoutMs(options.httpTimeout),
             });
@@ -224,17 +211,21 @@ export class GeminiOmniVideoModelDefinition implements ModelDefinition<OmniVideo
     }
 
     formatLlumiverseError(_driver: VertexAIDriver, error: unknown, context: LlumiverseErrorContext): LlumiverseError {
-        const code = statusCode(error);
+        if (!(error instanceof OmniVideoTerminalError) && !(error instanceof OmniVideoInteractionError)) {
+            if (!(error instanceof Error) || error.name !== 'AbortError') {
+                // Let VertexAIDriver fall back to the shared HTTP/network classifier. In particular,
+                // timeouts and all 5xx responses are retryable while ordinary 4xx responses are not.
+                throw error;
+            }
+        }
+        const retryable = error instanceof OmniVideoInteractionError ? error.retryable : false;
         const name = error instanceof Error ? error.name : 'GeminiOmniVideoError';
-        const terminal =
-            error instanceof OmniVideoTerminalError || name === 'AbortError' || name === 'TimeoutError' || code === 504;
-        const retryable = terminal ? false : code === 429 || code === 500 || code === 503 ? true : undefined;
         return new LlumiverseError(
             error instanceof Error ? error.message : String(error),
             retryable,
             context,
             error,
-            code,
+            undefined,
             name,
         );
     }

--- a/drivers/src/vertexai/models/omni-video.ts
+++ b/drivers/src/vertexai/models/omni-video.ts
@@ -77,6 +77,34 @@ function resolveTask(options: VertexAIGeminiOmniVideoOptions | undefined, imageC
     return task;
 }
 
+function interactionFailureRetryable(errors: Interactions.Error[] | undefined): boolean | undefined {
+    const details = JSON.stringify(errors ?? []).toLowerCase();
+    if (
+        details.includes('invalid_argument') ||
+        details.includes('unauthenticated') ||
+        details.includes('permission_denied') ||
+        details.includes('not_found') ||
+        details.includes('failed_precondition') ||
+        details.includes('out_of_range') ||
+        details.includes('unimplemented')
+    ) {
+        return false;
+    }
+    if (
+        details.includes('resource_exhausted') ||
+        details.includes('rate_limit') ||
+        details.includes('throttl') ||
+        details.includes('aborted') ||
+        details.includes('internal') ||
+        details.includes('unavailable') ||
+        details.includes('deadline_exceeded') ||
+        details.includes('timeout')
+    ) {
+        return true;
+    }
+    return undefined;
+}
+
 function parseVideoResults(response: Interactions.Interaction, outputPrefix: string) {
     if (response.status !== 'completed') {
         const details = response.errors?.length ? `: ${JSON.stringify(response.errors)}` : '';
@@ -84,7 +112,11 @@ function parseVideoResults(response: Interactions.Interaction, outputPrefix: str
         const transient = new Set(['queued', 'in_progress', 'incomplete']);
         throw new OmniVideoInteractionError(
             `Gemini Omni video interaction did not complete (status: ${response.status})${details}`,
-            permanent.has(response.status) ? false : transient.has(response.status) ? true : undefined,
+            permanent.has(response.status)
+                ? false
+                : transient.has(response.status)
+                  ? true
+                  : interactionFailureRetryable(response.errors),
         );
     }
 

--- a/drivers/src/vertexai/models/omni-video.ts
+++ b/drivers/src/vertexai/models/omni-video.ts
@@ -1,0 +1,241 @@
+import {
+    type AIModel,
+    type Completion,
+    type DriverCompletionStream,
+    type ExecutionOptions,
+    type ExecutionTokenUsage,
+    LlumiverseError,
+    type LlumiverseErrorContext,
+    ModelType,
+    type PromptSegment,
+    type VertexAIGeminiOmniVideoOptions,
+} from '@llumiverse/core';
+import type { VertexAIDriver } from '../index.js';
+import type { ModelDefinition } from '../models.js';
+
+export const GEMINI_OMNI_VIDEO_MODEL = 'gemini-omni-flash-preview';
+
+const SUPPORTED_IMAGE_MIME_TYPES = new Set(['image/png', 'image/jpeg', 'image/webp', 'image/heic', 'image/heif']);
+
+interface OmniVideoImageInput {
+    type: 'image';
+    uri: string;
+    mime_type: string;
+}
+
+export interface OmniVideoPrompt {
+    text: string;
+    images: OmniVideoImageInput[];
+}
+
+interface OmniInteractionResponse {
+    status?: string;
+    error?: unknown;
+    usage?: {
+        total_tokens?: number;
+        total_input_tokens?: number;
+        total_output_tokens?: number;
+    };
+    steps?: Array<{
+        type?: string;
+        content?: Array<{
+            type?: string;
+            uri?: string;
+            mime_type?: string;
+            data?: unknown;
+        }>;
+    }>;
+}
+
+class OmniVideoTerminalError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'OmniVideoTerminalError';
+    }
+}
+
+function isGcsUri(value: string, requireObject = false): boolean {
+    const match = /^gs:\/\/([^/]+)\/(.*)$/.exec(value);
+    return !!match && (!requireObject || match[2].length > 0);
+}
+
+function normalizeOutputPrefix(value: string | undefined): string {
+    if (!value || !isGcsUri(value)) {
+        throw new OmniVideoTerminalError('Gemini Omni video generation requires a valid GCS output prefix');
+    }
+    return value.endsWith('/') ? value : `${value}/`;
+}
+
+function resolveTask(options: VertexAIGeminiOmniVideoOptions | undefined, imageCount: number) {
+    const task = options?.task ?? (imageCount === 0 ? 'text_to_video' : undefined);
+    if (!task) {
+        throw new OmniVideoTerminalError(
+            'Gemini Omni video generation with images requires an explicit image_to_video or reference_to_video task',
+        );
+    }
+    if (task === 'text_to_video' && imageCount !== 0) {
+        throw new OmniVideoTerminalError('text_to_video does not accept image inputs');
+    }
+    if (task === 'image_to_video' && imageCount !== 1) {
+        throw new OmniVideoTerminalError('image_to_video requires exactly one image input');
+    }
+    if (task === 'reference_to_video' && (imageCount < 1 || imageCount > 3)) {
+        throw new OmniVideoTerminalError('reference_to_video requires between one and three image inputs');
+    }
+    return task;
+}
+
+function parseVideoResults(response: OmniInteractionResponse, outputPrefix: string) {
+    if (response.status !== 'completed') {
+        const details = response.error ? `: ${JSON.stringify(response.error)}` : '';
+        throw new OmniVideoTerminalError(
+            `Gemini Omni video interaction did not complete (status: ${response.status ?? 'missing'})${details}`,
+        );
+    }
+
+    const videoParts = (response.steps ?? [])
+        .filter((step) => step.type === 'model_output')
+        .flatMap((step) => step.content ?? [])
+        .filter((part) => part.type === 'video');
+    if (videoParts.length === 0) {
+        throw new OmniVideoTerminalError('Gemini Omni completed without a video output URI');
+    }
+
+    return videoParts.map((part) => {
+        if (part.data !== undefined) {
+            throw new OmniVideoTerminalError('Gemini Omni returned inline video data instead of URI delivery');
+        }
+        if (!part.uri || !isGcsUri(part.uri, true)) {
+            throw new OmniVideoTerminalError('Gemini Omni returned a missing or invalid GCS video URI');
+        }
+        if (!part.uri.startsWith(outputPrefix)) {
+            throw new OmniVideoTerminalError('Gemini Omni returned a video URI outside the requested output prefix');
+        }
+        if (part.mime_type && !part.mime_type.startsWith('video/')) {
+            throw new OmniVideoTerminalError(`Gemini Omni returned an invalid video MIME type: ${part.mime_type}`);
+        }
+        return { type: 'video' as const, value: part.uri };
+    });
+}
+
+function statusCode(error: unknown): number | undefined {
+    if (!error || typeof error !== 'object') return undefined;
+    const candidate = error as { code?: unknown; status?: unknown; statusCode?: unknown };
+    for (const value of [candidate.code, candidate.status, candidate.statusCode]) {
+        if (typeof value === 'number') return value;
+    }
+    return undefined;
+}
+
+export class GeminiOmniVideoModelDefinition implements ModelDefinition<OmniVideoPrompt> {
+    readonly model: AIModel;
+
+    constructor() {
+        this.model = {
+            id: GEMINI_OMNI_VIDEO_MODEL,
+            name: GEMINI_OMNI_VIDEO_MODEL,
+            provider: 'vertexai',
+            type: ModelType.Video,
+            can_stream: false,
+        } satisfies AIModel;
+    }
+
+    async createPrompt(
+        _driver: VertexAIDriver,
+        segments: PromptSegment[],
+        options: ExecutionOptions,
+    ): Promise<OmniVideoPrompt> {
+        if (options.conversation)
+            throw new OmniVideoTerminalError('Gemini Omni video does not support conversation resume');
+        if (options.tools?.length) throw new OmniVideoTerminalError('Gemini Omni video does not support tools');
+        if (options.result_schema)
+            throw new OmniVideoTerminalError('Gemini Omni video does not support result schemas');
+
+        const text = segments
+            .map((segment) => segment.content.trim())
+            .filter(Boolean)
+            .join('\n');
+        if (!text) throw new OmniVideoTerminalError('Gemini Omni video requires a non-empty text prompt');
+
+        const images: OmniVideoImageInput[] = [];
+        for (const segment of segments) {
+            for (const file of segment.files ?? []) {
+                if (!SUPPORTED_IMAGE_MIME_TYPES.has(file.mime_type)) {
+                    throw new OmniVideoTerminalError(
+                        `Gemini Omni video does not support input MIME type ${file.mime_type}`,
+                    );
+                }
+                const uri = await file.getURI();
+                if (!isGcsUri(uri, true)) {
+                    throw new OmniVideoTerminalError('Gemini Omni video image inputs must expose a GCS object URI');
+                }
+                images.push({ type: 'image', uri, mime_type: file.mime_type });
+            }
+        }
+
+        resolveTask(options.model_options as VertexAIGeminiOmniVideoOptions | undefined, images.length);
+        return { text, images };
+    }
+
+    async requestTextCompletion(
+        driver: VertexAIDriver,
+        prompt: OmniVideoPrompt,
+        options: ExecutionOptions,
+        signal?: AbortSignal,
+    ): Promise<Completion> {
+        const modelOptions = options.model_options as VertexAIGeminiOmniVideoOptions | undefined;
+        const task = resolveTask(modelOptions, prompt.images.length);
+        const outputPrefix = normalizeOutputPrefix(options.output_storage_uri);
+        const responseFormat = {
+            type: 'video' as const,
+            delivery: 'uri' as const,
+            gcs_uri: outputPrefix,
+            duration: `${modelOptions?.duration_seconds ?? 5}s`,
+            ...(modelOptions?.aspect_ratio ? { aspect_ratio: modelOptions.aspect_ratio } : {}),
+        };
+        const response = await driver
+            .getFetchClientForRegion('global', 'v1beta1')
+            .post<OmniInteractionResponse>('interactions', {
+                payload: {
+                    model: GEMINI_OMNI_VIDEO_MODEL,
+                    input: [{ type: 'text', text: prompt.text }, ...prompt.images],
+                    response_format: [responseFormat],
+                    generation_config: { video_config: { task } },
+                },
+                signal,
+                timeoutMs: driver.getRequestTimeoutMs(options.httpTimeout),
+            });
+
+        const tokenUsage: ExecutionTokenUsage = {
+            total: response.usage?.total_tokens,
+            prompt: response.usage?.total_input_tokens,
+            result: response.usage?.total_output_tokens,
+        };
+        return {
+            result: parseVideoResults(response, outputPrefix),
+            token_usage: tokenUsage,
+            finish_reason: 'stop',
+            ...(options.include_original_response ? { original_response: response } : {}),
+        };
+    }
+
+    requestTextCompletionStream(): Promise<DriverCompletionStream> {
+        return Promise.reject(new OmniVideoTerminalError('Gemini Omni video does not support streaming'));
+    }
+
+    formatLlumiverseError(_driver: VertexAIDriver, error: unknown, context: LlumiverseErrorContext): LlumiverseError {
+        const code = statusCode(error);
+        const name = error instanceof Error ? error.name : 'GeminiOmniVideoError';
+        const terminal =
+            error instanceof OmniVideoTerminalError || name === 'AbortError' || name === 'TimeoutError' || code === 504;
+        const retryable = terminal ? false : code === 429 || code === 500 || code === 503 ? true : undefined;
+        return new LlumiverseError(
+            error instanceof Error ? error.message : String(error),
+            retryable,
+            context,
+            error,
+            code,
+            name,
+        );
+    }
+}

--- a/drivers/test/utils.ts
+++ b/drivers/test/utils.ts
@@ -23,6 +23,8 @@ export function completionResultToString(result: CompletionResult): string {
             return JSON.stringify(result.value, null, 2);
         case 'image':
             return result.value;
+        case 'video':
+            return result.value;
     }
 }
 


### PR DESCRIPTION
## Summary
- add Gemini Omni Flash preview video generation to the Vertex AI driver
- support URI-based video output destinations and typed video completion results
- preserve video media through completion streams and provider response handling
- classify provider and interaction failures as retryable or non-retryable where appropriate

## Test Plan
- [x] `pnpm check`
- [x] `pnpm build`
- [x] `pnpm typecheck:test`
- [x] `pnpm --filter @llumiverse/drivers test --exclude "**/*.live.test.ts"` (50 files, 555 passed, 17 skipped)
- [x] common and core suites via `pnpm test` (416 tests passed)
- [ ] `pnpm test` live Bedrock cases could not authenticate because the local AWS SSO token is expired; deterministic tests and available Vertex live tests passed