### PR TITLE
fix: coordinate Gemini context caches

### DIFF
--- a/common/src/schemas/completion.test.ts
+++ b/common/src/schemas/completion.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { CompletionResultSchema } from './completion.js';
+import { CompletionResultSchema, PromptCacheDiagnosticSchema, StatelessExecutionOptionsSchema } from './completion.js';
 
 describe('CompletionResultSchema', () => {
     it('accepts thoughts as a separate completion result type', () => {
@@ -14,5 +14,38 @@ describe('CompletionResultSchema', () => {
             type: 'video',
             value: 'gs://bucket/video.mp4',
         });
+    });
+});
+
+describe('StatelessExecutionOptionsSchema', () => {
+    it('requires explicit cache TTLs to meet the provider minimum', () => {
+        expect(
+            StatelessExecutionOptionsSchema.safeParse({ model: 'gemini-3.7-flash', prompt_cache_ttl_seconds: 60 })
+                .success,
+        ).toBe(true);
+        expect(
+            StatelessExecutionOptionsSchema.safeParse({ model: 'gemini-3.7-flash', prompt_cache_ttl_seconds: 59 })
+                .success,
+        ).toBe(false);
+    });
+
+    it('accepts required mode for explicit-cache diagnostics', () => {
+        expect(
+            StatelessExecutionOptionsSchema.parse({ model: 'gemini-3.7-flash', prompt_cache_mode: 'required' }),
+        ).toMatchObject({ prompt_cache_mode: 'required' });
+    });
+
+    it('publishes safe cache-path diagnostics without provider resource data', () => {
+        expect(
+            PromptCacheDiagnosticSchema.parse({
+                path: 'distributed_registry_hit',
+                explicit_cache_used: true,
+                content_hash_prefix: '0123456789ab',
+                model: 'gemini-3.7-flash',
+                scope: 'environment:project:us-central1',
+                cacheable_part_count: 2,
+                preparation_latency_ms: 4,
+            }),
+        ).not.toHaveProperty('resource_name');
     });
 });

--- a/common/src/schemas/completion.ts
+++ b/common/src/schemas/completion.ts
@@ -36,7 +36,45 @@ export const ModalitiesSchema = z.enum(Modalities).meta({ id: 'Modalities' });
 
 // A literal union rather than a TS enum: this one is only ever written as a plain string in an
 // interaction's execution options, so there is no enum value for callers to import.
-export const PromptCacheModeSchema = z.enum(['auto', 'off']).meta({ id: 'PromptCacheMode' });
+export const PromptCacheModeSchema = z.enum(['auto', 'off', 'required']).meta({ id: 'PromptCacheMode' });
+
+export const PromptCachePathSchema = z
+    .enum([
+        'disabled',
+        'no_key',
+        'local_memo_hit',
+        'distributed_registry_hit',
+        'provider_list_recovery',
+        'created',
+        'waited_for_creator',
+        'refreshed',
+        'fallback_quota',
+        'fallback_provider_error',
+        'fallback_coordination_unavailable',
+        'fallback_wait_timeout',
+        'minimum_token_rejection',
+        'unusable_resource_recreated',
+    ])
+    .meta({ id: 'PromptCachePath' });
+
+export const PromptCacheDiagnosticSchema = z
+    .strictObject({
+        path: PromptCachePathSchema,
+        explicit_cache_used: z.boolean(),
+        content_hash_prefix: z.string().optional(),
+        model: z.string(),
+        scope: z.string().optional(),
+        cacheable_part_count: z.number().int().nonnegative().optional(),
+        preparation_latency_ms: z.number().nonnegative(),
+        wait_latency_ms: z.number().nonnegative().optional(),
+        provider_status: z.number().int().optional(),
+    })
+    .meta({
+        id: 'PromptCacheDiagnostic',
+        description:
+            'Safe diagnostic for one provider-side explicit prompt-cache attempt. It never contains prompt ' +
+            'contents, images, credentials, or full provider resource names.',
+    });
 
 // The wire form of a data source: what it is called and what it contains. The BYTES are not here —
 // a `DataSource` in memory can hand back a stream, and the published component has only ever
@@ -192,17 +230,19 @@ export const StatelessExecutionOptionsSchema = z
             description:
                 'Controls provider-side explicit caches — cache resources the driver creates and reuses (e.g. ' +
                 'Vertex cachedContents). "auto" (default) caches the static prefix whenever prompt_cache_key is ' +
-                'set; "off" never creates or uses a cache resource and leaves the provider payload unchanged. ' +
+                'set; "off" never creates or uses a cache resource and leaves the provider payload unchanged; ' +
+                '"required" behaves like auto but surfaces cache preparation failures instead of falling back. ' +
                 'Implicit caching and cache breakpoints are unaffected.',
         }).optional(),
         prompt_cache_ttl_seconds: z
             .number()
             .int()
