### PR TITLE
feat: capture provider service tiers

### DIFF
--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -407,6 +407,8 @@ export type CompletionResult = TextResult | ThoughtsResult | JsonResult | ImageR
 export interface CompletionChunkObject {
     result: CompletionResult[];
     token_usage?: ExecutionTokenUsage;
+    /** The processing tier the provider actually used for this response. */
+    service_tier?: string;
     finish_reason?: 'stop' | 'length' | string;
     /**
      * Tool calls returned by the model during streaming.
@@ -466,6 +468,8 @@ export interface Completion {
     token_usage?: ExecutionTokenUsage;
     /** Safe diagnostics for the provider-side explicit prompt-cache path used by this completion. */
     prompt_cache_diagnostic?: PromptCacheDiagnostic;
+    /** The processing tier the provider actually used for this response. */
+    service_tier?: string;
     /**
      * Contains the tools from which the model awaits information.
      */

--- a/core/src/CompletionStream.thoughts.test.ts
+++ b/core/src/CompletionStream.thoughts.test.ts
@@ -48,7 +48,11 @@ class ThoughtsStreamDriver extends AbstractDriver<DriverOptions, string> {
                 yield { result: [{ type: 'thoughts', value: 'reason-' }] };
                 yield { result: [{ type: 'thoughts', value: prompt }] };
                 await Promise.resolve();
-                yield { result: [{ type: 'text', value: `answer-${prompt}` }], finish_reason: 'stop' };
+                yield {
+                    result: [{ type: 'text', value: `answer-${prompt}` }],
+                    finish_reason: 'stop',
+                    service_tier: 'priority',
+                };
             },
             finalizeConversation: () => nativeAssistant,
         };
@@ -81,6 +85,7 @@ describe('DefaultCompletionStream thoughts', () => {
             { type: 'text', value: 'answer-one' },
         ]);
         expect(stream.completion?.conversation).toEqual({ role: 'assistant', id: 'one' });
+        expect(stream.completion?.service_tier).toBe('priority');
     });
 
     it('separates thoughts from the answer in the fallback string stream', async () => {

--- a/core/src/CompletionStream.ts
+++ b/core/src/CompletionStream.ts
@@ -352,6 +352,7 @@ export class DefaultCompletionStream<PromptT = unknown> extends ManagedCompletio
 
         const start = Date.now();
         let finish_reason: string | undefined;
+        let serviceTier: string | undefined;
         let promptTokens: number = 0;
         let resultTokens: number | undefined;
         let promptCachedTokens: number | undefined;
@@ -387,6 +388,9 @@ export class DefaultCompletionStream<PromptT = unknown> extends ManagedCompletio
                         if (chunk.finish_reason) {
                             //Do not replace non-null values with null values
                             finish_reason = chunk.finish_reason; //Used to skip empty finish_reason chunks coming after "stop" or "length"
+                        }
+                        if (chunk.service_tier) {
+                            serviceTier = chunk.service_tier;
                         }
                         if (chunk.token_usage) {
                             //Tokens returned include prior parts of stream,
@@ -550,6 +554,7 @@ export class DefaultCompletionStream<PromptT = unknown> extends ManagedCompletio
             prompt: this.driver.formatDebugPrompt(this.prompt),
             execution_time: Date.now() - start,
             token_usage: tokens,
+            service_tier: serviceTier,
             finish_reason: finish_reason,
             chunks: this.chunks,
             tool_use: toolUseArray,

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -807,6 +807,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
                 prompt_cached: result.usage?.cacheReadInputTokens ?? undefined,
                 prompt_cache_write: result.usage?.cacheWriteInputTokens ?? undefined,
             },
+            service_tier: result.serviceTier?.type,
             finish_reason: converseFinishReason(result.stopReason),
         };
 
@@ -927,6 +928,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
         const completionResult: CompletionChunkObject = {
             result: reasoning + output ? [{ type: 'text', value: reasoning + output }] : [],
             token_usage: token_usage,
+            service_tier: result.metadata?.serviceTier?.type,
             finish_reason: converseFinishReason(stop_reason),
             tool_use,
         };
@@ -1231,6 +1233,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
 
         return {
             result: result.message ? [{ type: 'text' as const, value: result.message }] : [],
+            service_tier: res.serviceTier,
             finish_reason: finishReason,
             original_response: options.include_original_response ? result : undefined,
         };
@@ -1289,17 +1292,20 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
                                     ? [{ type: 'text' as const, value: result.delta || result.message || '' }]
                                     : [],
                             finish_reason: finishReason,
+                            service_tier: res.serviceTier,
                         } satisfies CompletionChunkObject;
                     } catch {
                         // If JSON parsing fails, return empty chunk
                         return {
                             result: [],
+                            service_tier: res.serviceTier,
                         } satisfies CompletionChunkObject;
                     }
                 }
 
                 return {
                     result: [],
+                    service_tier: res.serviceTier,
                 } satisfies CompletionChunkObject;
             });
             return withBedrockRuntimeScope(stream, executorScope);

