### PR TITLE
fix: keep Claude agent prompt prefixes byte-stable across turns

### DIFF
--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -598,6 +598,14 @@ export type StatelessExecutionOptions = z.infer<typeof StatelessExecutionOptions
  */
 export type PromptCacheMode = z.infer<typeof PromptCacheModeSchema>;
 
+/** Namespace used by agent conversations that require stable Claude cache layout. */
+export const AGENT_PROMPT_CACHE_KEY_PREFIX = 'agent-';
+
+/** Stable prefixes shared by prompt generators and cached-conversation deduplication. */
+export const JSON_SCHEMA_INSTRUCTION_PREFIX = 'The answer must be a JSON object using the following JSON Schema:';
+export const TOOL_AWARE_JSON_SCHEMA_INSTRUCTION_PREFIX =
+    'When not calling tools, the answer must be a JSON object using the following JSON Schema:';
+
 export interface ExecutionOptionsBase extends PromptOptions {
     /**
      * If set to true the original response from the target LLM will be included in the response under the original_response field.

--- a/core/src/formatters/commons.ts
+++ b/core/src/formatters/commons.ts
@@ -1,5 +1,5 @@
-import type { JSONSchema } from '@llumiverse/common';
+import { JSON_SCHEMA_INSTRUCTION_PREFIX, type JSONSchema } from '@llumiverse/common';
 
 export function getJSONSafetyNotice(schema: JSONSchema) {
-    return `The answer must be a JSON object using the following JSON Schema:\n${JSON.stringify(schema, undefined, 2)}`;
+    return `${JSON_SCHEMA_INSTRUCTION_PREFIX}\n${JSON.stringify(schema, undefined, 2)}`;
 }

--- a/drivers/src/bedrock/converse.ts
+++ b/drivers/src/bedrock/converse.ts
@@ -6,6 +6,7 @@ import {
     type SystemContentBlock,
     type ToolResultContentBlock,
 } from '@aws-sdk/client-bedrock-runtime';
+import { JSON_SCHEMA_INSTRUCTION_PREFIX, TOOL_AWARE_JSON_SCHEMA_INSTRUCTION_PREFIX } from '@llumiverse/common';
 import {
     type DataSource,
     type ExecutionOptions,
@@ -468,9 +469,9 @@ export async function formatConversePrompt(
     if (options.result_schema && shouldIncludeSchemaInConversePrompt(options.model)) {
         let schemaText: string;
         if (options.tools && options.tools.length > 0) {
-            schemaText = `When not calling tools, the answer must be a JSON object using the following JSON Schema:\n${JSON.stringify(options.result_schema, undefined, 2)}`;
+            schemaText = `${TOOL_AWARE_JSON_SCHEMA_INSTRUCTION_PREFIX}\n${JSON.stringify(options.result_schema, undefined, 2)}`;
         } else {
-            schemaText = `The answer must be a JSON object using the following JSON Schema:\n${JSON.stringify(options.result_schema, undefined, 2)}`;
+            schemaText = `${JSON_SCHEMA_INSTRUCTION_PREFIX}\n${JSON.stringify(options.result_schema, undefined, 2)}`;
         }
         const schemaInstruction = `IMPORTANT: ${schemaText}`;
         const taskMessage = messages[messages.length - 1];

--- a/drivers/src/shared/claude-messages.test.ts
+++ b/drivers/src/shared/claude-messages.test.ts
@@ -1,6 +1,11 @@
 import { type DataSource, type ExecutionOptions, PromptRole, type PromptSegment } from '@llumiverse/core';
 import { describe, expect, it, vi } from 'vitest';
-import { anthropicUsageToTokenUsage, formatClaudePrompt, getClaudePayload } from './claude-messages.js';
+import {
+    anthropicUsageToTokenUsage,
+    buildClaudeStreamingConversation,
+    formatClaudePrompt,
+    getClaudePayload,
+} from './claude-messages.js';
 
 describe('formatClaudePrompt', () => {
     const imageSource = (): DataSource => ({
@@ -207,5 +212,87 @@ describe('formatClaudePrompt', () => {
             result: 10,
             total: 185,
         });
+    });
+
+    it('keeps the serialized cached conversation prefix immutable as tool turns are appended', () => {
+        const largeHistoricalResult = `SOURCE:${'x'.repeat(12_000)}`;
+        const historicalMessages = Array.from({ length: 14 }, (_, index) => ({
+            role: (index % 2 === 0 ? 'assistant' : 'user') as 'assistant' | 'user',
+            content: [
+                index === 1
+                    ? {
+                          type: 'tool_result' as const,
+                          tool_use_id: 'historical-read',
+                          content: largeHistoricalResult,
+                      }
+                    : { type: 'text' as const, text: `historical-${index}` },
+            ],
+        }));
+        const options: ExecutionOptions = {
+            model: 'claude-sonnet-4-6',
+            model_options: { cache_enabled: true } as never,
+            stripTextMaxTokens: 8_000,
+            conversation: { messages: historicalMessages },
+        };
+
+        const first = buildClaudeStreamingConversation(
+            {
+                messages: [
+                    {
+                        role: 'user',
+                        content: [{ type: 'text', text: 'first new tool result' }],
+                    },
+                ],
+            },
+            [],
+            [{ id: 'tool-1', tool_name: 'app_workspace_edit', tool_input: { path: 'src/App.tsx' } }],
+            options,
+        );
+        const second = buildClaudeStreamingConversation(
+            {
+                messages: [
+                    {
+                        role: 'user',
+                        content: [{ type: 'text', text: 'second new tool result' }],
+                    },
+                ],
+            },
+            [],
+            [{ id: 'tool-2', tool_name: 'app_workspace_typecheck', tool_input: {} }],
+            { ...options, conversation: first },
+        );
+
+        expect(JSON.stringify(first.messages)).toContain(largeHistoricalResult);
+        expect(second.messages.slice(0, first.messages.length)).toEqual(first.messages);
+        expect(JSON.stringify(second.messages.slice(0, first.messages.length))).toBe(JSON.stringify(first.messages));
+    });
+
+    it('retains sliding text truncation when prompt caching is disabled', () => {
+        const largeHistoricalResult = `SOURCE:${'x'.repeat(12_000)}`;
+        const conversation = buildClaudeStreamingConversation(
+            {
+                messages: Array.from({ length: 14 }, (_, index) => ({
+                    role: (index % 2 === 0 ? 'assistant' : 'user') as 'assistant' | 'user',
+                    content: [
+                        index === 1
+                            ? {
+                                  type: 'tool_result' as const,
+                                  tool_use_id: 'historical-read',
+                                  content: largeHistoricalResult,
+                              }
+                            : { type: 'text' as const, text: `historical-${index}` },
+                    ],
+                })),
+            },
+            [],
+            [{ id: 'tool-1', tool_name: 'app_workspace_edit', tool_input: { path: 'src/App.tsx' } }],
+            {
+                model: 'claude-sonnet-4-6',
+                stripTextMaxTokens: 8_000,
+            },
+        );
+
+        expect(JSON.stringify(conversation.messages)).not.toContain(largeHistoricalResult);
+        expect(JSON.stringify(conversation.messages)).toContain('[Content truncated');
     });
 });

--- a/drivers/src/shared/claude-messages.test.ts
+++ b/drivers/src/shared/claude-messages.test.ts
@@ -5,6 +5,7 @@ import {
     buildClaudeStreamingConversation,
     formatClaudePrompt,
     getClaudePayload,
+    updateClaudeConversation,
 } from './claude-messages.js';
 
 describe('formatClaudePrompt', () => {
@@ -161,6 +162,66 @@ describe('formatClaudePrompt', () => {
         expect(second.messages[0].content[0]).toMatchObject({
             cache_control: { type: 'ephemeral', ttl: '1h' },
         });
+    });
+
+    it('keeps one stable result-schema system block across agent tool continuations', async () => {
+        const options: ExecutionOptions = {
+            model: 'claude-sonnet-4-6',
+            prompt_cache_key: 'agent-stable-prefix',
+            result_schema: { type: 'object', properties: { value: { type: 'string' } } },
+        };
+        const initial = await formatClaudePrompt(
+            [
+                { role: PromptRole.system, content: 'agent instructions' },
+                { role: PromptRole.user, content: 'start work' },
+            ],
+            options,
+        );
+        const continuation = await formatClaudePrompt(
+            [{ role: PromptRole.tool, tool_use_id: 'tool-1', content: 'first result' }],
+            options,
+        );
+        const nextContinuation = await formatClaudePrompt(
+            [{ role: PromptRole.tool, tool_use_id: 'tool-2', content: 'second result' }],
+            options,
+        );
+
+        const firstConversation = updateClaudeConversation(initial, continuation);
+        const secondConversation = updateClaudeConversation(firstConversation, nextContinuation);
+        const schemaBlocks = secondConversation.system?.filter((block) => block.text.includes('JSON Schema'));
+
+        expect(initial.messages[0].content[0]).toEqual({ type: 'text', text: 'start work' });
+        expect(firstConversation.system).toEqual(secondConversation.system);
+        expect(schemaBlocks).toHaveLength(1);
+        expect(schemaBlocks?.[0].text).toContain('"value"');
+    });
+
+    it('collapses legacy duplicate agent result-schema system blocks on the next continuation', async () => {
+        const options: ExecutionOptions = {
+            model: 'claude-sonnet-4-6',
+            prompt_cache_key: 'agent-stable-prefix',
+            result_schema: { type: 'object', properties: { value: { type: 'string' } } },
+        };
+        const continuation = await formatClaudePrompt(
+            [{ role: PromptRole.tool, tool_use_id: 'tool-1', content: 'result' }],
+            options,
+        );
+        const schemaBlock = continuation.system?.find((block) => block.text.includes('JSON Schema'));
+        expect(schemaBlock).toBeDefined();
+        if (!schemaBlock) throw new Error('Expected generated result-schema system block');
+        const legacyConversation = {
+            messages: [{ role: 'user' as const, content: [{ type: 'text' as const, text: 'start work' }] }],
+            system: [
+                { type: 'text' as const, text: 'agent instructions' },
+                schemaBlock,
+                { ...schemaBlock },
+                { ...schemaBlock },
+            ],
+        };
+
+        const repaired = updateClaudeConversation(legacyConversation, continuation);
+
+        expect(repaired.system?.filter((block) => block.text.includes('JSON Schema'))).toHaveLength(1);
     });
 
     it('appends a user turn when the conversation ends with an assistant message on no-prefill models', () => {

--- a/drivers/src/shared/claude-messages.test.ts
+++ b/drivers/src/shared/claude-messages.test.ts
@@ -127,6 +127,42 @@ describe('formatClaudePrompt', () => {
         });
     });
 
+    it('keeps agent cache breakpoints on fixed blocks as the conversation grows', () => {
+        const messages = Array.from({ length: 49 }, (_, index) => ({
+            role: (index % 2 === 0 ? 'user' : 'assistant') as 'user' | 'assistant',
+            content: [{ type: 'text' as const, text: `block-${index}` }],
+        }));
+        const options: ExecutionOptions = {
+            model: 'claude-sonnet-4-6',
+            prompt_cache_key: 'agent-stable-prefix',
+            model_options: { cache_ttl: '1h' } as never,
+        };
+
+        const first = getClaudePayload(options, {
+            system: [{ type: 'text', text: 'system' }],
+            messages: messages.slice(0, 25),
+        }).payload;
+        const second = getClaudePayload(options, {
+            system: [{ type: 'text', text: 'system' }],
+            messages,
+        }).payload;
+
+        expect(second.messages.slice(0, first.messages.length)).toEqual(first.messages);
+        expect(second.system).toEqual([{ type: 'text', text: 'system' }]);
+        expect(
+            second.messages.flatMap((message, messageIndex) =>
+                Array.isArray(message.content)
+                    ? message.content
+                          .map((block) => ('cache_control' in block ? messageIndex : undefined))
+                          .filter((index): index is number => index !== undefined)
+                    : [],
+            ),
+        ).toEqual([0, 12, 24, 36]);
+        expect(second.messages[0].content[0]).toMatchObject({
+            cache_control: { type: 'ephemeral', ttl: '1h' },
+        });
+    });
+
     it('appends a user turn when the conversation ends with an assistant message on no-prefill models', () => {
         const options: ExecutionOptions = { model: 'claude-fable-5' };
         const prompt = {

--- a/drivers/src/shared/claude-messages.ts
+++ b/drivers/src/shared/claude-messages.ts
@@ -36,7 +36,12 @@ import type {
 import type { MessageStreamParams } from '@anthropic-ai/sdk/resources/index.mjs';
 import type { MessageCreateParamsBase, RawMessageStreamEvent } from '@anthropic-ai/sdk/resources/messages.js';
 import type AnthropicVertex from '@anthropic-ai/vertex-sdk';
-import { getClaudeMaxTokensLimit } from '@llumiverse/common';
+import {
+    AGENT_PROMPT_CACHE_KEY_PREFIX,
+    getClaudeMaxTokensLimit,
+    JSON_SCHEMA_INSTRUCTION_PREFIX,
+    TOOL_AWARE_JSON_SCHEMA_INSTRUCTION_PREFIX,
+} from '@llumiverse/common';
 import {
     type Completion,
     type CompletionChunkObject,
@@ -76,12 +81,11 @@ import { truncateBinaryForDebug } from './debug-prompt.js';
 // below — so long agent conversations don't balloon context.
 const KEEP_RECENT_MESSAGES = 12;
 const OLD_MESSAGE_TEXT_MAX_TOKENS = 2000;
-const AGENT_PROMPT_CACHE_KEY_PREFIX = 'agent-';
 const AGENT_MESSAGE_CACHE_BLOCK_INTERVAL = 12;
 const MAX_CLAUDE_CACHE_BREAKPOINTS = 4;
 const RESULT_SCHEMA_INSTRUCTION_PREFIXES = [
-    'When not calling tools, the answer must be a JSON object using the following JSON Schema:',
-    'The answer must be a JSON object using the following JSON Schema:',
+    TOOL_AWARE_JSON_SCHEMA_INSTRUCTION_PREFIX,
+    JSON_SCHEMA_INSTRUCTION_PREFIX,
 ] as const;
 
 export function isClaudePromptCacheEnabled(options: ExecutionOptions): boolean {
@@ -372,8 +376,8 @@ export async function formatClaudePrompt(
     if (options.result_schema) {
         schemaText =
             options.tools && options.tools.length > 0
-                ? `When not calling tools, the answer must be a JSON object using the following JSON Schema:\n${JSON.stringify(options.result_schema)}`
-                : `The answer must be a JSON object using the following JSON Schema:\n${JSON.stringify(options.result_schema)}`;
+                ? `${TOOL_AWARE_JSON_SCHEMA_INSTRUCTION_PREFIX}\n${JSON.stringify(options.result_schema)}`
+                : `${JSON_SCHEMA_INSTRUCTION_PREFIX}\n${JSON.stringify(options.result_schema)}`;
         if (options.prompt_cache_key === undefined) {
             system.push({ text: schemaText, type: 'text' as const });
         }

--- a/drivers/src/shared/claude-messages.ts
+++ b/drivers/src/shared/claude-messages.ts
@@ -76,10 +76,42 @@ import { truncateBinaryForDebug } from './debug-prompt.js';
 // below — so long agent conversations don't balloon context.
 const KEEP_RECENT_MESSAGES = 12;
 const OLD_MESSAGE_TEXT_MAX_TOKENS = 2000;
+const AGENT_PROMPT_CACHE_KEY_PREFIX = 'agent-';
+const AGENT_MESSAGE_CACHE_BLOCK_INTERVAL = 12;
+const MAX_CLAUDE_CACHE_BREAKPOINTS = 4;
 
 export function isClaudePromptCacheEnabled(options: ExecutionOptions): boolean {
     const modelOptions = options.model_options as ClaudeBaseOptions | undefined;
     return options.prompt_cache_key !== undefined || modelOptions?.cache_enabled === true;
+}
+
+function isAgentPromptCacheKey(promptCacheKey: string | undefined): boolean {
+    return promptCacheKey?.startsWith(AGENT_PROMPT_CACHE_KEY_PREFIX) === true;
+}
+
+function addAgentMessageCacheBreakpoints(
+    messages: MessageParam[],
+    cacheControl: { type: 'ephemeral'; ttl?: '5m' | '1h' },
+): boolean {
+    let cacheableBlockIndex = 0;
+    let breakpointCount = 0;
+
+    for (const message of messages) {
+        if (!Array.isArray(message.content)) continue;
+
+        for (const block of message.content) {
+            if (block.type === 'thinking' || block.type === 'redacted_thinking') continue;
+
+            if (cacheableBlockIndex === breakpointCount * AGENT_MESSAGE_CACHE_BLOCK_INTERVAL) {
+                block.cache_control = cacheControl;
+                breakpointCount++;
+                if (breakpointCount === MAX_CLAUDE_CACHE_BREAKPOINTS) return true;
+            }
+            cacheableBlockIndex++;
+        }
+    }
+
+    return breakpointCount > 0;
 }
 
 interface WarnLogger {
@@ -740,17 +772,27 @@ export function getClaudePayload(
         const cacheTtl = model_options?.cache_ttl as '5m' | '1h' | undefined;
         const cacheControl = { type: 'ephemeral' as const, ...(cacheTtl && { ttl: cacheTtl }) };
 
-        if (sanitizedSystem && sanitizedSystem.length > 0) {
+        // Vertex requires cache_control to remain on the same blocks across
+        // requests. Agent conversations therefore use fixed block ordinals:
+        // each newly reached breakpoint extends the cached prefix without
+        // relocating or deleting an earlier breakpoint. Four message markers
+        // also cache the preceding system and tool definitions, while covering
+        // the growing tool loop until the next semantic checkpoint.
+        const hasAgentMessageBreakpoints =
+            isAgentPromptCacheKey(options.prompt_cache_key) &&
+            addAgentMessageCacheBreakpoints(sanitizedMessages, cacheControl);
+
+        if (!hasAgentMessageBreakpoints && sanitizedSystem && sanitizedSystem.length > 0) {
             const lastBlock = sanitizedSystem[sanitizedSystem.length - 1] as TextBlockParam & {
                 cache_control?: unknown;
             };
             lastBlock.cache_control = cacheControl;
         }
-        if (sanitizedTools && sanitizedTools.length > 0) {
+        if (!hasAgentMessageBreakpoints && sanitizedTools && sanitizedTools.length > 0) {
             const lastTool = sanitizedTools[sanitizedTools.length - 1] as ClaudeTool & { cache_control?: unknown };
             lastTool.cache_control = cacheControl;
         }
-        if (options.prompt_cache_key !== undefined) {
+        if (!hasAgentMessageBreakpoints && options.prompt_cache_key !== undefined) {
             const lastMessage = sanitizedMessages[sanitizedMessages.length - 1];
             if (lastMessage && Array.isArray(lastMessage.content) && lastMessage.content.length >= 2) {
                 const stablePrefixBlock = lastMessage.content[lastMessage.content.length - 2];
@@ -764,7 +806,7 @@ export function getClaudePayload(
                     stablePrefixBlock.cache_control = cacheControl;
                 }
             }
-        } else if (sanitizedMessages.length >= 4) {
+        } else if (!hasAgentMessageBreakpoints && sanitizedMessages.length >= 4) {
             const pivotMsg = sanitizedMessages[sanitizedMessages.length - 2];
             if (Array.isArray(pivotMsg.content) && pivotMsg.content.length > 0) {
                 const lastBlock = pivotMsg.content[pivotMsg.content.length - 1];

--- a/drivers/src/shared/claude-messages.ts
+++ b/drivers/src/shared/claude-messages.ts
@@ -77,6 +77,11 @@ import { truncateBinaryForDebug } from './debug-prompt.js';
 const KEEP_RECENT_MESSAGES = 12;
 const OLD_MESSAGE_TEXT_MAX_TOKENS = 2000;
 
+export function isClaudePromptCacheEnabled(options: ExecutionOptions): boolean {
+    const modelOptions = options.model_options as ClaudeBaseOptions | undefined;
+    return options.prompt_cache_key !== undefined || modelOptions?.cache_enabled === true;
+}
+
 interface WarnLogger {
     warn: (data: Record<string, unknown>, message: string) => void;
 }
@@ -730,7 +735,7 @@ export function getClaudePayload(
         ? stripClaudeCacheControlFromTools(options.tools as MessageCreateParamsBase['tools'])
         : undefined;
 
-    const cacheEnabled = options.prompt_cache_key !== undefined || model_options?.cache_enabled === true;
+    const cacheEnabled = isClaudePromptCacheEnabled(options);
     if (cacheEnabled) {
         const cacheTtl = model_options?.cache_ttl as '5m' | '1h' | undefined;
         const cacheControl = { type: 'ephemeral' as const, ...(cacheTtl && { ttl: cacheTtl }) };
@@ -846,11 +851,21 @@ export function buildClaudeStreamingConversation(
     // stale blocks; long agent conversations otherwise balloon context and
     // trigger frequent expensive checkpoints.
     const requestedTextMax = options.stripTextMaxTokens;
+    // Sliding-window truncation rewrites one previously sent message whenever it
+    // falls out of the recent-message window. That defeats Anthropic's exact
+    // prefix cache and turns the growing conversation into a cache write on every
+    // agent iteration. Cached Claude conversations are append-only between
+    // semantic checkpoints; their model-facing tool results are already bounded
+    // and artifact-backed at the Studio execution boundary.
+    const preserveCachedTextPrefix = isClaudePromptCacheEnabled(options);
     const stripOptions = {
         keepForTurns: options.stripImagesAfterTurns ?? Infinity,
         currentTurn,
-        textMaxTokens: requestedTextMax ? Math.min(requestedTextMax, OLD_MESSAGE_TEXT_MAX_TOKENS) : undefined,
-        keepRecentMessages: requestedTextMax ? KEEP_RECENT_MESSAGES : undefined,
+        textMaxTokens:
+            requestedTextMax && !preserveCachedTextPrefix
+                ? Math.min(requestedTextMax, OLD_MESSAGE_TEXT_MAX_TOKENS)
+                : undefined,
+        keepRecentMessages: requestedTextMax && !preserveCachedTextPrefix ? KEEP_RECENT_MESSAGES : undefined,
     };
     let processed = stripBase64ImagesFromConversation(conversation, stripOptions);
     processed = truncateLargeTextInConversation(processed, stripOptions);
@@ -883,7 +898,9 @@ function finalizeClaudeConversation(
     const stripOpts = {
         keepForTurns: options.stripImagesAfterTurns ?? Infinity,
         currentTurn,
-        textMaxTokens: options.stripTextMaxTokens,
+        // See buildClaudeStreamingConversation: cached histories must remain
+        // byte-stable between checkpoints, so do not age-rewrite text blocks.
+        textMaxTokens: isClaudePromptCacheEnabled(options) ? undefined : options.stripTextMaxTokens,
         preserveSubtree,
     };
     let processedConversation = stripBase64ImagesFromConversation(completedConversation, stripOpts);

--- a/drivers/src/shared/claude-messages.ts
+++ b/drivers/src/shared/claude-messages.ts
@@ -79,6 +79,10 @@ const OLD_MESSAGE_TEXT_MAX_TOKENS = 2000;
 const AGENT_PROMPT_CACHE_KEY_PREFIX = 'agent-';
 const AGENT_MESSAGE_CACHE_BLOCK_INTERVAL = 12;
 const MAX_CLAUDE_CACHE_BREAKPOINTS = 4;
+const RESULT_SCHEMA_INSTRUCTION_PREFIXES = [
+    'When not calling tools, the answer must be a JSON object using the following JSON Schema:',
+    'The answer must be a JSON object using the following JSON Schema:',
+] as const;
 
 export function isClaudePromptCacheEnabled(options: ExecutionOptions): boolean {
     const modelOptions = options.model_options as ClaudeBaseOptions | undefined;
@@ -87,6 +91,22 @@ export function isClaudePromptCacheEnabled(options: ExecutionOptions): boolean {
 
 function isAgentPromptCacheKey(promptCacheKey: string | undefined): boolean {
     return promptCacheKey?.startsWith(AGENT_PROMPT_CACHE_KEY_PREFIX) === true;
+}
+
+function isResultSchemaSystemBlock(block: TextBlockParam): boolean {
+    return block.type === 'text' && RESULT_SCHEMA_INSTRUCTION_PREFIXES.some((prefix) => block.text.startsWith(prefix));
+}
+
+function mergeClaudeSystemBlocks(base: TextBlockParam[], additions: TextBlockParam[]): TextBlockParam[] {
+    if (!additions.some(isResultSchemaSystemBlock)) return base.concat(additions);
+
+    // Agent tool continuations carry result_schema on every request. Replacing
+    // the prior generated schema block keeps the system prefix byte-stable and
+    // also repairs conversations persisted by older workers, which accumulated
+    // one identical ~3.5 KB schema block per tool iteration.
+    const combined = base.concat(additions);
+    const latestSchemaIndex = combined.findLastIndex(isResultSchemaSystemBlock);
+    return combined.filter((block, index) => !isResultSchemaSystemBlock(block) || index === latestSchemaIndex);
 }
 
 function addAgentMessageCacheBreakpoints(
@@ -406,14 +426,22 @@ export async function formatClaudePrompt(
     }
 
     if (schemaText && options.prompt_cache_key !== undefined) {
-        const taskMessage = messages[messages.length - 1];
-        const taskBlock = Array.isArray(taskMessage?.content)
-            ? taskMessage.content[taskMessage.content.length - 1]
-            : undefined;
-        if (taskBlock?.type === 'text') {
-            taskBlock.text = `${taskBlock.text}\n\n${schemaText}`;
-        } else {
+        if (isAgentPromptCacheKey(options.prompt_cache_key)) {
+            // Agent result schemas are stable for the whole tool loop. Keep one
+            // generated system block rather than appending the same schema to
+            // every persisted continuation prompt. Routed one-shot prompts keep
+            // the schema on their dynamic task block below.
             system.push({ text: schemaText, type: 'text' as const });
+        } else {
+            const taskMessage = messages[messages.length - 1];
+            const taskBlock = Array.isArray(taskMessage?.content)
+                ? taskMessage.content[taskMessage.content.length - 1]
+                : undefined;
+            if (taskBlock?.type === 'text') {
+                taskBlock.text = `${taskBlock.text}\n\n${schemaText}`;
+            } else {
+                system.push({ text: schemaText, type: 'text' as const });
+            }
         }
     }
 
@@ -591,7 +619,7 @@ export function updateClaudeConversation(
 ): ClaudePrompt {
     const baseSystemMessages = conversation?.system || [];
     const baseMessages = conversation?.messages || [];
-    const system = baseSystemMessages.concat(prompt.system || []);
+    const system = mergeClaudeSystemBlocks(baseSystemMessages, prompt.system || []);
     const combined = sanitizeMessages(baseMessages.concat(prompt.messages || []));
     const mergedMessages = mergeConsecutiveUserMessages(combined);
     return {

--- a/drivers/src/vertexai/index.ts
+++ b/drivers/src/vertexai/index.ts
@@ -30,7 +30,7 @@ import {
     buildOpenAIChatCompletionsStreamingConversation,
     type OpenAIChatCompletionsPrompt,
 } from '../openai/openai_chat_completions.js';
-import { type ClaudePrompt, formatClaudeDebugPrompt } from '../shared/claude-messages.js';
+import { type ClaudePrompt, formatClaudeDebugPrompt, isClaudePromptCacheEnabled } from '../shared/claude-messages.js';
 import { resolveModelListingMetadata } from '../shared/model-listing.js';
 import { generateVertexAiEmbeddings } from './embeddings/embed.js';
 import { ANTHROPIC_REGIONS, NON_GLOBAL_ANTHROPIC_MODELS } from './models/claude.js';
@@ -635,7 +635,10 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
         const stripOptions = {
             keepForTurns: options.stripImagesAfterTurns ?? Infinity,
             currentTurn,
-            textMaxTokens: options.stripTextMaxTokens,
+            // Cached Claude histories must remain byte-stable between semantic
+            // checkpoints. Studio already bounds and artifact-backs model-facing
+            // tool results before they reach this driver.
+            textMaxTokens: isClaudePromptCacheEnabled(options) ? undefined : options.stripTextMaxTokens,
         };
         let processedConversation = stripBase64ImagesFromConversation(withTurn, stripOptions);
         processedConversation = truncateLargeTextInConversation(processedConversation, stripOptions);

--- a/drivers/test/vertexai-streaming-conversation.test.ts
+++ b/drivers/test/vertexai-streaming-conversation.test.ts
@@ -77,4 +77,47 @@ describe('VertexAI streaming conversation rebuild', () => {
         expect(conversation.messages[1].content[0].text).toBe('continue');
         expect(conversation.messages[2].content[0].text).toBe('response');
     });
+
+    test('Claude streaming path keeps a cached prefix immutable across appended tool turns', () => {
+        const driver = new VertexAIDriver({ project: 'test', region: 'us-central1' });
+        const largeToolResult = `SOURCE:${'x'.repeat(12_000)}`;
+        const existing = {
+            messages: [
+                { role: 'assistant', content: [{ type: 'tool_use', id: 'read-1', name: 'read', input: {} }] },
+                { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'read-1', content: largeToolResult }] },
+            ],
+            system: [{ type: 'text', text: 'system' }],
+        };
+        const options = {
+            model: 'publishers/anthropic/models/claude-sonnet-4-6',
+            model_options: { cache_enabled: true },
+            stripTextMaxTokens: 2_000,
+            conversation: existing,
+        } as ExecutionOptions;
+
+        const first = driver.buildStreamingConversation(
+            {
+                messages: [{ role: 'assistant', content: [{ type: 'text', text: 'continue' }] }],
+            } as unknown as VertexAIPrompt,
+            [],
+            [{ id: 'tool-2', tool_name: 'app_workspace_edit', tool_input: { path: 'src/App.tsx' } }],
+            options,
+        ) as unknown as Tree;
+        const second = driver.buildStreamingConversation(
+            {
+                messages: [
+                    { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'tool-2', content: 'edited' }] },
+                ],
+            } as unknown as VertexAIPrompt,
+            [],
+            [{ id: 'tool-3', tool_name: 'app_workspace_typecheck', tool_input: {} }],
+            { ...options, conversation: first },
+        ) as unknown as Tree;
+
+        const firstMessages = first.messages as unknown as unknown[];
+        const secondMessages = second.messages as unknown as unknown[];
+        expect(JSON.stringify(firstMessages)).toContain(largeToolResult);
+        expect(secondMessages.slice(0, firstMessages.length)).toEqual(firstMessages);
+        expect(JSON.stringify(secondMessages.slice(0, firstMessages.length))).toBe(JSON.stringify(firstMessages));
+    });
 });


### PR DESCRIPTION
## Why

Cache-enabled Claude agent conversations were rewriting their own history on every
iteration, so Anthropic's exact-prefix cache almost never hit:

- **Sliding-window truncation** rewrote a previously sent message each time it aged out
  of the recent-message window, changing bytes the cache had already keyed on.
- **The result schema** (~3.5 KB) was appended to the last task block on every tool
  continuation, so the prompt grew a fresh copy per iteration.
- **`cache_control` moved** to the second-to-last block of the newest message each
  request. Vertex requires the marker to stay on the same block across requests, so a
  relocating breakpoint is a guaranteed miss.

The result was a cache write, not a cache read, on nearly every agent turn.

## What changed

- Cached Claude histories are append-only between semantic checkpoints: text truncation
  is disabled while `prompt_cache_key` or `cache_enabled` is set, in both
  `buildClaudeStreamingConversation` and `finalizeClaudeConversation`.
- Agent result schemas are hoisted to a single system block instead of being appended per
  continuation. `mergeClaudeSystemBlocks` keeps only the newest schema block, which also
  repairs conversations persisted by older workers that accumulated one copy per iteration.
- Up to four cache breakpoints are placed at fixed message-block ordinals (0, 12, 24, 36),
  skipping thinking blocks. Each newly reached ordinal extends the cached prefix without
  relocating an earlier one. Beyond ordinal 36 the cached prefix stops growing until the
  next checkpoint, respecting Claude's four-breakpoint cap.
- `AGENT_PROMPT_CACHE_KEY_PREFIX`, `JSON_SCHEMA_INSTRUCTION_PREFIX`, and
  `TOOL_AWARE_JSON_SCHEMA_INSTRUCTION_PREFIX` are exported from `@llumiverse/common` and
  shared by prompt generators and the schema-block matcher, preventing wording or namespace
  drift from silently disabling the optimized layout.
- Applies to Anthropic, Bedrock Mantle, and Vertex-hosted Claude streaming builders.
- Routed document-prefix caching and the sliding text-truncation policy are unchanged when
  prompt caching is off.

## Agent cache-key contract

The optimized agent path is selected by a `prompt_cache_key` in the exported `agent-`
namespace. Agent orchestration consumers can build or qualify stable keys from that shared
constant instead of duplicating an undocumented string convention.

## Rollout note

Consumers that qualify previously unprefixed explicit agent keys may see one cache miss and
full cache write for an in-flight conversation during rollout. Subsequent turns reuse the
new stable prefix normally.

## Test Plan

- [x] `common`: lint / build / typecheck:test / test (235 passed)
- [x] `core`: lint / build / typecheck:test / test (181 passed)
- [x] `drivers`: lint / build / typecheck:test / test (605 passed, 19 skipped)
- [x] New regressions: byte-stable prefixes across turns, fixed breakpoint ordinals as a
      conversation grows, and shared schema/cache-key prefix contracts
- [ ] Live cache read/write ratios from a deployed agent run