-            .positive()
+            .min(60)
             .meta({
                 description:
                     'Lifetime, in seconds, of a provider-side cache resource created for this execution. Defaults ' +
-                    'to 1800 (30 minutes). Ignored by providers without an explicit cache API.',
+                    'to 1800 (30 minutes) and must be at least 60 seconds. Ignored by providers without an explicit ' +
+                    'cache API.',
             })
             .optional(),
         httpTimeout: HttpTimeoutOptionsSchema.meta({

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -1,7 +1,9 @@
 import type { z } from 'zod';
 import type {
     ExecutionTokenUsageSchema,
+    PromptCacheDiagnosticSchema,
     PromptCacheModeSchema,
+    PromptCachePathSchema,
     StatelessExecutionOptionsSchema,
 } from './schemas/completion.js';
 import type {
@@ -423,6 +425,7 @@ export interface CompletionChunkObject {
  */
 export interface DriverCompletionStream extends AsyncIterable<CompletionChunkObject> {
     finalizeConversation?: () => unknown | Promise<unknown>;
+    finalizePromptCacheDiagnostic?: () => PromptCacheDiagnostic | undefined;
 }
 
 /**
@@ -461,6 +464,8 @@ export interface Completion {
     // the driver impl must return the result and optionally the token_usage. the execution time is computed by the extended abstract driver
     result: CompletionResult[];
     token_usage?: ExecutionTokenUsage;
+    /** Safe diagnostics for the provider-side explicit prompt-cache path used by this completion. */
+    prompt_cache_diagnostic?: PromptCacheDiagnostic;
     /**
      * Contains the tools from which the model awaits information.
      */
@@ -598,6 +603,10 @@ export type StatelessExecutionOptions = z.infer<typeof StatelessExecutionOptions
  */
 export type PromptCacheMode = z.infer<typeof PromptCacheModeSchema>;
 
+export type PromptCachePath = z.infer<typeof PromptCachePathSchema>;
+
+export type PromptCacheDiagnostic = z.infer<typeof PromptCacheDiagnosticSchema>;
+
 /** Namespace used by agent conversations that require stable Claude cache layout. */
 export const AGENT_PROMPT_CACHE_KEY_PREFIX = 'agent-';
 
@@ -630,6 +639,8 @@ export interface ExecutionOptionsBase extends PromptOptions {
      *   whenever `prompt_cache_key` is set. Without a key nothing is created.
      * - `off`: never create or use a provider-side cache resource for this execution. Implicit
      *   caching and cache breakpoints are unaffected, and the provider payload is unchanged.
+     * - `required`: use an explicit cache like `auto`, but surface preparation failures instead of
+     *   silently sending the request without it. Intended for diagnostics and validation.
      */
     prompt_cache_mode?: PromptCacheMode;
 

--- a/core/src/CompletionStream.ts
+++ b/core/src/CompletionStream.ts
@@ -538,6 +538,7 @@ export class DefaultCompletionStream<PromptT = unknown> extends ManagedCompletio
             finish_reason: finish_reason,
             chunks: this.chunks,
             tool_use: toolUseArray,
+            prompt_cache_diagnostic: stream?.finalizePromptCacheDiagnostic?.(),
         };
 
         // Build conversation context for multi-turn support

--- a/drivers/src/vertexai/index.ts
+++ b/drivers/src/vertexai/index.ts
@@ -35,11 +35,21 @@ import { resolveModelListingMetadata } from '../shared/model-listing.js';
 import { generateVertexAiEmbeddings } from './embeddings/embed.js';
 import { ANTHROPIC_REGIONS, NON_GLOBAL_ANTHROPIC_MODELS } from './models/claude.js';
 import { formatGeminiDebugPrompt } from './models/gemini.js';
-import { GeminiContextCacheManager } from './models/gemini-context-cache.js';
+import {
+    type GeminiContextCacheCoordinationKey,
+    type GeminiContextCacheCoordinator,
+    GeminiContextCacheManager,
+} from './models/gemini-context-cache.js';
 import { formatImagenDebugPrompt, ImagenModelDefinition, type ImagenPrompt } from './models/imagen.js';
 import { GEMINI_OMNI_VIDEO_MODEL, type OmniVideoPrompt } from './models/omni-video.js';
 import { getModelDefinition, trimModelName } from './models.js';
 import { getListedVertexOpenMaaSModels } from './open-maas-models.js';
+
+export type {
+    GeminiContextCacheCoordinationKey,
+    GeminiContextCacheCoordinator,
+    GeminiContextCacheEntry,
+} from './models/gemini-context-cache.js';
 
 export interface VertexAIDriverOptions extends DriverOptions {
     project: string;
@@ -57,6 +67,10 @@ export interface VertexAIDriverOptions extends DriverOptions {
      * Defaults to 1800 (30 minutes). `ExecutionOptions.prompt_cache_ttl_seconds` overrides it per call.
      */
     geminiContextCacheTtlSeconds?: number;
+    /** Host-supplied fleet coordinator. Llumiverse itself has no Redis dependency. */
+    geminiContextCacheCoordinator?: GeminiContextCacheCoordinator;
+    /** Host isolation scope, normally the Studio environment ID. */
+    geminiContextCacheScope?: string;
 }
 
 export interface GenerateContentPrompt {
@@ -130,23 +144,43 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
     }
 
     /**
-     * Registry of the Vertex `cachedContents` resources this driver instance has created, used by the
-     * Gemini execution path to find-or-create the cache for an execution's `prompt_cache_key`.
+     * Local memo and optional host-supplied fleet coordinator for Vertex `cachedContents`, used by
+     * the Gemini execution path to find-or-create the cache for an execution's `prompt_cache_key`.
      * Returns `undefined` when the driver-level kill switch is off, which keeps the Gemini payload
      * exactly as it is built today.
      *
-     * The registry is per instance on purpose. Two instances create two resources for the same
-     * prefix; the duplicate expires on its own TTL and costs only storage rent for that window,
-     * which is far cheaper than the coordination a shared registry would need.
+     * Llumiverse does not depend on a coordination backend. Studio injects its Redis adapter through
+     * the driver options; standalone consumers retain process-local singleflight and Vertex-list
+     * recovery.
      */
     public getGeminiContextCacheManager(): GeminiContextCacheManager | undefined {
         if (this.options.geminiContextCache === false) return undefined;
         if (!this.geminiContextCacheManager) {
             this.geminiContextCacheManager = new GeminiContextCacheManager({
                 ttlSeconds: this.options.geminiContextCacheTtlSeconds,
+                coordinator: this.options.geminiContextCacheCoordinator,
+                coordinationScope: this.options.geminiContextCacheScope,
             });
         }
         return this.geminiContextCacheManager;
+    }
+
+    public getGeminiContextCacheCoordinationKey(
+        location: string,
+        model: string,
+        contentHash: string,
+    ): GeminiContextCacheCoordinationKey {
+        return {
+            scope: this.options.geminiContextCacheScope,
+            project: this.options.project,
+            location,
+            model,
+            contentHash,
+        };
+    }
+
+    public getVertexRegion(): string {
+        return this.options.region;
     }
 
     /**

--- a/drivers/src/vertexai/models/gemini-context-cache.test.ts
+++ b/drivers/src/vertexai/models/gemini-context-cache.test.ts
@@ -9,15 +9,20 @@ import {
     type Pager,
     type UpdateCachedContentParameters,
 } from '@google/genai';
-import type { ExecutionOptions, Logger } from '@llumiverse/core';
+import { type DataSource, type ExecutionOptions, type Logger, PromptRole, type PromptSegment } from '@llumiverse/core';
 import { describe, expect, it, vi } from 'vitest';
 import { type GenerateContentPrompt, VertexAIDriver, type VertexAIDriverOptions } from '../index.js';
 import { GeminiModelDefinition, getGeminiPayload } from './gemini.js';
 import {
     deriveGeminiCachePrefix,
     GEMINI_CACHE_DISPLAY_NAME_PREFIX,
+    type GeminiContextCacheCoordinationKey,
+    type GeminiContextCacheCoordinator,
+    type GeminiContextCacheEntry,
+    GeminiContextCacheRequiredError,
     geminiCacheContentHash,
     geminiCacheDisplayName,
+    isMinimumTokenCountError,
     stripLeadingParts,
 } from './gemini-context-cache.js';
 
@@ -64,6 +69,110 @@ function cachedContent(name = CACHE_NAME, ttlSeconds = 1800): CachedContent {
 
 function apiError(status: number, message: string): Error {
     return Object.assign(new Error(message), { status });
+}
+
+class FakeDistributedCoordinator implements GeminiContextCacheCoordinator {
+    readonly entries = new Map<string, GeminiContextCacheEntry>();
+    readonly leases = new Map<string, string>();
+    readonly cooldowns = new Map<string, number>();
+    readonly permits = new Set<string>();
+    invalidations = 0;
+    unavailable = false;
+
+    private cacheKey(key: GeminiContextCacheCoordinationKey): string {
+        return JSON.stringify([key.scope, key.project, key.location, key.model, key.contentHash]);
+    }
+
+    private scopeKey(key: GeminiContextCacheCoordinationKey): string {
+        return JSON.stringify([key.scope, key.project, key.location]);
+    }
+
+    private assertAvailable(): void {
+        if (this.unavailable) throw new Error('fake Redis unavailable');
+    }
+
+    async getEntry(key: GeminiContextCacheCoordinationKey): Promise<GeminiContextCacheEntry | undefined> {
+        this.assertAvailable();
+        return this.entries.get(this.cacheKey(key));
+    }
+
+    async acquireLease(key: GeminiContextCacheCoordinationKey): Promise<string | undefined> {
+        this.assertAvailable();
+        const cacheKey = this.cacheKey(key);
+        if (this.leases.has(cacheKey)) return undefined;
+        const token = `lease-${this.leases.size}-${Math.random()}`;
+        this.leases.set(cacheKey, token);
+        return token;
+    }
+
+    async waitForEntry(
+        key: GeminiContextCacheCoordinationKey,
+        timeoutMs: number,
+    ): Promise<GeminiContextCacheEntry | undefined> {
+        this.assertAvailable();
+        const cacheKey = this.cacheKey(key);
+        const deadline = Date.now() + timeoutMs;
+        while (Date.now() < deadline) {
+            const entry = this.entries.get(cacheKey);
+            if (entry) return entry;
+            if (!this.leases.has(cacheKey) || this.cooldowns.has(this.scopeKey(key))) return undefined;
+            await new Promise((resolve) => setTimeout(resolve, 1));
+        }
+        return undefined;
+    }
+
+    async publishEntry(
+        key: GeminiContextCacheCoordinationKey,
+        leaseToken: string,
+        entry: GeminiContextCacheEntry,
+    ): Promise<boolean> {
+        this.assertAvailable();
+        const cacheKey = this.cacheKey(key);
+        if (this.leases.get(cacheKey) !== leaseToken) return false;
+        this.entries.set(cacheKey, entry);
+        return true;
+    }
+
+    async releaseLease(key: GeminiContextCacheCoordinationKey, leaseToken: string): Promise<void> {
+        this.assertAvailable();
+        const cacheKey = this.cacheKey(key);
+        if (this.leases.get(cacheKey) === leaseToken) this.leases.delete(cacheKey);
+    }
+
+    async invalidateEntry(key: GeminiContextCacheCoordinationKey, expectedName: string): Promise<void> {
+        this.assertAvailable();
+        const cacheKey = this.cacheKey(key);
+        if (this.entries.get(cacheKey)?.name === expectedName) {
+            this.entries.delete(cacheKey);
+            this.invalidations++;
+        }
+    }
+
+    async getCooldownUntil(key: GeminiContextCacheCoordinationKey): Promise<number | undefined> {
+        this.assertAvailable();
+        const until = this.cooldowns.get(this.scopeKey(key));
+        return until && until > Date.now() ? until : undefined;
+    }
+
+    async setCooldownUntil(key: GeminiContextCacheCoordinationKey, untilMs: number): Promise<void> {
+        this.assertAvailable();
+        const scopeKey = this.scopeKey(key);
+        this.cooldowns.set(scopeKey, Math.max(this.cooldowns.get(scopeKey) ?? 0, untilMs));
+    }
+
+    async acquireCreatePermit(key: GeminiContextCacheCoordinationKey, limit: number): Promise<string | undefined> {
+        this.assertAvailable();
+        const prefix = `${this.scopeKey(key)}:`;
+        if ([...this.permits].filter((permit) => permit.startsWith(prefix)).length >= limit) return undefined;
+        const token = `${prefix}${Math.random()}`;
+        this.permits.add(token);
+        return token;
+    }
+
+    async releaseCreatePermit(_key: GeminiContextCacheCoordinationKey, permitToken: string): Promise<void> {
+        this.assertAvailable();
+        this.permits.delete(permitToken);
+    }
 }
 
 /** The display name the driver must give — and look for — for the Balise route prefix. */
@@ -366,7 +475,7 @@ describe('Gemini explicit context caching', () => {
 
     it('sends the full un-cached request when cache creation fails', async () => {
         const { driver, create, requests, warn } = makeDriver();
-        create.mockRejectedValueOnce(apiError(503, 'UNAVAILABLE'));
+        create.mockRejectedValue(apiError(400, 'cache creation rejected'));
 
         const completion = await new GeminiModelDefinition(MODEL).requestTextCompletion(
             driver,
@@ -380,8 +489,7 @@ describe('Gemini explicit context caching', () => {
             role: 'user',
             parts: [{ text: 'Route each photo to a domain.' }],
         });
-        expect(requests[0].contents).toHaveLength(1);
-        expect((requests[0].contents as { parts: unknown[] }[])[0].parts).toHaveLength(3);
+        expect(requests[0].contents).toEqual(baliseRoutePrompt().contents);
         expect(completion.result).toEqual([{ type: 'text', value: 'places' }]);
     });
 
@@ -395,6 +503,10 @@ describe('Gemini explicit context caching', () => {
 
         expect(create).toHaveBeenCalledTimes(1);
         expect(warn).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not classify a minimum TTL error as a minimum token error', () => {
+        expect(isMinimumTokenCountError(apiError(400, 'TTL must be at least the minimum of 60 seconds.'))).toBe(false);
     });
 
     it('rediscovers, then recreates once, when the resource has gone', async () => {
@@ -479,6 +591,269 @@ describe('Gemini explicit context caching', () => {
             total: 4230,
         });
     });
+
+    it('deduplicates 20 concurrent creates inside one driver process', async () => {
+        const { driver, create } = makeDriver();
+        create.mockImplementation(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 10));
+            return cachedContent();
+        });
+        const model = new GeminiModelDefinition(MODEL);
+
+        await Promise.all(
+            Array.from({ length: 20 }, () => model.requestTextCompletion(driver, baliseRoutePrompt(), cachedOptions())),
+        );
+
+        expect(create).toHaveBeenCalledTimes(1);
+    });
+
+    it('leaves transient create retry policy to the host workflow', async () => {
+        const { driver, create } = makeDriver();
+        create.mockRejectedValueOnce(apiError(503, 'UNAVAILABLE'));
+
+        const completion = await new GeminiModelDefinition(MODEL).requestTextCompletion(
+            driver,
+            baliseRoutePrompt(),
+            cachedOptions(),
+        );
+
+        expect(create).toHaveBeenCalledTimes(1);
+        expect(completion.prompt_cache_diagnostic).toMatchObject({
+            path: 'fallback_provider_error',
+            provider_status: 503,
+        });
+    });
+});
+
+describe('Gemini distributed context cache coordination', () => {
+    const coordinatedOptions = (coordinator: FakeDistributedCoordinator): Partial<VertexAIDriverOptions> => ({
+        geminiContextCacheCoordinator: coordinator,
+        geminiContextCacheScope: 'environment-1',
+    });
+
+    it('produces one create across 20 driver instances sharing a coordinator', async () => {
+        const coordinator = new FakeDistributedCoordinator();
+        const harnesses = Array.from({ length: 20 }, () => makeDriver(coordinatedOptions(coordinator)));
+
+        const completions = await Promise.all(
+            harnesses.map(({ driver }) =>
+                new GeminiModelDefinition(MODEL).requestTextCompletion(driver, baliseRoutePrompt(), cachedOptions()),
+            ),
+        );
+
+        expect(harnesses.reduce((sum, harness) => sum + harness.create.mock.calls.length, 0)).toBe(1);
+        expect(
+            completions.filter((completion) => completion.prompt_cache_diagnostic?.explicit_cache_used),
+        ).toHaveLength(20);
+    });
+
+    it('converges route and extraction calls with identical cached contents', async () => {
+        const coordinator = new FakeDistributedCoordinator();
+        const route = makeDriver(coordinatedOptions(coordinator));
+        const extraction = makeDriver(coordinatedOptions(coordinator));
+        const extractionPrompt = baliseRoutePrompt();
+        extractionPrompt.contents[1] = {
+            role: 'user',
+            parts: [
+                { text: 'Photo 99: extract fields.' },
+                { inlineData: { data: 'cGhvdG8=', mimeType: 'image/jpeg' } },
+            ],
+        };
+
+        await Promise.all([
+            new GeminiModelDefinition(MODEL).requestTextCompletion(route.driver, baliseRoutePrompt(), cachedOptions()),
+            new GeminiModelDefinition(MODEL).requestTextCompletion(
+                extraction.driver,
+                extractionPrompt,
+                cachedOptions(),
+            ),
+        ]);
+
+        expect(route.create.mock.calls.length + extraction.create.mock.calls.length).toBe(1);
+        expect(route.requests[0].config?.cachedContent).toBe(extraction.requests[0].config?.cachedContent);
+    });
+
+    it('never shares a resource for different cache contents even when keys match', async () => {
+        const coordinator = new FakeDistributedCoordinator();
+        const first = makeDriver(coordinatedOptions(coordinator));
+        const second = makeDriver(coordinatedOptions(coordinator));
+        const otherPrompt = baliseRoutePrompt();
+        otherPrompt.contents[0] = { role: 'user', parts: [{ text: `${CATALOG_TEXT}different` }] };
+
+        await Promise.all([
+            new GeminiModelDefinition(MODEL).requestTextCompletion(first.driver, baliseRoutePrompt(), cachedOptions()),
+            new GeminiModelDefinition(MODEL).requestTextCompletion(second.driver, otherPrompt, cachedOptions()),
+        ]);
+
+        expect(first.create.mock.calls.length + second.create.mock.calls.length).toBe(2);
+        expect(coordinator.entries.size).toBe(2);
+    });
+
+    it('shares a 429 cooldown and allows exactly one retry after it clears', async () => {
+        const coordinator = new FakeDistributedCoordinator();
+        const first = makeDriver(coordinatedOptions(coordinator));
+        const second = makeDriver(coordinatedOptions(coordinator));
+        first.create.mockRejectedValue(
+            Object.assign(apiError(429, 'RESOURCE_EXHAUSTED'), { headers: { 'retry-after': '2' } }),
+        );
+
+        const firstCompletion = await new GeminiModelDefinition(MODEL).requestTextCompletion(
+            first.driver,
+            baliseRoutePrompt(),
+            cachedOptions(),
+        );
+        const secondCompletion = await new GeminiModelDefinition(MODEL).requestTextCompletion(
+            second.driver,
+            baliseRoutePrompt(),
+            cachedOptions(),
+        );
+
+        expect(first.create).toHaveBeenCalledTimes(1);
+        expect(second.create).not.toHaveBeenCalled();
+        expect(firstCompletion.prompt_cache_diagnostic?.path).toBe('fallback_quota');
+        expect(secondCompletion.prompt_cache_diagnostic?.path).toBe('fallback_quota');
+        expect([...coordinator.cooldowns.values()][0] - Date.now()).toBeGreaterThan(1_500);
+
+        coordinator.cooldowns.clear();
+        const retries = [makeDriver(coordinatedOptions(coordinator)), makeDriver(coordinatedOptions(coordinator))];
+        await Promise.all(
+            retries.map(({ driver }) =>
+                new GeminiModelDefinition(MODEL).requestTextCompletion(driver, baliseRoutePrompt(), cachedOptions()),
+            ),
+        );
+        expect(retries.reduce((sum, harness) => sum + harness.create.mock.calls.length, 0)).toBe(1);
+    });
+
+    it('coordinates a near-expiry TTL refresh once', async () => {
+        const coordinator = new FakeDistributedCoordinator();
+        const seed = makeDriver(coordinatedOptions(coordinator));
+        const prefix = deriveGeminiCachePrefix(baliseRoutePrompt());
+        if (!prefix) throw new Error('expected cacheable prefix');
+        const contentHash = geminiCacheContentHash(MODEL, prefix, undefined, undefined);
+        const key = seed.driver.getGeminiContextCacheCoordinationKey('us-central1', MODEL, contentHash);
+        coordinator.entries.set(JSON.stringify([key.scope, key.project, key.location, key.model, key.contentHash]), {
+            name: CACHE_NAME,
+            expiresAtMs: Date.now() + 60_000,
+        });
+        const harnesses = Array.from({ length: 20 }, () => makeDriver(coordinatedOptions(coordinator)));
+
+        await Promise.all(
+            harnesses.map(({ driver }) =>
+                new GeminiModelDefinition(MODEL).requestTextCompletion(driver, baliseRoutePrompt(), cachedOptions()),
+            ),
+        );
+
+        expect(harnesses.reduce((sum, harness) => sum + harness.update.mock.calls.length, 0)).toBe(1);
+        expect(harnesses.reduce((sum, harness) => sum + harness.create.mock.calls.length, 0)).toBe(0);
+    });
+
+    it('invalidates a 404 by expected name and coordinates one recreation', async () => {
+        const coordinator = new FakeDistributedCoordinator();
+        const harness = makeDriver(coordinatedOptions(coordinator));
+        const prefix = deriveGeminiCachePrefix(baliseRoutePrompt());
+        if (!prefix) throw new Error('expected cacheable prefix');
+        const contentHash = geminiCacheContentHash(MODEL, prefix, undefined, undefined);
+        const key = harness.driver.getGeminiContextCacheCoordinationKey('us-central1', MODEL, contentHash);
+        coordinator.entries.set(JSON.stringify([key.scope, key.project, key.location, key.model, key.contentHash]), {
+            name: PEER_CACHE_NAME,
+            expiresAtMs: Date.now() + 20 * 60_000,
+        });
+        harness.generateContent.mockRejectedValueOnce(apiError(404, 'CachedContent not found.'));
+
+        const completion = await new GeminiModelDefinition(MODEL).requestTextCompletion(
+            harness.driver,
+            baliseRoutePrompt(),
+            cachedOptions(),
+        );
+
+        expect(coordinator.invalidations).toBe(1);
+        expect(harness.create).toHaveBeenCalledTimes(1);
+        expect(completion.prompt_cache_diagnostic?.path).toBe('unusable_resource_recreated');
+    });
+
+    it('preserves inference without any create when coordination is unavailable', async () => {
+        const coordinator = new FakeDistributedCoordinator();
+        coordinator.unavailable = true;
+        const harnesses = Array.from({ length: 20 }, () => makeDriver(coordinatedOptions(coordinator)));
+
+        const completions = await Promise.all(
+            harnesses.map(({ driver }) =>
+                new GeminiModelDefinition(MODEL).requestTextCompletion(driver, baliseRoutePrompt(), cachedOptions()),
+            ),
+        );
+
+        expect(harnesses.reduce((sum, harness) => sum + harness.create.mock.calls.length, 0)).toBe(0);
+        expect(completions.every((completion) => completion.result[0]?.value === 'places')).toBe(true);
+        expect(
+            completions.every(
+                (completion) => completion.prompt_cache_diagnostic?.path === 'fallback_coordination_unavailable',
+            ),
+        ).toBe(true);
+    });
+});
+
+describe('Gemini PromptSegment cache breakpoint', () => {
+    function image(): DataSource {
+        return {
+            name: 'photo.jpg',
+            mime_type: 'image/jpeg',
+            getURI: vi.fn().mockResolvedValue('gs://balise-dev/photo.jpg'),
+            getURL: vi.fn(),
+            getStream: vi.fn(),
+        } as unknown as DataSource;
+    }
+
+    const segments = (): PromptSegment[] => [
+        { role: PromptRole.system, content: 'Route each photo to a domain.' },
+        { role: PromptRole.user, content: CATALOG_TEXT },
+        { role: PromptRole.user, content: 'Route this photo.', files: [image()] },
+    ];
+
+    it('keeps stable user text in cachedContents and the image task in both provider paths', async () => {
+        const blocking = makeDriver();
+        const streaming = makeDriver();
+        const model = new GeminiModelDefinition(MODEL);
+        const blockingPrompt = await model.createPrompt(blocking.driver, segments(), cachedOptions());
+        const streamingPrompt = await model.createPrompt(streaming.driver, segments(), cachedOptions());
+
+        expect(blockingPrompt.contents).toHaveLength(2);
+        await model.requestTextCompletion(blocking.driver, blockingPrompt, cachedOptions());
+        const stream = await model.requestTextCompletionStream(streaming.driver, streamingPrompt, cachedOptions());
+        for await (const _chunk of stream) {
+            // Drain the native stream so its final diagnostic and conversation are available.
+        }
+
+        for (const harness of [blocking, streaming]) {
+            expect(harness.create.mock.calls[0][0].config?.contents).toEqual([
+                { role: 'user', parts: [{ text: CATALOG_TEXT }] },
+            ]);
+            expect(harness.requests[0].contents).toEqual([
+                {
+                    role: 'user',
+                    parts: [
+                        { text: 'Route this photo.' },
+                        { fileData: { fileUri: 'gs://balise-dev/photo.jpg', mimeType: 'image/jpeg' } },
+                    ],
+                },
+            ]);
+        }
+    });
+
+    it('keeps a trailing model segment out of cachedContents.create', async () => {
+        const harness = makeDriver();
+        const prompt = baliseRoutePrompt();
+        prompt.contents.splice(1, 0, { role: 'model', parts: [{ text: 'Ready to route a photo.' }] });
+
+        await new GeminiModelDefinition(MODEL).requestTextCompletion(harness.driver, prompt, cachedOptions());
+
+        expect(harness.create.mock.calls[0][0].config?.contents).toEqual([
+            { role: 'user', parts: [{ text: CATALOG_TEXT }] },
+        ]);
+        expect(harness.requests[0].contents).toEqual([
+            { role: 'model', parts: [{ text: 'Ready to route a photo.' }] },
+            prompt.contents[2],
+        ]);
+    });
 });
 
 describe('Gemini explicit context caching opt-out', () => {
@@ -513,6 +888,20 @@ describe('Gemini explicit context caching opt-out', () => {
 
         expect(request).toEqual(getGeminiPayload(options, baliseRoutePrompt()));
         expect(create).not.toHaveBeenCalled();
+    });
+
+    it('surfaces preparation failure when prompt_cache_mode is required', async () => {
+        const { driver, create, generateContent } = makeDriver();
+        create.mockRejectedValue(apiError(400, 'cache creation rejected'));
+
+        await expect(
+            new GeminiModelDefinition(MODEL).requestTextCompletion(
+                driver,
+                baliseRoutePrompt(),
+                cachedOptions({ prompt_cache_mode: 'required' }),
+            ),
+        ).rejects.toBeInstanceOf(GeminiContextCacheRequiredError);
+        expect(generateContent).not.toHaveBeenCalled();
     });
 
     it('exposes no registry when the driver kill switch is off', () => {

--- a/drivers/src/vertexai/models/gemini-context-cache.ts
+++ b/drivers/src/vertexai/models/gemini-context-cache.ts
@@ -8,7 +8,7 @@ import type {
     Tool,
     ToolConfig,
 } from '@google/genai';
-import type { ExecutionOptions } from '@llumiverse/core';
+import type { ExecutionOptions, PromptCacheDiagnostic, PromptCachePath } from '@llumiverse/core';
 import type { GenerateContentPrompt, VertexAIDriver } from '../index.js';
 
 /**
@@ -36,9 +36,9 @@ import type { GenerateContentPrompt, VertexAIDriver } from '../index.js';
  *            stopping before the first block containing a non-text part (image, file, tool call,
  *            signed thought) or before the final block, whichever comes first.
  *
- * The final block is never cached: it is the turn that changes from call to call. Derivation runs on
- * the prompt's `Content` blocks *before* `mergeConsecutiveRole` collapses same-role neighbours, so
- * the boundary the caller expressed by sending separate segments survives. A prompt shaped
+ * The final block is never cached: it is the turn that changes from call to call. Prompt content
+ * blocks are never merged, so the boundary the caller expressed by sending separate segments
+ * survives. A prompt shaped
  * `[system, user: catalog text, user: task text + image]` therefore caches `system + catalog` and
  * sends `task + image` — which is the shape that matters, since the task text names the photo.
  *
@@ -50,20 +50,17 @@ import type { GenerateContentPrompt, VertexAIDriver } from '../index.js';
  * shard that key (`route:0` … `route:3`) to spread load, and hashing it would mint four resources
  * for four byte-identical prefixes. Content addressing collapses the shards onto one cache for free.
  *
- * ## Registry: Vertex itself, with a local memo in front
+ * ## Registry: host coordination, with a local memo and Vertex recovery
  *
  * A registry that lives only in a process costs hit rate linearly in fleet size — every instance
- * pays its own cold create, multiplied by every shard. So the shared registry *is* Vertex: each
- * cache is created with a deterministic `displayName` built from the content hash, and a cold
- * instance lists `cachedContents` and adopts a live match instead of creating its own.
+ * pays its own cold create, multiplied by every shard. Hosts can inject a distributed coordinator;
+ * Studio supplies Redis. The coordinator stores resource name/expiry, grants one bounded lease per
+ * content hash, shares create cooldowns, and limits concurrent creates per Vertex project/location.
  *
- * The in-memory map on the driver instance is a memo in front of that, not the registry itself:
- * listing happens on a cold key, on expiry, and after a 404 — never per call.
- *
- * Two instances that go cold at the same moment can still both create. That is left alone
- * deliberately: the duplicate expires on its own TTL, costs storage rent for that window rather than
- * a re-billed prefix, and both instances converge on one resource at the next list. Locking would
- * cost more than the duplication does.
+ * The in-memory map on the driver instance is a memo in front of that registry. Vertex listing by
+ * deterministic `displayName` remains recovery for a missing registry entry or a pre-existing
+ * resource; it is not the normal fleet lookup. If the injected coordinator is unavailable, a live
+ * local memo may still be used, but a cold instance sends uncached rather than creating in a storm.
  *
  * `ListCachedContents` carries no filter field, so the match is client-side: one control-plane read
  * per cold key, paged at 100 (the API coerces anything above 1000), stopping at the first hit and
@@ -72,10 +69,10 @@ import type { GenerateContentPrompt, VertexAIDriver } from '../index.js';
  *
  * ## Fallback
  *
- * Every failure on the cache path is non-fatal. A create error, a min-token rejection, an expired
- * resource, a permission error: one warning through the driver logger, then the full un-cached
- * request exactly as before. A min-token rejection additionally marks the prefix uncacheable so the
- * next thousand calls do not each pay for a doomed create.
+ * In `auto` mode every failure on the cache path is non-fatal. A create error, a min-token rejection,
+ * an expired resource, or a permission error produces a safe diagnostic and then the full uncached
+ * request. In `required` mode the same preparation failure is surfaced for validation. A min-token
+ * rejection additionally marks the prefix uncacheable so later calls do not repeat a doomed create.
  */
 
 /** Default lifetime of a created `cachedContents` resource. */
@@ -107,15 +104,73 @@ const LIST_PAGE_SIZE = 100;
 /** Bound on a single discovery sweep, so a project full of unrelated caches cannot stall a call. */
 const LIST_MAX_SCANNED = 1000;
 
+const CACHE_LEASE_MS = 60_000;
+const CACHE_WAIT_MS = 5_000;
+const CREATE_PERMIT_WAIT_MS = 1_500;
+const CREATE_PERMIT_LEASE_MS = 60_000;
+const MAX_CONCURRENT_CREATES_PER_LOCATION = 2;
+const DEFAULT_QUOTA_COOLDOWN_MS = 30_000;
+
 export interface GeminiContextCacheEntry {
     /** Server-generated resource name, e.g. `projects/p/locations/l/cachedContents/123`. */
     name: string;
     expiresAtMs: number;
 }
 
+export interface GeminiContextCacheCoordinationKey {
+    /** Studio environment ID or another caller-defined isolation scope. */
+    scope?: string;
+    project: string;
+    location: string;
+    model: string;
+    contentHash: string;
+}
+
+/**
+ * Optional fleet coordinator supplied by the host application.
+ *
+ * Llumiverse deliberately owns no Redis dependency. Studio injects these functions when it creates
+ * a Vertex driver; another host can implement the same semantics with its own coordination store.
+ * A rejected operation means coordination is unavailable and causes a safe uncached fallback.
+ */
+export interface GeminiContextCacheCoordinator {
+    getEntry(key: GeminiContextCacheCoordinationKey): Promise<GeminiContextCacheEntry | undefined>;
+    acquireLease(key: GeminiContextCacheCoordinationKey, leaseMs: number): Promise<string | undefined>;
+    waitForEntry(
+        key: GeminiContextCacheCoordinationKey,
+        timeoutMs: number,
+    ): Promise<GeminiContextCacheEntry | undefined>;
+    publishEntry(
+        key: GeminiContextCacheCoordinationKey,
+        leaseToken: string,
+        entry: GeminiContextCacheEntry,
+        ttlMs: number,
+    ): Promise<boolean>;
+    releaseLease(key: GeminiContextCacheCoordinationKey, leaseToken: string): Promise<void>;
+    invalidateEntry(key: GeminiContextCacheCoordinationKey, expectedName: string): Promise<void>;
+    getCooldownUntil(key: GeminiContextCacheCoordinationKey): Promise<number | undefined>;
+    setCooldownUntil(key: GeminiContextCacheCoordinationKey, untilMs: number): Promise<void>;
+    acquireCreatePermit(
+        key: GeminiContextCacheCoordinationKey,
+        limit: number,
+        leaseMs: number,
+        waitMs: number,
+    ): Promise<string | undefined>;
+    releaseCreatePermit(key: GeminiContextCacheCoordinationKey, permitToken: string): Promise<void>;
+}
+
 export interface GeminiContextCacheManagerOptions {
     /** TTL used when an execution does not carry `prompt_cache_ttl_seconds`. */
     ttlSeconds?: number;
+    coordinator?: GeminiContextCacheCoordinator;
+    coordinationScope?: string;
+}
+
+interface GeminiContextCacheResolution {
+    entry?: GeminiContextCacheEntry;
+    path: PromptCachePath;
+    waitLatencyMs?: number;
+    providerStatus?: number;
 }
 
 /**
@@ -125,17 +180,23 @@ export interface GeminiContextCacheManagerOptions {
  * and de-duplication of concurrent lookups for the same content. It holds no client and makes no
  * calls; the caller supplies the loader, so discovery and creation stay testable without GCP.
  *
- * This is a memo, not the registry — the registry is Vertex, reached by listing. Its only job is to
- * keep that listing off the per-call path.
+ * This is a memo, not the fleet registry. Its job is to keep distributed lookups off the hot path
+ * and collapse concurrent calls inside one driver process.
  */
 export class GeminiContextCacheManager {
     private readonly entries = new Map<string, GeminiContextCacheEntry>();
     private readonly uncacheable = new Set<string>();
-    private readonly pending = new Map<string, Promise<GeminiContextCacheEntry | undefined>>();
+    private readonly pending = new Map<string, Promise<GeminiContextCacheResolution>>();
+    private createCooldownUntilMs = 0;
+    private activeCreates = 0;
     readonly defaultTtlSeconds: number;
+    readonly coordinator: GeminiContextCacheCoordinator | undefined;
+    readonly coordinationScope: string | undefined;
 
     constructor(options: GeminiContextCacheManagerOptions = {}) {
         this.defaultTtlSeconds = options.ttlSeconds ?? DEFAULT_GEMINI_CONTEXT_CACHE_TTL_SECONDS;
+        this.coordinator = options.coordinator;
+        this.coordinationScope = options.coordinationScope;
     }
 
     get(key: string): GeminiContextCacheEntry | undefined {
@@ -170,20 +231,48 @@ export class GeminiContextCacheManager {
         }
     }
 
+    getLocalCooldownUntil(): number | undefined {
+        return this.createCooldownUntilMs > Date.now() ? this.createCooldownUntilMs : undefined;
+    }
+
+    setLocalCooldownUntil(untilMs: number): void {
+        this.createCooldownUntilMs = Math.max(this.createCooldownUntilMs, untilMs);
+    }
+
+    async acquireLocalCreatePermit(waitMs: number): Promise<boolean> {
+        const deadline = Date.now() + waitMs;
+        while (this.activeCreates >= MAX_CONCURRENT_CREATES_PER_LOCATION) {
+            if (Date.now() >= deadline) return false;
+            await delay(Math.min(25, Math.max(1, deadline - Date.now())));
+        }
+        this.activeCreates++;
+        return true;
+    }
+
+    releaseLocalCreatePermit(): void {
+        this.activeCreates = Math.max(0, this.activeCreates - 1);
+    }
+
     /**
      * Return the memoized entry for `key`, or run `load` — discovery then creation — on a miss or
      * near expiry. Concurrent callers for the same content share one lookup.
      */
     async resolve(
         key: string,
-        load: () => Promise<GeminiContextCacheEntry | undefined>,
-    ): Promise<GeminiContextCacheEntry | undefined> {
+        load: () => Promise<GeminiContextCacheResolution>,
+    ): Promise<GeminiContextCacheResolution> {
         const existing = this.entries.get(key);
         if (existing && existing.expiresAtMs - Date.now() > CACHE_REFRESH_MARGIN_MS) {
-            return existing;
+            return { entry: existing, path: 'local_memo_hit' };
         }
         const inflight = this.pending.get(key);
-        if (inflight) return inflight;
+        if (inflight) {
+            const startedAt = Date.now();
+            const resolution = await inflight;
+            return resolution.entry
+                ? { ...resolution, path: 'waited_for_creator', waitLatencyMs: Date.now() - startedAt }
+                : resolution;
+        }
 
         const started = load().finally(() => this.pending.delete(key));
         this.pending.set(key, started);
@@ -198,7 +287,7 @@ export class GeminiContextCacheManager {
 export interface GeminiCachePrefix {
     system?: Content;
     contents: Content[];
-    /** Number of leading `Part`s the prefix covers once same-role blocks are merged. */
+    /** Number of leading `Part`s lifted into the cache resource. */
     partCount: number;
 }
 
@@ -232,14 +321,19 @@ export function deriveGeminiCachePrefix(prompt: GenerateContentPrompt): GeminiCa
         prefix.push(contents[i]);
         partCount += parts.length;
     }
+    // Vertex rejects cachedContents.create when its request ends in a model turn. Keep any trailing
+    // model blocks in the uncached continuation; the resource must end on a user turn.
+    while (prefix.at(-1)?.role === 'model') {
+        partCount -= prefix.pop()?.parts?.length ?? 0;
+    }
     if (!prompt.system && prefix.length === 0) return undefined;
     return { system: prompt.system, contents: prefix, partCount };
 }
 
 /**
- * Drop the first `count` `Part`s from a merged `Content[]`, dropping blocks that empty out.
- * Returns `undefined` if the request holds fewer parts than the prefix claims — a mismatch means the
- * payload is not the merge of the prompt we derived from, and caching must not touch it.
+ * Drop the first `count` `Part`s from a `Content[]`, dropping blocks that empty out. Returns
+ * `undefined` if the request holds fewer parts than the prefix claims; caching must not touch a
+ * payload that no longer matches the prompt from which the prefix was derived.
  */
 export function stripLeadingParts(contents: Content[], count: number): Content[] | undefined {
     if (count <= 0) return contents;
@@ -289,7 +383,7 @@ function errorMessage(error: unknown): string {
 export function isMinimumTokenCountError(error: unknown): boolean {
     const status = errorStatus(error);
     if (status !== undefined && status !== 400) return false;
-    return /minimum|min_?total_?token|too small|too few tokens|at least \d+ tokens/i.test(errorMessage(error));
+    return /minimum token|min_?total_?token|too (?:small|few).*token|at least \d+ tokens/i.test(errorMessage(error));
 }
 
 /**
@@ -311,9 +405,28 @@ export function isCacheUnusableError(error: unknown): boolean {
 
 interface GeminiContextCachePlan {
     payload: GenerateContentParameters;
-    contentHash: string;
+    managerKey: string;
     cacheName: string;
     manager: GeminiContextCacheManager;
+    coordinationKey?: GeminiContextCacheCoordinationKey;
+    diagnostic: PromptCacheDiagnostic;
+}
+
+interface GeminiContextCachePlanResult {
+    plan?: GeminiContextCachePlan;
+    diagnostic: PromptCacheDiagnostic;
+}
+
+export interface GeminiContextCacheExecution<T> {
+    value: T;
+    diagnostic: PromptCacheDiagnostic;
+}
+
+export class GeminiContextCacheRequiredError extends Error {
+    constructor(readonly diagnostic: PromptCacheDiagnostic) {
+        super(`Gemini explicit context cache was required but unavailable (${diagnostic.path})`);
+        this.name = 'GeminiContextCacheRequiredError';
+    }
 }
 
 /**
@@ -376,28 +489,52 @@ async function planGeminiContextCache(
     options: ExecutionOptions,
     prompt: GenerateContentPrompt,
     payload: GenerateContentParameters,
+    location: string,
     /** Resource names already proven unusable on this call, so discovery does not re-adopt them. */
     excludeCacheNames?: ReadonlySet<string>,
-): Promise<GeminiContextCachePlan | undefined> {
+): Promise<GeminiContextCachePlanResult> {
+    const startedAt = Date.now();
+    const baseDiagnostic = (path: PromptCachePath): PromptCacheDiagnostic => ({
+        path,
+        explicit_cache_used: false,
+        model: payload.model,
+        preparation_latency_ms: Date.now() - startedAt,
+    });
     // Order matters: without a cache key nothing below runs, so a driver that never opted in — or a
     // test double that does not implement the registry — sees exactly today's payload.
-    if (!options.prompt_cache_key) return undefined;
-    if (options.prompt_cache_mode === 'off') return undefined;
+    if (options.prompt_cache_mode === 'off') return { diagnostic: baseDiagnostic('disabled') };
+    if (!options.prompt_cache_key) return { diagnostic: baseDiagnostic('no_key') };
     // Image generation carries its own config shape and no reusable prefix.
-    if (options.model.toLowerCase().includes('image')) return undefined;
+    if (options.model.toLowerCase().includes('image')) return { diagnostic: baseDiagnostic('disabled') };
     const manager = driver.getGeminiContextCacheManager?.();
-    if (!manager) return undefined;
-    if (!Array.isArray(payload.contents)) return undefined;
+    if (!manager) return { diagnostic: baseDiagnostic('disabled') };
+    if (!Array.isArray(payload.contents)) return { diagnostic: baseDiagnostic('fallback_provider_error') };
 
     const prefix = deriveGeminiCachePrefix(prompt);
-    if (!prefix) return undefined;
+    if (!prefix) return { diagnostic: baseDiagnostic('fallback_provider_error') };
 
     // Vertex rejects a generateContent request that sets systemInstruction, tools or toolConfig
     // alongside cachedContent — those belong to the cache. So they are part of its identity.
     const tools = payload.config?.tools as Tool[] | undefined;
     const toolConfig = payload.config?.toolConfig;
     const contentHash = geminiCacheContentHash(payload.model, prefix, tools, toolConfig);
-    if (manager.isUncacheable(contentHash)) return undefined;
+    const managerKey = `${location}:${contentHash}`;
+    const coordinationKey = driver.getGeminiContextCacheCoordinationKey?.(location, payload.model, contentHash);
+    const diagnostic = (path: PromptCachePath, extra: Partial<PromptCacheDiagnostic> = {}): PromptCacheDiagnostic => ({
+        path,
+        explicit_cache_used: false,
+        content_hash_prefix: contentHash.slice(0, 12),
+        model: payload.model,
+        scope: coordinationKey
+            ? [coordinationKey.scope, coordinationKey.project, coordinationKey.location].filter(Boolean).join(':')
+            : manager.coordinationScope,
+        cacheable_part_count: prefix.partCount,
+        preparation_latency_ms: Date.now() - startedAt,
+        ...extra,
+    });
+    if (manager.isUncacheable(managerKey)) {
+        return { diagnostic: diagnostic('minimum_token_rejection') };
+    }
 
     const requestContents = stripLeadingParts(payload.contents as Content[], prefix.partCount);
     if (!requestContents || requestContents.length === 0) {
@@ -405,38 +542,58 @@ async function planGeminiContextCache(
             { model: payload.model },
             '[VertexAI] Gemini context cache: request contents do not match the derived prefix, sending un-cached',
         );
-        return undefined;
+        return { diagnostic: diagnostic('fallback_provider_error') };
     }
 
-    const entry = await manager.resolve(contentHash, () =>
+    const resolution = await manager.resolve(managerKey, () =>
         adoptOrCreateCache({
             driver,
             client,
             manager,
             contentHash,
+            managerKey,
             model: payload.model,
             prefix,
             tools,
             toolConfig,
             ttlSeconds: resolveTtlSeconds(options, manager),
             excludeCacheNames,
+            coordinationKey,
         }),
     );
-    if (!entry) return undefined;
+    if (!resolution.entry) {
+        return {
+            diagnostic: diagnostic(resolution.path, {
+                wait_latency_ms: resolution.waitLatencyMs,
+                provider_status: resolution.providerStatus,
+            }),
+        };
+    }
+
+    const cacheDiagnostic = diagnostic(resolution.path, {
+        explicit_cache_used: true,
+        wait_latency_ms: resolution.waitLatencyMs,
+        provider_status: resolution.providerStatus,
+    });
 
     return {
-        contentHash,
-        cacheName: entry.name,
-        manager,
-        payload: {
-            ...payload,
-            contents: requestContents,
-            config: {
-                ...payload.config,
-                systemInstruction: undefined,
-                tools: undefined,
-                toolConfig: undefined,
-                cachedContent: entry.name,
+        diagnostic: cacheDiagnostic,
+        plan: {
+            managerKey,
+            cacheName: resolution.entry.name,
+            manager,
+            coordinationKey,
+            diagnostic: cacheDiagnostic,
+            payload: {
+                ...payload,
+                contents: requestContents,
+                config: {
+                    ...payload.config,
+                    systemInstruction: undefined,
+                    tools: undefined,
+                    toolConfig: undefined,
+                    cachedContent: resolution.entry.name,
+                },
             },
         },
     };
@@ -447,12 +604,14 @@ interface AdoptOrCreateCacheParams {
     client: GoogleGenAI;
     manager: GeminiContextCacheManager;
     contentHash: string;
+    managerKey: string;
     model: string;
     prefix: GeminiCachePrefix;
     tools: Tool[] | undefined;
     toolConfig: ToolConfig | undefined;
     ttlSeconds: number;
     excludeCacheNames?: ReadonlySet<string>;
+    coordinationKey?: GeminiContextCacheCoordinationKey;
 }
 
 /**
@@ -467,24 +626,44 @@ async function adoptOrCreateCache({
     client,
     manager,
     contentHash,
+    managerKey,
     model,
     prefix,
     tools,
     toolConfig,
     ttlSeconds,
     excludeCacheNames,
-}: AdoptOrCreateCacheParams): Promise<GeminiContextCacheEntry | undefined> {
+    coordinationKey,
+}: AdoptOrCreateCacheParams): Promise<GeminiContextCacheResolution> {
     const displayName = geminiCacheDisplayName(model, contentHash);
 
-    // 1. Memoized and near expiry — extend rather than lose the prefix mid-flight.
-    const existing = manager.get(contentHash);
-    if (existing && !excludeCacheNames?.has(existing.name)) {
+    if (manager.coordinator && coordinationKey) {
+        return coordinateAdoptOrCreateCache({
+            driver,
+            client,
+            manager,
+            managerKey,
+            model,
+            prefix,
+            tools,
+            toolConfig,
+            ttlSeconds,
+            excludeCacheNames,
+            coordinationKey,
+            displayName,
+        });
+    }
+
+    // Standalone provider-library path: local singleflight plus Vertex recovery. Studio always
+    // injects a coordinator, so this path never turns a Redis outage into a fleet-wide create storm.
+    const existing = manager.get(managerKey);
+    if (existing && existing.expiresAtMs > Date.now() && !excludeCacheNames?.has(existing.name)) {
         const refreshed = await extendCacheTtl(driver, client, existing, model, ttlSeconds);
         if (refreshed) {
-            manager.set(contentHash, refreshed);
-            return refreshed;
+            manager.set(managerKey, refreshed);
+            return { entry: refreshed, path: 'refreshed' };
         }
-        manager.invalidate(contentHash);
+        manager.invalidate(managerKey);
     }
 
     // 2. Vertex is the shared registry: adopt whatever a peer instance already built.
@@ -494,11 +673,195 @@ async function adoptOrCreateCache({
             adopted.expiresAtMs - Date.now() < CACHE_REFRESH_MARGIN_MS
                 ? ((await extendCacheTtl(driver, client, adopted, model, ttlSeconds)) ?? adopted)
                 : adopted;
-        manager.set(contentHash, entry);
-        return entry;
+        manager.set(managerKey, entry);
+        return { entry, path: 'provider_list_recovery' };
     }
 
-    // 3. Nobody has one. Build it.
+    const cooldownUntil = manager.getLocalCooldownUntil();
+    if (cooldownUntil) return { path: 'fallback_quota', waitLatencyMs: Math.max(0, cooldownUntil - Date.now()) };
+    if (!(await manager.acquireLocalCreatePermit(CREATE_PERMIT_WAIT_MS))) {
+        return { path: 'fallback_wait_timeout', waitLatencyMs: CREATE_PERMIT_WAIT_MS };
+    }
+    try {
+        return await createCache({
+            driver,
+            client,
+            manager,
+            managerKey,
+            model,
+            prefix,
+            tools,
+            toolConfig,
+            ttlSeconds,
+            displayName,
+        });
+    } finally {
+        manager.releaseLocalCreatePermit();
+    }
+}
+
+interface CoordinatedAdoptOrCreateCacheParams extends Omit<AdoptOrCreateCacheParams, 'contentHash'> {
+    coordinationKey: GeminiContextCacheCoordinationKey;
+    displayName: string;
+}
+
+async function coordinateAdoptOrCreateCache({
+    driver,
+    client,
+    manager,
+    managerKey,
+    model,
+    prefix,
+    tools,
+    toolConfig,
+    ttlSeconds,
+    excludeCacheNames,
+    coordinationKey,
+    displayName,
+}: CoordinatedAdoptOrCreateCacheParams): Promise<GeminiContextCacheResolution> {
+    const coordinator = manager.coordinator;
+    if (!coordinator) return { path: 'fallback_coordination_unavailable' };
+
+    const localEntry = manager.get(managerKey);
+    try {
+        const sharedEntry = await coordinator.getEntry(coordinationKey);
+        if (
+            sharedEntry &&
+            sharedEntry.expiresAtMs > Date.now() &&
+            !excludeCacheNames?.has(sharedEntry.name) &&
+            sharedEntry.expiresAtMs - Date.now() > CACHE_REFRESH_MARGIN_MS
+        ) {
+            manager.set(managerKey, sharedEntry);
+            return { entry: sharedEntry, path: 'distributed_registry_hit' };
+        }
+
+        const leaseToken = await coordinator.acquireLease(coordinationKey, CACHE_LEASE_MS);
+        if (!leaseToken) {
+            const waitStartedAt = Date.now();
+            const waitedEntry = await coordinator.waitForEntry(coordinationKey, CACHE_WAIT_MS);
+            const waitLatencyMs = Date.now() - waitStartedAt;
+            if (waitedEntry && waitedEntry.expiresAtMs > Date.now() && !excludeCacheNames?.has(waitedEntry.name)) {
+                manager.set(managerKey, waitedEntry);
+                return { entry: waitedEntry, path: 'waited_for_creator', waitLatencyMs };
+            }
+            const cooldownUntil = await coordinator.getCooldownUntil(coordinationKey);
+            return cooldownUntil && cooldownUntil > Date.now()
+                ? { path: 'fallback_quota', waitLatencyMs }
+                : { path: 'fallback_wait_timeout', waitLatencyMs };
+        }
+
+        try {
+            // Re-read after acquiring the lease: a previous leader may have published between our
+            // initial read and acquisition.
+            const current = await coordinator.getEntry(coordinationKey);
+            if (current && current.expiresAtMs > Date.now() && !excludeCacheNames?.has(current.name)) {
+                if (current.expiresAtMs - Date.now() > CACHE_REFRESH_MARGIN_MS) {
+                    manager.set(managerKey, current);
+                    return { entry: current, path: 'distributed_registry_hit' };
+                }
+                const refreshed = await extendCacheTtl(driver, client, current, model, ttlSeconds);
+                if (refreshed) {
+                    await coordinator.publishEntry(
+                        coordinationKey,
+                        leaseToken,
+                        refreshed,
+                        Math.max(1_000, refreshed.expiresAtMs - Date.now()),
+                    );
+                    manager.set(managerKey, refreshed);
+                    return { entry: refreshed, path: 'refreshed' };
+                }
+                await coordinator.invalidateEntry(coordinationKey, current.name);
+            }
+
+            const adopted = await findCacheByDisplayName(driver, client, displayName, model, excludeCacheNames);
+            if (adopted) {
+                const entry =
+                    adopted.expiresAtMs - Date.now() < CACHE_REFRESH_MARGIN_MS
+                        ? ((await extendCacheTtl(driver, client, adopted, model, ttlSeconds)) ?? adopted)
+                        : adopted;
+                await coordinator.publishEntry(
+                    coordinationKey,
+                    leaseToken,
+                    entry,
+                    Math.max(1_000, entry.expiresAtMs - Date.now()),
+                );
+                manager.set(managerKey, entry);
+                return { entry, path: 'provider_list_recovery' };
+            }
+
+            const cooldownUntil = await coordinator.getCooldownUntil(coordinationKey);
+            if (cooldownUntil && cooldownUntil > Date.now()) {
+                return { path: 'fallback_quota', waitLatencyMs: Math.max(0, cooldownUntil - Date.now()) };
+            }
+
+            const permitToken = await coordinator.acquireCreatePermit(
+                coordinationKey,
+                MAX_CONCURRENT_CREATES_PER_LOCATION,
+                CREATE_PERMIT_LEASE_MS,
+                CREATE_PERMIT_WAIT_MS,
+            );
+            if (!permitToken) return { path: 'fallback_wait_timeout', waitLatencyMs: CREATE_PERMIT_WAIT_MS };
+            try {
+                const resolution = await createCache({
+                    driver,
+                    client,
+                    manager,
+                    managerKey,
+                    model,
+                    prefix,
+                    tools,
+                    toolConfig,
+                    ttlSeconds,
+                    displayName,
+                    coordinator,
+                    coordinationKey,
+                });
+                if (resolution.entry) {
+                    await coordinator.publishEntry(
+                        coordinationKey,
+                        leaseToken,
+                        resolution.entry,
+                        Math.max(1_000, resolution.entry.expiresAtMs - Date.now()),
+                    );
+                }
+                return resolution;
+            } finally {
+                await coordinator.releaseCreatePermit(coordinationKey, permitToken);
+            }
+        } finally {
+            await coordinator.releaseLease(coordinationKey, leaseToken);
+        }
+    } catch {
+        // A still-live memo is safe to use while the registry is unavailable. On a cold instance we
+        // deliberately do not create: uncached inference is preferable to a fleet-wide create storm.
+        if (localEntry && localEntry.expiresAtMs > Date.now() && !excludeCacheNames?.has(localEntry.name)) {
+            return { entry: localEntry, path: 'local_memo_hit' };
+        }
+        return { path: 'fallback_coordination_unavailable' };
+    }
+}
+
+interface CreateCacheParams
+    extends Omit<AdoptOrCreateCacheParams, 'contentHash' | 'excludeCacheNames' | 'coordinationKey'> {
+    displayName: string;
+    coordinator?: GeminiContextCacheCoordinator;
+    coordinationKey?: GeminiContextCacheCoordinationKey;
+}
+
+async function createCache({
+    driver,
+    client,
+    manager,
+    managerKey,
+    model,
+    prefix,
+    tools,
+    toolConfig,
+    ttlSeconds,
+    displayName,
+    coordinator,
+    coordinationKey,
+}: CreateCacheParams): Promise<GeminiContextCacheResolution> {
     try {
         const created = await client.caches.create({
             model,
@@ -514,24 +877,59 @@ async function adoptOrCreateCache({
         const entry = toCacheEntry(created, ttlSeconds);
         if (!entry) {
             driver.logger.warn({ model }, '[VertexAI] Gemini context cache: create returned no resource name');
-            return undefined;
+            return { path: 'fallback_provider_error' };
         }
-        manager.set(contentHash, entry);
-        return entry;
+        manager.set(managerKey, entry);
+        return { entry, path: 'created' };
     } catch (error) {
+        const status = errorStatus(error);
         if (isMinimumTokenCountError(error)) {
-            // Below the model's minimum cacheable size. This will never succeed for this prefix.
-            manager.markUncacheable(contentHash);
-            driver.logger.warn(
-                { error, model },
-                '[VertexAI] Gemini context cache: prefix below the model minimum token count, caching disabled ' +
-                    'for this prefix',
-            );
-            return undefined;
+            manager.markUncacheable(managerKey);
+            return { path: 'minimum_token_rejection', providerStatus: status };
         }
-        driver.logger.warn({ error, model }, '[VertexAI] Gemini context cache: create failed, sending un-cached');
-        return undefined;
+
+        // This is not a provider retry loop. In auto mode the cache-create 429 is swallowed so the
+        // completion can proceed uncached and Temporal cannot observe it. Retain only Vertex's
+        // Retry-After as a shared create-suppression window for the remaining fleet traffic.
+        if (status === 429) {
+            const untilMs = Date.now() + (retryAfterMilliseconds(error) ?? DEFAULT_QUOTA_COOLDOWN_MS);
+            if (coordinator && coordinationKey) await coordinator.setCooldownUntil(coordinationKey, untilMs);
+            else manager.setLocalCooldownUntil(untilMs);
+            return { path: 'fallback_quota', providerStatus: status };
+        }
+
+        return { path: 'fallback_provider_error', providerStatus: status };
     }
+}
+
+function delay(milliseconds: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function retryAfterMilliseconds(error: unknown): number | undefined {
+    if (!error || typeof error !== 'object') return undefined;
+    const candidates = [
+        (error as { headers?: unknown }).headers,
+        (error as { response?: { headers?: unknown } }).response?.headers,
+    ];
+    for (const headers of candidates) {
+        let value: unknown;
+        if (headers && typeof headers === 'object' && 'get' in headers && typeof headers.get === 'function') {
+            value = headers.get('retry-after');
+        } else if (headers && typeof headers === 'object') {
+            value =
+                (headers as Record<string, unknown>)['retry-after'] ??
+                (headers as Record<string, unknown>)['Retry-After'];
+        }
+        if (typeof value !== 'string' && typeof value !== 'number') continue;
+        const seconds = Number(value);
+        if (Number.isFinite(seconds) && seconds >= 0) return Math.ceil(seconds * 1000);
+        if (typeof value === 'string') {
+            const dateMs = Date.parse(value);
+            if (!Number.isNaN(dateMs)) return Math.max(0, dateMs - Date.now());
+        }
+    }
+    return undefined;
 }
 
 /** Push a resource's expiry out. Returns `undefined` when Vertex would not extend it. */
@@ -604,46 +1002,105 @@ export async function generateWithGeminiContextCache<T>(
     prompt: GenerateContentPrompt,
     payload: GenerateContentParameters,
     send: (payload: GenerateContentParameters) => Promise<T>,
-): Promise<T> {
+    location: string,
+): Promise<GeminiContextCacheExecution<T>> {
     // `planGeminiContextCache` already swallows provider failures, but nothing on this path is
     // allowed to cost the caller a completion — so an unexpected throw degrades too.
-    const plan = await planGeminiContextCache(driver, client, options, prompt, payload).catch((error: unknown) => {
+    const planned: GeminiContextCachePlanResult = await planGeminiContextCache(
+        driver,
+        client,
+        options,
+        prompt,
+        payload,
+        location,
+    ).catch((error: unknown): GeminiContextCachePlanResult => {
         driver.logger.warn(
             { error, model: payload.model },
             '[VertexAI] Gemini context cache: preparation failed, sending un-cached',
         );
-        return undefined;
+        return {
+            diagnostic: {
+                path: 'fallback_provider_error' as const,
+                explicit_cache_used: false,
+                model: payload.model,
+                preparation_latency_ms: 0,
+                provider_status: errorStatus(error),
+            },
+        };
     });
-    if (!plan) return send(payload);
+    logCacheDiagnostic(driver, planned.diagnostic);
+    const plan = planned.plan;
+    if (!plan) {
+        if (options.prompt_cache_mode === 'required') throw new GeminiContextCacheRequiredError(planned.diagnostic);
+        return { value: await send(payload), diagnostic: planned.diagnostic };
+    }
 
     try {
-        return await send(plan.payload);
+        return { value: await send(plan.payload), diagnostic: plan.diagnostic };
     } catch (error) {
         if (!isCacheUnusableError(error)) throw error;
         // The resource is gone (expired, deleted, or created by an instance that no longer owns it).
         // Forget it, then re-plan: discovery may find a peer's live cache before falling through to
         // a create. The dead name is excluded so a stale listing cannot hand it back.
-        plan.manager.invalidate(plan.contentHash);
+        plan.manager.invalidate(plan.managerKey);
+        if (plan.coordinationKey && plan.manager.coordinator) {
+            await plan.manager.coordinator.invalidateEntry(plan.coordinationKey, plan.cacheName).catch(() => undefined);
+        }
         driver.logger.warn(
             { error, model: payload.model },
             '[VertexAI] Gemini context cache: cached content unusable, rediscovering',
         );
         const exclude = new Set([plan.cacheName]);
-        const retry = await planGeminiContextCache(driver, client, options, prompt, payload, exclude).catch(
-            () => undefined,
-        );
+        const retryResult = await planGeminiContextCache(
+            driver,
+            client,
+            options,
+            prompt,
+            payload,
+            location,
+            exclude,
+        ).catch(() => undefined);
+        const retry = retryResult?.plan;
         if (retry) {
             try {
-                return await send(retry.payload);
+                const diagnostic = { ...retry.diagnostic, path: 'unusable_resource_recreated' as const };
+                logCacheDiagnostic(driver, diagnostic);
+                return { value: await send(retry.payload), diagnostic };
             } catch (retryError) {
                 if (!isCacheUnusableError(retryError)) throw retryError;
-                retry.manager.invalidate(retry.contentHash);
+                retry.manager.invalidate(retry.managerKey);
+                if (retry.coordinationKey && retry.manager.coordinator) {
+                    await retry.manager.coordinator
+                        .invalidateEntry(retry.coordinationKey, retry.cacheName)
+                        .catch(() => undefined);
+                }
                 driver.logger.warn(
                     { error: retryError, model: payload.model },
                     '[VertexAI] Gemini context cache: replacement cache also unusable, sending un-cached',
                 );
             }
         }
-        return send(payload);
+        const diagnostic: PromptCacheDiagnostic = {
+            ...(retryResult?.diagnostic ?? plan.diagnostic),
+            path: 'fallback_provider_error',
+            explicit_cache_used: false,
+            provider_status: errorStatus(error),
+        };
+        logCacheDiagnostic(driver, diagnostic);
+        if (options.prompt_cache_mode === 'required') throw new GeminiContextCacheRequiredError(diagnostic);
+        return { value: await send(payload), diagnostic };
+    }
+}
+
+function logCacheDiagnostic(driver: VertexAIDriver, diagnostic: PromptCacheDiagnostic): void {
+    const fields = { prompt_cache: diagnostic };
+    if (
+        diagnostic.provider_status !== undefined ||
+        diagnostic.path === 'fallback_coordination_unavailable' ||
+        diagnostic.path === 'fallback_wait_timeout'
+    ) {
+        driver.logger.warn(fields, '[VertexAI] Gemini explicit context cache degraded');
+    } else {
+        driver.logger.debug?.(fields, '[VertexAI] Gemini explicit context cache path');
     }
 }

--- a/drivers/src/vertexai/models/gemini-orphaned-tool-result.test.ts
+++ b/drivers/src/vertexai/models/gemini-orphaned-tool-result.test.ts
@@ -101,7 +101,7 @@ describe('fixOrphanedToolResults - Gemini', () => {
 });
 
 describe('getGeminiPayload - orphaned tool results', () => {
-    test('retains split parallel functionResponses by merging consecutive user contents before cleanup', () => {
+    test('retains split parallel functionResponses without merging consecutive user contents', () => {
         const contents: Content[] = [
             {
                 role: 'model',
@@ -114,5 +114,6 @@ describe('getGeminiPayload - orphaned tool results', () => {
         const payload = getGeminiPayload(OPTIONS_WITH_TOOLS, { contents });
 
         expect(functionResponseNames(payload.contents as Content[])).toEqual(['a', 'b']);
+        expect(payload.contents).toHaveLength(3);
     });
 });

--- a/drivers/src/vertexai/models/gemini.ts
+++ b/drivers/src/vertexai/models/gemini.ts
@@ -219,7 +219,7 @@ export function getGeminiPayload(options: ExecutionOptions, prompt: GenerateCont
     // When no tools are provided but conversation contains functionCall/functionResponse parts
     // (e.g. checkpoint summary calls), convert them to text to avoid API errors.
     // Use a local variable to avoid mutating the caller's conversation object.
-    let payloadContents = mergeConsecutiveRole(prompt.contents);
+    let payloadContents = prompt.contents ? [...prompt.contents] : [];
     if (!tools && payloadContents) {
         const hasToolParts = payloadContents.some((c) => c.parts?.some((p) => p.functionCall || p.functionResponse));
         if (hasToolParts) {
@@ -389,35 +389,6 @@ function collectToolUseParts(content: Content): ToolUse[] | undefined {
     return out.length > 0 ? out : undefined;
 }
 
-export function mergeConsecutiveRole(contents: Content[] | undefined): Content[] {
-    if (!contents || contents.length === 0) return [];
-
-    const needsMerging = contents.some(
-        (content, i) => i < contents.length - 1 && content.role === contents[i + 1].role,
-    );
-    // If no merging needed, return original array
-    if (!needsMerging) {
-        return contents;
-    }
-
-    const result: Content[] = [];
-    let currentContent = { ...contents[0], parts: [...(contents[0].parts || [])] };
-
-    for (let i = 1; i < contents.length; i++) {
-        if (currentContent.role === contents[i].role) {
-            // Same role - concatenate parts (without merging individual parts)
-            currentContent.parts = (currentContent.parts || []).concat(...(contents[i].parts || []));
-        } else {
-            // Different role - push current and start new
-            result.push(currentContent);
-            currentContent = { ...contents[i], parts: [...(contents[i].parts || [])] };
-        }
-    }
-
-    result.push(currentContent);
-    return result;
-}
-
 /**
  * Drop functionResponse parts whose name has no matching functionCall in the
  * immediately-preceding `model` content. Gemini pairs a functionResponse to its
@@ -426,30 +397,32 @@ export function mergeConsecutiveRole(contents: Content[] | undefined): Content[]
  * causes the API to reject the request. Mirrors the same guard added to the
  * Claude, Bedrock, and OpenAI drivers.
  *
- * Run after mergeConsecutiveRole so parallel responses that were split across
- * user contents are first recombined under the model turn that issued the calls,
- * and are therefore not mistaken for orphans.
+ * Consecutive user contents remain separate because they are also cache boundaries. The matching
+ * model call set therefore remains active across a run of user function-response contents, which
+ * preserves split parallel tool results without merging the caller's segments.
  */
 export function fixOrphanedToolResults(contents: Content[]): Content[] {
     if (contents.length === 0) return contents;
     const result: Content[] = [];
-    for (let i = 0; i < contents.length; i++) {
-        const content = contents[i];
+    let allowedNames = new Set<string>();
+    for (const content of contents) {
+        if (content.role === 'model') {
+            allowedNames = new Set(
+                (content.parts ?? []).flatMap((part) => (part.functionCall?.name ? [part.functionCall.name] : [])),
+            );
+            result.push(content);
+            continue;
+        }
         if (content.role !== 'user' || !content.parts) {
+            allowedNames = new Set();
             result.push(content);
             continue;
         }
         const hasFunctionResponse = content.parts.some((part) => part.functionResponse);
         if (!hasFunctionResponse) {
+            allowedNames = new Set();
             result.push(content);
             continue;
-        }
-        const prev = contents[i - 1];
-        const allowedNames = new Set<string>();
-        if (prev && prev.role === 'model' && prev.parts) {
-            for (const part of prev.parts) {
-                if (part.functionCall?.name) allowedNames.add(part.functionCall.name);
-            }
         }
         const filtered = content.parts.filter((part) =>
             part.functionResponse ? allowedNames.has(part.functionResponse.name ?? '') : true,
@@ -694,9 +667,8 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
             contents = contents.concat(safety);
         }
 
-        // Merge consecutive messages with the same role. Note: this may not be necessary, works without it, keeping to match previous behavior.
-        contents = mergeConsecutiveRole(contents);
-
+        // Preserve PromptSegment boundaries through the provider request. Besides retaining the
+        // explicit-cache breakpoint, this avoids changing the caller's conversation turn shape.
         return { contents, system };
     }
 
@@ -781,9 +753,16 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
         if (signal) payload.config = { ...payload.config, abortSignal: signal };
         // Routes through an explicit Vertex context cache when this execution carries a
         // prompt_cache_key; sends `payload` untouched otherwise, and on any cache failure.
-        const response = await generateWithGeminiContextCache(driver, client, options, prompt, payload, (request) =>
-            client.models.generateContent(request),
+        const cacheExecution = await generateWithGeminiContextCache(
+            driver,
+            client,
+            options,
+            prompt,
+            payload,
+            (request) => client.models.generateContent(request),
+            region ?? driver.getVertexRegion?.() ?? 'global',
         );
+        const response = cacheExecution.value;
 
         const token_usage: ExecutionTokenUsage = this.usageMetadataToTokenUsage(driver, response.usageMetadata);
 
@@ -841,6 +820,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
             original_response: options.include_original_response ? response : undefined,
             conversation: finalConversation,
             tool_use,
+            prompt_cache_diagnostic: cacheExecution.diagnostic,
         } satisfies Completion;
     }
 
@@ -885,9 +865,16 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
 
         const payload = getGeminiPayload(options, prompt);
         payload.config = { ...payload.config, abortSignal: signal };
-        const response = await generateWithGeminiContextCache(driver, client, options, prompt, payload, (request) =>
-            client.models.generateContentStream(request),
+        const cacheExecution = await generateWithGeminiContextCache(
+            driver,
+            client,
+            options,
+            prompt,
+            payload,
+            (request) => client.models.generateContentStream(request),
+            region ?? driver.getVertexRegion?.() ?? 'global',
         );
+        const response = cacheExecution.value;
 
         const nativeParts: Part[] = [];
         const stream = asyncMap(response, async (item) => {
@@ -945,6 +932,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
         });
 
         return Object.assign(stream, {
+            finalizePromptCacheDiagnostic: () => cacheExecution.diagnostic,
             finalizeConversation: () =>
                 finalizeGeminiConversation(
                     conversation,


### PR DESCRIPTION
## Summary
- preserve Gemini prompt segment boundaries and prevent cached-content resources from ending on a model turn
- expose a host-injected cache coordinator with fleet singleflight, bounded creates, and shared Retry-After suppression
- add required diagnostic mode, configurable TTL, safe cache-path diagnostics, and blocking/streaming parity
- leave provider retries to the host workflow; cache creation is attempted once

## Test Plan
- [x] `pnpm lint` (common, core, drivers)
- [x] `pnpm typecheck:test` (common, drivers)
- [x] `pnpm build`
- [x] `pnpm test src/vertexai/models/gemini-context-cache.test.ts src/vertexai/models/gemini-orphaned-tool-result.test.ts src/vertexai/models/gemini-conversation-mutation.test.ts` (63 tests)
- [x] `pnpm test src/schemas/completion.test.ts` (5 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Gemini request shape (no role merging) and multi-instance cache creation/coordination; misconfigured coordinators or the new `required` mode can change failure vs fallback behavior for cached executions.
> 
> **Overview**
> Adds **fleet-wide coordination** for Vertex Gemini `cachedContents`: hosts inject a `GeminiContextCacheCoordinator` (e.g. Redis in Studio) so many driver instances share one create per content hash via leases, wait-for-creator, shared 429 cooldowns, and bounded concurrent creates. When coordination is down, cold instances **fall back to uncached** inference instead of stampeding creates.
> 
> The public contract grows **`prompt_cache_mode: 'required'`** (fail on cache prep instead of silent fallback), a **60s minimum** on `prompt_cache_ttl_seconds`, and **`PromptCacheDiagnostic`** on completions (path, timings, hash prefix—no resource names or prompt data). Streaming picks up the same diagnostic via `finalizePromptCacheDiagnostic`.
> 
> **Gemini payload shaping** stops merging consecutive same-role `Content` blocks so `PromptSegment` boundaries stay cache breakpoints; prefix derivation also **drops trailing model turns** from `cachedContents.create`. Orphaned tool-result handling is updated so split parallel `functionResponse` blocks stay separate but still pair correctly.
> 
> Cache prep is **single-attempt** per call (transient create errors surface as diagnostics / uncached send); host workflows own retries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ba85237e3f73cad1bd5e7692a2ae2f054956b5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->