### PR TITLE
fix: classify Gemini finish reason errors

### DIFF
--- a/drivers/src/vertexai/models/gemini-error-handling.test.ts
+++ b/drivers/src/vertexai/models/gemini-error-handling.test.ts
@@ -1,3 +1,4 @@
+import { FinishReason } from '@google/genai';
 import { LlumiverseError } from '@llumiverse/core';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { exposePrivate, getProp } from '../../../test/__helpers__/test-utils.js';
@@ -20,7 +21,94 @@ describe('GeminiModelDefinition Error Handling', () => {
         modelDef = new GeminiModelDefinition('gemini-2.0-flash');
     });
 
+    async function formatFinishReasonError(
+        finishReason: FinishReason,
+        safetyRatings?: unknown[],
+    ): Promise<LlumiverseError> {
+        const responseDriver = {
+            logger: { warn: () => {}, info: () => {}, error: () => {} },
+            getGoogleGenAIClient: () => ({
+                models: {
+                    generateContent: async () => ({
+                        candidates: [{ finishReason, content: { role: 'model' }, safetyRatings }],
+                    }),
+                },
+            }),
+        } as unknown as VertexAIDriver;
+
+        const originalError = await modelDef
+            .requestTextCompletion(
+                responseDriver,
+                { contents: [{ role: 'user', parts: [{ text: 'Describe this image' }] }] },
+                { model: 'publishers/google/models/gemini-2.0-flash' },
+            )
+            .then(
+                () => undefined,
+                (error: unknown) => error,
+            );
+        expect(originalError).toBeInstanceOf(Error);
+
+        return modelDef.formatLlumiverseError(driver, originalError, {
+            provider: 'vertexai',
+            model: 'gemini-2.0-flash',
+            operation: 'execute',
+        });
+    }
+
     describe('formatLlumiverseError', () => {
+        it('surfaces a SAFETY finish reason as a non-retryable error', async () => {
+            const safetyRatings = [
+                {
+                    category: 'HARM_CATEGORY_DANGEROUS_CONTENT',
+                    probability: 'HIGH',
+                    blocked: true,
+                },
+            ];
+            const error = await formatFinishReasonError(FinishReason.SAFETY, safetyRatings);
+
+            expect(error).toBeInstanceOf(LlumiverseError);
+            expect(error.retryable).toBe(false);
+            expect(error.name).toBe('SAFETY');
+            expect(error.message).toContain('Gemini blocked the response because it may violate safety policies');
+            expect(error.message).toContain('Finish reason: SAFETY');
+            expect(error.message).toContain('HARM_CATEGORY_DANGEROUS_CONTENT');
+            expect(error.message).not.toContain('content:');
+        });
+
+        it.each([
+            FinishReason.SAFETY,
+            FinishReason.RECITATION,
+            FinishReason.LANGUAGE,
+            FinishReason.BLOCKLIST,
+            FinishReason.PROHIBITED_CONTENT,
+            FinishReason.SPII,
+            FinishReason.IMAGE_SAFETY,
+            FinishReason.IMAGE_PROHIBITED_CONTENT,
+            FinishReason.IMAGE_RECITATION,
+        ])('classifies policy finish reason %s as non-retryable', async (finishReason) => {
+            const error = await formatFinishReasonError(finishReason);
+            expect(error.retryable).toBe(false);
+            expect(error.name).toBe(finishReason);
+        });
+
+        it.each([
+            FinishReason.MALFORMED_FUNCTION_CALL,
+            FinishReason.NO_IMAGE,
+            FinishReason.IMAGE_OTHER,
+            FinishReason.OTHER,
+        ])('classifies generation finish reason %s as retryable', async (finishReason) => {
+            const error = await formatFinishReasonError(finishReason);
+            expect(error.retryable).toBe(true);
+            expect(error.name).toBe(finishReason);
+        });
+
+        it('keeps an unknown finish reason retryability unspecified', async () => {
+            const error = await formatFinishReasonError('FUTURE_FINISH_REASON' as FinishReason);
+            expect(error.retryable).toBeUndefined();
+            expect(error.message).toContain('unsupported finish reason');
+            expect(error.name).toBe('FUTURE_FINISH_REASON');
+        });
+
         it('should handle INVALID_ARGUMENT error (400)', () => {
             const googleError = {
                 status: 400,

--- a/drivers/src/vertexai/models/gemini.ts
+++ b/drivers/src/vertexai/models/gemini.ts
@@ -13,6 +13,7 @@ import {
     Modality,
     type Part,
     ProminentPeople,
+    type SafetyRating,
     type SafetySetting,
     type ThinkingConfig,
     ThinkingLevel,
@@ -53,6 +54,85 @@ import type { ModelDefinition } from '../models.js';
 import { generateWithGeminiContextCache } from './gemini-context-cache.js';
 
 type GoogleApiErrorLike = Pick<ApiError, 'status' | 'message'>;
+type GeminiFinishReasonHandling = { message: string; retryable: boolean };
+
+const geminiFinishReasonHandling: Partial<Record<FinishReason, GeminiFinishReasonHandling>> = {
+    [FinishReason.SAFETY]: {
+        message: 'Gemini blocked the response because it may violate safety policies.',
+        retryable: false,
+    },
+    [FinishReason.RECITATION]: {
+        message: 'Gemini blocked the response because it may reproduce protected source material.',
+        retryable: false,
+    },
+    [FinishReason.LANGUAGE]: {
+        message: 'Gemini stopped because the response used an unsupported language.',
+        retryable: false,
+    },
+    [FinishReason.BLOCKLIST]: {
+        message: 'Gemini blocked the response because it contains a forbidden term.',
+        retryable: false,
+    },
+    [FinishReason.PROHIBITED_CONTENT]: {
+        message: 'Gemini blocked the response because it may contain prohibited content.',
+        retryable: false,
+    },
+    [FinishReason.SPII]: {
+        message: 'Gemini blocked the response because it may contain sensitive personal information.',
+        retryable: false,
+    },
+    [FinishReason.IMAGE_SAFETY]: {
+        message: 'Gemini blocked the generated image because it may violate safety policies.',
+        retryable: false,
+    },
+    [FinishReason.IMAGE_PROHIBITED_CONTENT]: {
+        message: 'Gemini blocked the generated image because it may contain prohibited content.',
+        retryable: false,
+    },
+    [FinishReason.IMAGE_RECITATION]: {
+        message: 'Gemini blocked the generated image because it may reproduce protected source material.',
+        retryable: false,
+    },
+    [FinishReason.MALFORMED_FUNCTION_CALL]: {
+        message: 'Gemini generated an invalid function call.',
+        retryable: true,
+    },
+    [FinishReason.NO_IMAGE]: { message: 'Gemini did not generate the requested image.', retryable: true },
+    [FinishReason.IMAGE_OTHER]: {
+        message: 'Gemini stopped image generation for an unspecified reason.',
+        retryable: true,
+    },
+    [FinishReason.OTHER]: { message: 'Gemini stopped generation for an unspecified reason.', retryable: true },
+};
+
+class GeminiFinishReasonError extends Error {
+    readonly retryable: boolean | undefined;
+
+    constructor(
+        readonly finishReason: FinishReason,
+        readonly finishMessage?: string,
+        readonly safetyRatings?: SafetyRating[],
+    ) {
+        super(formatGeminiFinishReasonErrorMessage(finishReason, finishMessage, safetyRatings));
+        this.name = 'GeminiFinishReasonError';
+        this.retryable = geminiFinishReasonHandling[finishReason]?.retryable;
+    }
+}
+
+function formatGeminiFinishReasonErrorMessage(
+    finishReason: FinishReason,
+    finishMessage?: string,
+    safetyRatings?: SafetyRating[],
+): string {
+    const summary =
+        geminiFinishReasonHandling[finishReason]?.message ??
+        'Gemini stopped generation with an unsupported finish reason.';
+
+    const details = [`${summary} Finish reason: ${finishReason}.`];
+    if (finishMessage) details.push(`Finish message: ${finishMessage}.`);
+    if (safetyRatings?.length) details.push(`Safety ratings: ${JSON.stringify(safetyRatings)}.`);
+    return details.join(' ');
+}
 
 function supportsStructuredOutput(options: PromptOptions): boolean {
     // Gemini 1.0 Ultra does not support JSON output, 1.0 Pro does.
@@ -390,9 +470,23 @@ const supportedFinishReasons: FinishReason[] = [
 // Finish reasons that indicate tool call issues but should be recovered gracefully
 // instead of throwing an error. The tool_use is still extracted and returned
 // so the workflow can generate a proper toolError response.
-const recoverableToolCallReasons = [
-    'UNEXPECTED_TOOL_CALL', // Model called an undeclared tool
-];
+const recoverableToolCallReasons = [FinishReason.UNEXPECTED_TOOL_CALL];
+
+function isRecoverableGeminiFinishReason(finishReason: FinishReason | undefined): boolean {
+    return finishReason !== undefined && recoverableToolCallReasons.includes(finishReason);
+}
+
+function assertSupportedGeminiFinishReason(candidate: {
+    finishReason?: FinishReason;
+    finishMessage?: string;
+    safetyRatings?: SafetyRating[];
+}): boolean {
+    const isRecoverableToolCall = isRecoverableGeminiFinishReason(candidate.finishReason);
+    if (candidate.finishReason && !supportedFinishReasons.includes(candidate.finishReason) && !isRecoverableToolCall) {
+        throw new GeminiFinishReasonError(candidate.finishReason, candidate.finishMessage, candidate.safetyRatings);
+    }
+    return isRecoverableToolCall;
+}
 
 function geminiThinkingLevelForEffort(effort: VertexAIGeminiOptions['effort']): ThinkingLevel | undefined {
     switch (effort) {
@@ -710,19 +804,9 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
             }
             const content = candidate.content;
 
-            // Check for unsupported finish reasons, but allow recoverable tool call issues
-            const isRecoverableToolCall = recoverableToolCallReasons.includes(candidate.finishReason as string);
-            if (
-                candidate.finishReason &&
-                !supportedFinishReasons.includes(candidate.finishReason) &&
-                !isRecoverableToolCall
-            ) {
-                throw new Error(
-                    `Unsupported finish reason: ${candidate.finishReason}, ` +
-                        `finish message: ${candidate.finishMessage}, ` +
-                        `content: ${JSON.stringify(content, null, 2)}, safety: ${JSON.stringify(candidate.safetyRatings, null, 2)}`,
-                );
-            }
+            // Provider finish reasons are terminal responses, not transport failures. Classify them
+            // explicitly while allowing recoverable tool-call issues to continue through the workflow.
+            const isRecoverableToolCall = assertSupportedGeminiFinishReason(candidate);
 
             if (content) {
                 tool_use = collectToolUseParts(content);
@@ -822,19 +906,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
                         default:
                             finish_reason = candidate.finishReason;
                     }
-                    // Check for unsupported finish reasons, but allow recoverable tool call issues
-                    const isRecoverableToolCall = recoverableToolCallReasons.includes(candidate.finishReason as string);
-                    if (
-                        candidate.finishReason &&
-                        !supportedFinishReasons.includes(candidate.finishReason) &&
-                        !isRecoverableToolCall
-                    ) {
-                        throw new Error(
-                            `Unsupported finish reason: ${candidate.finishReason}, ` +
-                                `finish message: ${candidate.finishMessage}, ` +
-                                `content: ${JSON.stringify(candidate.content, null, 2)}, safety: ${JSON.stringify(candidate.safetyRatings, null, 2)}`,
-                        );
-                    }
+                    const isRecoverableToolCall = assertSupportedGeminiFinishReason(candidate);
                     if (candidate.content?.role === 'model') {
                         appendGeminiStreamParts(nativeParts, candidate.content.parts ?? []);
                         // Collect all parts in order (text and images)
@@ -904,6 +976,17 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
      * @see https://docs.cloud.google.com/vertex-ai/generative-ai/docs/model-reference/api-errors
      */
     formatLlumiverseError(_driver: VertexAIDriver, error: unknown, context: LlumiverseErrorContext): LlumiverseError {
+        if (error instanceof GeminiFinishReasonError) {
+            return new LlumiverseError(
+                `[${context.provider}] ${error.message}`,
+                error.retryable,
+                context,
+                error,
+                undefined,
+                error.finishReason,
+            );
+        }
+
         // Check if it's a Google API error with status code
         const isApiError = this.isGoogleApiError(error);
 


### PR DESCRIPTION
## Summary
- classify Gemini terminal finish reasons as structured Llumiverse errors with explicit retryability
- provide concise reason-specific messages while retaining finish messages and compact safety ratings
- share classification across blocking and streaming paths while preserving recoverable unexpected tool calls

## Behavior changes

| Scenario | `main` | This PR |
| --- | --- | --- |
| Policy and input blocks, including `SAFETY` | Generic unsupported-finish error with no retryability classification | Clear reason-specific error with `retryable: false` |
| Generation failures | Generic unsupported-finish error with no retryability classification | Clear reason-specific error with `retryable: true` |
| Unknown future finish reasons | Generic unsupported-finish error | Clear error with retryability left unspecified |
| Error detail | Includes the raw candidate content | Includes the finish message and compact safety ratings without dumping candidate content |
| Blocking and streaming responses | Separate finish-reason handling | Shared classification and formatting |
| `UNEXPECTED_TOOL_CALL` | Recoverable | Remains recoverable |

## Test Plan
- [x] `pnpm --filter @llumiverse/drivers lint`
- [x] `pnpm --filter @llumiverse/drivers typecheck:test`
- [x] `pnpm build`
- [x] `pnpm exec vitest run --exclude '**/*.live.test.ts'` (76 files; 1,013 passed, 17 skipped)
