### PR TITLE
fix: wait for deferred merge gates

### DIFF
--- a/.github/workflows/backport-automerge.yaml
+++ b/.github/workflows/backport-automerge.yaml
@@ -46,9 +46,9 @@ jobs:
     if: |
       github.event.workflow_run.event == 'pull_request' &&
       startsWith(github.event.workflow_run.head_branch, 'backport-')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     environment: renovate-automerge
-    timeout-minutes: 5
+    timeout-minutes: 10
     concurrency:
       group: backport-automerge-${{ github.event.workflow_run.head_branch }}
       cancel-in-progress: false
@@ -228,6 +228,51 @@ jobs:
           gh pr review "$PR_URL" \
             --approve \
             --body "Auto-approved clean backport after build/test and lint passed for ${HEAD_SHA}."
+
+          # The eligibility gate above only waits for the build/test and lint workflows.
+          # The base branch rulesets also enforce gates that complete independently of
+          # them: CodeQL code scanning (GitHub's default setup, so there is no workflow
+          # file we could gate on) and, on some branches, Copilot code review. Merging
+          # immediately races those and fails with "the base branch policy prohibits the
+          # merge", which strands the PR approved but unmerged for good, because nothing
+          # re-triggers this workflow once the workflows it does gate on have completed.
+          # Let GitHub settle the merge state first, then merge the exact head SHA below.
+          merge_state_timeout=180
+          merge_state_poll=10
+
+          deadline=$(( SECONDS + merge_state_timeout ))
+          while :; do
+            pr_state="$(gh pr view "$PR_URL" --repo "$REPO" --json headRefOid,mergeStateStatus)"
+            settled_head_sha="$(jq -r '.headRefOid' <<< "$pr_state")"
+            settled_state="$(jq -r '.mergeStateStatus // ""' <<< "$pr_state")"
+
+            if [[ "$settled_head_sha" != "$HEAD_SHA" ]]; then
+              echo "Not merging $PR_URL: head moved from $HEAD_SHA to $settled_head_sha." >&2
+              echo "The run triggered by the new head is responsible for merging it." >&2
+              exit 1
+            fi
+
+            # CLEAN and HAS_HOOKS are mergeable. UNSTABLE means only non-required checks
+            # are failing, which the merge below accepted before this wait existed.
+            if [[ "$settled_state" == "CLEAN" || "$settled_state" == "HAS_HOOKS" || "$settled_state" == "UNSTABLE" ]]; then
+              echo "Merge state is '$settled_state'; proceeding to merge $HEAD_SHA."
+              break
+            fi
+
+            if [[ "$settled_state" == "DIRTY" ]]; then
+              echo "Not merging $PR_URL: the PR has merge conflicts." >&2
+              exit 1
+            fi
+
+            if (( SECONDS >= deadline )); then
+              echo "Not merging $PR_URL: merge state still '$settled_state' after ${merge_state_timeout}s." >&2
+              exit 1
+            fi
+
+            echo "Merge state is '$settled_state'; waiting for branch protection to settle."
+            sleep "$merge_state_poll"
+          done
+
           gh pr merge "$PR_URL" \
             --repo "$REPO" \
             --squash \

--- a/.github/workflows/backport-automerge.yaml
+++ b/.github/workflows/backport-automerge.yaml
@@ -264,6 +264,16 @@ jobs:
               exit 1
             fi
 
+            if [[ "$settled_state" == "BEHIND" ]]; then
+              echo "Not merging $PR_URL: the base branch advanced; update or rebase the PR first." >&2
+              exit 1
+            fi
+
+            if [[ "$settled_state" == "DRAFT" ]]; then
+              echo "Not merging $PR_URL: the PR became a draft." >&2
+              exit 1
+            fi
+
             if (( SECONDS >= deadline )); then
               echo "Not merging $PR_URL: merge state still '$settled_state' after ${merge_state_timeout}s." >&2
               exit 1

--- a/.github/workflows/release-automerge.yaml
+++ b/.github/workflows/release-automerge.yaml
@@ -266,6 +266,16 @@ jobs:
               exit 1
             fi
 