--- a/drivers/src/bedrock/service-tier.test.ts
+++ b/drivers/src/bedrock/service-tier.test.ts
@@ -1,4 +1,4 @@
-import type { ConverseRequest } from '@aws-sdk/client-bedrock-runtime';
+import type { ConverseRequest, ConverseResponse } from '@aws-sdk/client-bedrock-runtime';
 import type { NovaMessagesPrompt } from '@llumiverse/core/formatters';
 import { describe, expect, it, vi } from 'vitest';
 import { BedrockDriver } from './index.js';
@@ -11,6 +11,19 @@ const PROMPT: TwelvelabsPegasusRequest = {
 };
 
 describe('Bedrock service tiers', () => {
+    it('returns the processing tier reported by Converse', () => {
+        const driver = new BedrockDriver({ region: 'us-east-1' });
+        const completion = driver.getExtractedExecution({
+            output: { message: { role: 'assistant', content: [{ text: 'answer' }] } },
+            stopReason: 'end_turn',
+            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+            metrics: { latencyMs: 1 },
+            serviceTier: { type: 'priority' },
+        } as unknown as ConverseResponse);
+
+        expect(completion.service_tier).toBe('priority');
+    });
+
     it('uses the Converse service tier object for text models', () => {
         const driver = new BedrockDriver({ region: 'us-east-1' });
         const prompt: ConverseRequest = {

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -454,6 +454,7 @@ export abstract class OpenAIResponsesDriverBase extends OpenAICompatibleDriverBa
         return {
             result: allResults,
             token_usage: tokenInfo,
+            service_tier: result.service_tier ?? undefined,
             finish_reason: responseFinishReason(result, tools),
             tool_use: tools,
         };
@@ -1035,6 +1036,7 @@ export function mapResponseStream(
                         result: [],
                         finish_reason: responseFinishReason(event.response, finalTools),
                         token_usage: mapUsage(event.response.usage),
+                        service_tier: event.response.service_tier ?? undefined,
                     } satisfies CompletionChunkObject;
                 }
             }

--- a/drivers/src/openai/openai_chat_completions.ts
+++ b/drivers/src/openai/openai_chat_completions.ts
@@ -1033,6 +1033,7 @@ export abstract class OpenAIChatCompletionsProtocol<DriverT> {
             result: completionResults,
             tool_use,
             token_usage: mapOpenAIChatCompletionsUsage(result.usage),
+            service_tier: result.service_tier ?? undefined,
             finish_reason: normalizeOpenAIChatCompletionsFinishReason(choice?.finish_reason, !!tool_use?.length),
             original_response: options.include_original_response
                 ? ((result as OpenAIChatCompletionsResponseWithOriginal)[originalResponseSymbol] ?? result)
@@ -1126,6 +1127,7 @@ export abstract class OpenAIChatCompletionsProtocol<DriverT> {
                     !!toolUseChunks?.length,
                 ),
                 token_usage: mapOpenAIChatCompletionsUsage(json.usage),
+                service_tier: json.service_tier ?? undefined,
             } satisfies CompletionChunkObject;
         });
 

--- a/drivers/src/openai/responses-reasoning.test.ts
+++ b/drivers/src/openai/responses-reasoning.test.ts
@@ -38,6 +38,7 @@ function response() {
         object: 'response',
         created_at: 1,
         model: 'gpt-5',
+        service_tier: 'priority',
         status: 'completed',
         output: [reasoningItem, messageItem],
         output_text: 'answer',
@@ -55,6 +56,17 @@ function response() {
 }
 
 describe('OpenAI Responses reasoning', () => {
+    it('returns the processing tier reported by OpenAI', async () => {
+        const driver = new TestResponsesDriver(vi.fn(async () => response()));
+
+        const completion = await driver.requestTextCompletion(
+            [{ type: 'message', role: 'user', content: 'question' }],
+            { model: 'gpt-5' },
+        );
+
+        expect(completion.service_tier).toBe('priority');
+    });
+
     it('forwards a longer per-execution timeout to the SDK request', async () => {
         const create = vi.fn(async (_request: unknown, _options?: unknown) => response());
         const driver = new TestResponsesDriver(create);

--- a/drivers/src/vertexai/models/gemini-conversation-mutation.test.ts
+++ b/drivers/src/vertexai/models/gemini-conversation-mutation.test.ts
@@ -21,6 +21,7 @@ import {
     convertGeminiFunctionPartsToText,
     GeminiModelDefinition,
     getGeminiPayload,
+    normalizeVertexAIResolvedServiceTier,
     resolveVertexAIServiceTier,
 } from './gemini.js';
 
@@ -42,6 +43,18 @@ describe('resolveVertexAIServiceTier', () => {
                 flex: true,
             }),
         ).toBe('future-tier');
+    });
+});
+
+describe('normalizeVertexAIResolvedServiceTier', () => {
+    it.each([
+        ['ON_DEMAND', 'default'],
+        ['ON_DEMAND_PRIORITY', 'priority'],
+        ['ON_DEMAND_FLEX', 'flex'],
+        ['PROVISIONED_THROUGHPUT', 'provisioned'],
+        ['TRAFFIC_TYPE_UNSPECIFIED', undefined],
+    ])('maps %s to %s', (trafficType, expected) => {
+        expect(normalizeVertexAIResolvedServiceTier(trafficType)).toBe(expected);
     });
 });
 

--- a/drivers/src/vertexai/models/gemini.ts
+++ b/drivers/src/vertexai/models/gemini.ts
@@ -143,6 +143,21 @@ export function resolveVertexAIServiceTier(modelOptions?: VertexAIGeminiOptions)
     return modelOptions?.service_tier ?? (modelOptions?.flex ? 'flex' : undefined);
 }
 