+            if [[ "$settled_state" == "BEHIND" ]]; then
+              echo "Not merging $PR_URL: the base branch advanced; update or rebase the PR first." >&2
+              exit 1
+            fi
+
+            if [[ "$settled_state" == "DRAFT" ]]; then
+              echo "Not merging $PR_URL: the PR became a draft." >&2
+              exit 1
+            fi
+
             if (( SECONDS >= deadline )); then
               echo "Not merging $PR_URL: merge state still '$settled_state' after ${merge_state_timeout}s." >&2
               exit 1

--- a/.github/workflows/release-automerge.yaml
+++ b/.github/workflows/release-automerge.yaml
@@ -35,9 +35,9 @@ jobs:
     if: |
       github.event.workflow_run.event == 'pull_request' &&
       startsWith(github.event.workflow_run.head_branch, 'release-bump-')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     environment: renovate-automerge
-    timeout-minutes: 5
+    timeout-minutes: 10
     concurrency:
       group: release-automerge-${{ github.event.workflow_run.head_branch }}
       cancel-in-progress: false
@@ -230,6 +230,51 @@ jobs:
           gh pr review "$PR_URL" \
             --approve \
             --body "Auto-approved release-cut version bump after build/test and lint passed for ${HEAD_SHA}."
+
+          # The eligibility gate above only waits for the build/test and lint workflows.
+          # The base branch rulesets also enforce gates that complete independently of
+          # them: CodeQL code scanning (GitHub's default setup, so there is no workflow
+          # file we could gate on) and, on some branches, Copilot code review. Merging
+          # immediately races those and fails with "the base branch policy prohibits the
+          # merge", which strands the PR approved but unmerged for good, because nothing
+          # re-triggers this workflow once the workflows it does gate on have completed.
+          # Let GitHub settle the merge state first, then merge the exact head SHA below.
+          merge_state_timeout=180
+          merge_state_poll=10
+
+          deadline=$(( SECONDS + merge_state_timeout ))
+          while :; do
+            pr_state="$(gh pr view "$PR_URL" --repo "$REPO" --json headRefOid,mergeStateStatus)"
+            settled_head_sha="$(jq -r '.headRefOid' <<< "$pr_state")"
+            settled_state="$(jq -r '.mergeStateStatus // ""' <<< "$pr_state")"
+
+            if [[ "$settled_head_sha" != "$HEAD_SHA" ]]; then
+              echo "Not merging $PR_URL: head moved from $HEAD_SHA to $settled_head_sha." >&2
+              echo "The run triggered by the new head is responsible for merging it." >&2
+              exit 1
+            fi
+
+            # CLEAN and HAS_HOOKS are mergeable. UNSTABLE means only non-required checks
+            # are failing, which the merge below accepted before this wait existed.
+            if [[ "$settled_state" == "CLEAN" || "$settled_state" == "HAS_HOOKS" || "$settled_state" == "UNSTABLE" ]]; then
+              echo "Merge state is '$settled_state'; proceeding to merge $HEAD_SHA."
+              break
+            fi
+
+            if [[ "$settled_state" == "DIRTY" ]]; then
+              echo "Not merging $PR_URL: the PR has merge conflicts." >&2
+              exit 1
+            fi
+
+            if (( SECONDS >= deadline )); then
+              echo "Not merging $PR_URL: merge state still '$settled_state' after ${merge_state_timeout}s." >&2
+              exit 1
+            fi
+
+            echo "Merge state is '$settled_state'; waiting for branch protection to settle."
+            sleep "$merge_state_poll"
+          done
+
           gh pr merge "$PR_URL" \
             --repo "$REPO" \
             --squash \

--- a/.github/workflows/renovate-automerge.yaml
+++ b/.github/workflows/renovate-automerge.yaml
@@ -22,9 +22,9 @@ jobs:
     if: |
       github.event.workflow_run.event == 'pull_request' &&
       startsWith(github.event.workflow_run.head_branch, 'renovate/')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     environment: renovate-automerge