+export function normalizeVertexAIResolvedServiceTier(trafficType?: string): string | undefined {
+    switch (trafficType) {
+        case 'ON_DEMAND':
+            return 'default';
+        case 'ON_DEMAND_PRIORITY':
+            return 'priority';
+        case 'ON_DEMAND_FLEX':
+            return 'flex';
+        case 'PROVISIONED_THROUGHPUT':
+            return 'provisioned';
+        default:
+            return undefined;
+    }
+}
+
 const geminiSafetySettings: SafetySetting[] = [
     {
         category: HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
@@ -848,6 +863,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
         return {
             result: result && result.length > 0 ? result : [{ type: 'text' as const, value: '' }],
             token_usage: token_usage,
+            service_tier: normalizeVertexAIResolvedServiceTier(response.usageMetadata?.trafficType),
             finish_reason: finish_reason,
             original_response: options.include_original_response ? response : undefined,
             conversation: finalConversation,
@@ -947,6 +963,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
                         return {
                             result: combinedResults.length > 0 ? combinedResults : [],
                             token_usage: token_usage,
+                            service_tier: normalizeVertexAIResolvedServiceTier(item.usageMetadata?.trafficType),
                             finish_reason: finish_reason,
                             tool_use,
                         };
@@ -960,6 +977,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
                     : [],
                 finish_reason: item.promptFeedback?.blockReason ?? '',
                 token_usage: token_usage,
+                service_tier: normalizeVertexAIResolvedServiceTier(item.usageMetadata?.trafficType),
             };
         });
 


### PR DESCRIPTION
## Summary

Backport provider-resolved service-tier metadata to the 1.5 release line so downstream metering can price the tier that was actually used.

## Implementation

- Add optional `service_tier` response metadata.
- Capture OpenAI chat and Responses API service tiers.
- Capture Bedrock and Vertex Gemini service-tier metadata.
- Preserve service-tier metadata through streaming completion assembly.
- Add focused driver and completion-stream regression coverage.

## Tests

- `pnpm lint`
- `pnpm build`
- `pnpm typecheck:test`
- `pnpm test src/bedrock/service-tier.test.ts src/openai/responses-reasoning.test.ts src/vertexai/models/gemini-conversation-mutation.test.ts` in `drivers` — 45 passed
- Full common suite — 235 passed
- Full core suite — 181 passed
- The full driver command was also attempted; credential-dependent live Bedrock tests could not use the local AWS SSO profile (`sso_region` unavailable). All changed driver tests pass.

## Risks

The field is optional and backward compatible. Provider responses that omit a tier continue to behave as before.

## Source

Backport of https://github.com/vertesia/llumiverse/pull/607.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, backward-compatible response metadata with no change to request or auth paths; missing tiers behave as before.
> 
> **Overview**
> Adds optional **`service_tier`** on **`Completion`** and streaming **`CompletionChunkObject`**, recording the processing tier the provider actually used (not just what was requested).
> 
> **Bedrock**, **OpenAI** (Chat Completions and Responses, including streaming final events), and **Vertex Gemini** drivers now populate this field from provider responses. Gemini maps **`usageMetadata.trafficType`** through **`normalizeVertexAIResolvedServiceTier`** (e.g. `ON_DEMAND_PRIORITY` → `priority`). **`DefaultCompletionStream`** carries the last non-empty chunk value through to **`stream.completion`**.
> 
> Focused driver and stream tests assert the new metadata. The field stays optional when providers omit tier info.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6b7095e66d02b7353070f5b900e26aaced3217b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->