-    timeout-minutes: 5
+    timeout-minutes: 10
     concurrency:
       group: renovate-automerge-${{ github.event.workflow_run.head_branch }}
       cancel-in-progress: false
@@ -236,6 +236,51 @@ jobs:
           gh pr review "$PR_URL" \
             --approve \
             --body "Auto-approved eligible Renovate dependency update after build/test and lint passed for ${HEAD_SHA}."
+
+          # The eligibility gate above only waits for the build/test and lint workflows.
+          # The base branch rulesets also enforce gates that complete independently of
+          # them: CodeQL code scanning (GitHub's default setup, so there is no workflow
+          # file we could gate on) and, on some branches, Copilot code review. Merging
+          # immediately races those and fails with "the base branch policy prohibits the
+          # merge", which strands the PR approved but unmerged for good, because nothing
+          # re-triggers this workflow once the workflows it does gate on have completed.
+          # Let GitHub settle the merge state first, then merge the exact head SHA below.
+          merge_state_timeout=180
+          merge_state_poll=10
+
+          deadline=$(( SECONDS + merge_state_timeout ))
+          while :; do
+            pr_state="$(gh pr view "$PR_URL" --repo "$REPO" --json headRefOid,mergeStateStatus)"
+            settled_head_sha="$(jq -r '.headRefOid' <<< "$pr_state")"
+            settled_state="$(jq -r '.mergeStateStatus // ""' <<< "$pr_state")"
+
+            if [[ "$settled_head_sha" != "$HEAD_SHA" ]]; then
+              echo "Not merging $PR_URL: head moved from $HEAD_SHA to $settled_head_sha." >&2
+              echo "The run triggered by the new head is responsible for merging it." >&2
+              exit 1
+            fi
+
+            # CLEAN and HAS_HOOKS are mergeable. UNSTABLE means only non-required checks
+            # are failing, which the merge below accepted before this wait existed.
+            if [[ "$settled_state" == "CLEAN" || "$settled_state" == "HAS_HOOKS" || "$settled_state" == "UNSTABLE" ]]; then
+              echo "Merge state is '$settled_state'; proceeding to merge $HEAD_SHA."
+              break
+            fi
+
+            if [[ "$settled_state" == "DIRTY" ]]; then
+              echo "$PR_URL has merge conflicts; attempting pnpm-lock-only repair."
+              echo "should_repair_lock=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            if (( SECONDS >= deadline )); then
+              echo "Not merging $PR_URL: merge state still '$settled_state' after ${merge_state_timeout}s." >&2
+              exit 1
+            fi
+
+            echo "Merge state is '$settled_state'; waiting for branch protection to settle."
+            sleep "$merge_state_poll"
+          done
 
           merge_log="$(mktemp)"
           if gh pr merge "$PR_URL" \

--- a/.github/workflows/renovate-automerge.yaml
+++ b/.github/workflows/renovate-automerge.yaml
@@ -273,6 +273,16 @@ jobs:
               exit 0
             fi
 
+            if [[ "$settled_state" == "BEHIND" ]]; then
+              echo "Not merging $PR_URL: the base branch advanced; update or rebase the PR first." >&2
+              exit 1
+            fi
+
+            if [[ "$settled_state" == "DRAFT" ]]; then
+              echo "Not merging $PR_URL: the PR became a draft." >&2
+              exit 1
+            fi
+
             if (( SECONDS >= deadline )); then
               echo "Not merging $PR_URL: merge state still '$settled_state' after ${merge_state_timeout}s." >&2
               exit 1


### PR DESCRIPTION
## Summary
- wait for deferred branch-protection gates to settle before merging eligible automation PRs
- reject moved heads and preserve the existing lock-repair behavior for Renovate conflicts
- run the automerge jobs on ubuntu-slim and extend their timeout for the bounded wait

## Test Plan
- [x] pnpm lint:actions
- [x] actionlint with shellcheck enabled for the changed workflows
- [x] zizmor --persona=auditor --offline for the changed workflows
- [x] pnpm build