### PR TITLE
feat: support explicit Gemini media cache boundaries

### DIFF
--- a/common/src/schemas/completion.test.ts
+++ b/common/src/schemas/completion.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { CompletionResultSchema, PromptCacheDiagnosticSchema, StatelessExecutionOptionsSchema } from './completion.js';
+import {
+    CompletionResultSchema,
+    PromptCacheDiagnosticSchema,
+    PromptSegmentSchema,
+    StatelessExecutionOptionsSchema,
+} from './completion.js';
 
 describe('CompletionResultSchema', () => {
     it('accepts thoughts as a separate completion result type', () => {
@@ -45,7 +50,35 @@ describe('StatelessExecutionOptionsSchema', () => {
                 scope: 'environment:project:us-central1',
                 cacheable_part_count: 2,
                 preparation_latency_ms: 4,
+                provider_code: 'INVALID_ARGUMENT',
+                failure_reason: 'provider_rejected',
             }),
         ).not.toHaveProperty('resource_name');
+    });
+});
+
+describe('PromptSegmentSchema', () => {
+    it('accepts an explicit reusable-prefix boundary', () => {
+        expect(
+            PromptSegmentSchema.parse({
+                role: 'user',
+                content: 'stable photo',
+                cache_control: { type: 'ephemeral' },
+            }),
+        ).toMatchObject({ cache_control: { type: 'ephemeral' } });
+    });
+
+    it('rejects unknown cache-control modes and fields', () => {
+        expect(
+            PromptSegmentSchema.safeParse({ role: 'user', content: 'photo', cache_control: { type: 'forever' } })
+                .success,
+        ).toBe(false);
+        expect(
+            PromptSegmentSchema.safeParse({
+                role: 'user',
+                content: 'photo',
+                cache_control: { type: 'ephemeral', ttl: 3600 },
+            }).success,
+        ).toBe(false);
     });
 });

--- a/common/src/schemas/completion.ts
+++ b/common/src/schemas/completion.ts
@@ -57,6 +57,18 @@ export const PromptCachePathSchema = z
     ])
     .meta({ id: 'PromptCachePath' });
 
+export const PromptCacheFailureReasonSchema = z
+    .enum([
+        'no_cacheable_prefix',
+        'invalid_cache_boundary',
+        'unsupported_cache_part',
+        'cache_ends_with_model_turn',
+        'request_contents_mismatch',
+        'provider_missing_resource_name',
+        'provider_rejected',
+    ])
+    .meta({ id: 'PromptCacheFailureReason' });
+
 export const PromptCacheDiagnosticSchema = z
     .strictObject({
         path: PromptCachePathSchema,
@@ -68,6 +80,11 @@ export const PromptCacheDiagnosticSchema = z
         preparation_latency_ms: z.number().nonnegative(),
         wait_latency_ms: z.number().nonnegative().optional(),
         provider_status: z.number().int().optional(),
+        provider_code: z
+            .string()
+            .regex(/^[A-Z][A-Z0-9_]{0,63}$/)
+            .optional(),
+        failure_reason: PromptCacheFailureReasonSchema.optional(),
     })
     .meta({
         id: 'PromptCacheDiagnostic',
@@ -100,6 +117,14 @@ export const PromptSegmentSchema = z
             })
             .optional(),
         files: z.array(DataSourceSchema).optional(),
+        cache_control: z
+            .strictObject({ type: z.literal('ephemeral') })
+            .meta({
+                description:
+                    'Marks the end of a reusable prompt prefix. Providers that support explicit cache boundaries ' +
+                    'may cache this segment and every preceding segment, including supported media.',
+            })
+            .optional(),
     })
     .meta({ id: 'PromptSegment' });
 

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -2,6 +2,7 @@ import type { z } from 'zod';
 import type {
     ExecutionTokenUsageSchema,
     PromptCacheDiagnosticSchema,
+    PromptCacheFailureReasonSchema,
     PromptCacheModeSchema,
     PromptCachePathSchema,
     StatelessExecutionOptionsSchema,
@@ -609,6 +610,8 @@ export type PromptCacheMode = z.infer<typeof PromptCacheModeSchema>;
 
 export type PromptCachePath = z.infer<typeof PromptCachePathSchema>;
 
+export type PromptCacheFailureReason = z.infer<typeof PromptCacheFailureReasonSchema>;
+
 export type PromptCacheDiagnostic = z.infer<typeof PromptCacheDiagnosticSchema>;
 
 /** Namespace used by agent conversations that require stable Claude cache layout. */
@@ -832,6 +835,8 @@ export interface PromptSegment {
      */
     thought_signature?: string;
     files?: DataSource[];
+    /** Marks the end of a reusable prompt prefix, including supported media in this segment. */
+    cache_control?: { type: 'ephemeral' };
 }
 
 export type ExecutionTokenUsage = z.infer<typeof ExecutionTokenUsageSchema>;

--- a/drivers/src/vertexai/index.ts
+++ b/drivers/src/vertexai/index.ts
@@ -76,6 +76,8 @@ export interface VertexAIDriverOptions extends DriverOptions {
 export interface GenerateContentPrompt {
     contents: Content[];
     system?: Content;
+    /** Number of leading content blocks selected by an explicit PromptSegment cache boundary. */
+    cacheBoundaryContentCount?: number;
 }
 type ClaudeStreamingPrompt = { messages: unknown[]; system?: unknown[] };
 type ConversationWrapper = { messages?: unknown[]; system?: unknown[] };

--- a/drivers/src/vertexai/models/gemini-context-cache.test.ts
+++ b/drivers/src/vertexai/models/gemini-context-cache.test.ts
@@ -1,5 +1,6 @@
 import {
     type CachedContent,
+    type Content,
     type CreateCachedContentParameters,
     FinishReason,
     type GenerateContentParameters,
@@ -7,6 +8,7 @@ import {
     type GoogleGenAI,
     type ListCachedContentsParameters,
     type Pager,
+    type Part,
     type UpdateCachedContentParameters,
 } from '@google/genai';
 import { type DataSource, type ExecutionOptions, type Logger, PromptRole, type PromptSegment } from '@llumiverse/core';
@@ -46,6 +48,26 @@ function baliseRoutePrompt(): GenerateContentPrompt {
                 parts: [{ text: 'Photo 42: route it.' }, { inlineData: { data: 'aW1hZ2U=', mimeType: 'image/jpeg' } }],
             },
         ],
+    };
+}
+
+function balisePhotoPrompt(
+    imageData = 'c2FtZS1waG90bw==',
+    task = 'Route this photo.',
+    media: 'inline' | 'gcs' = 'inline',
+): GenerateContentPrompt {
+    const imagePart: Part =
+        media === 'gcs'
+            ? { fileData: { fileUri: `gs://balise-dev/${imageData}.jpg`, mimeType: 'image/jpeg' } }
+            : { inlineData: { data: imageData, mimeType: 'image/jpeg' } };
+    return {
+        system: { role: 'user', parts: [{ text: 'Route each photo to a domain.' }] },
+        contents: [
+            { role: 'user', parts: [{ text: CATALOG_TEXT }] },
+            { role: 'user', parts: [{ text: 'Stable photo.' }, imagePart] },
+            { role: 'user', parts: [{ text: task }] },
+        ],
+        cacheBoundaryContentCount: 2,
     };
 }
 
@@ -267,6 +289,28 @@ describe('deriveGeminiCachePrefix', () => {
     it('has nothing to cache for a single-turn prompt without a system instruction', () => {
         expect(deriveGeminiCachePrefix({ contents: [{ role: 'user', parts: [{ text: 'hello' }] }] })).toBeUndefined();
     });
+
+    it.each(['inline', 'gcs'] as const)('includes explicitly marked %s media in the prefix', (media) => {
+        const prompt = balisePhotoPrompt('photo-one', 'Extract fields.', media);
+        const prefix = deriveGeminiCachePrefix(prompt);
+
+        expect(prefix?.contents).toEqual(prompt.contents.slice(0, 2));
+        expect(prefix?.partCount).toBe(3);
+    });
+
+    it('rejects an explicit prefix that ends in a model turn', () => {
+        const prompt = balisePhotoPrompt();
+        prompt.contents[1] = { role: 'model', parts: [{ text: 'cached answer' }] };
+
+        expect(deriveGeminiCachePrefix(prompt)).toBeUndefined();
+    });
+
+    it('rejects tool traffic even behind an explicit boundary', () => {
+        const prompt = balisePhotoPrompt();
+        prompt.contents[1] = { role: 'user', parts: [{ functionCall: { name: 'lookup', args: {} } }] };
+
+        expect(deriveGeminiCachePrefix(prompt)).toBeUndefined();
+    });
 });
 
 describe('cache identity', () => {
@@ -352,6 +396,46 @@ describe('Gemini explicit context caching', () => {
         // Vertex rejects a request that repeats the cached system instruction.
         expect(requests[0].config?.systemInstruction).toBeUndefined();
         expect(warn).not.toHaveBeenCalled();
+    });
+
+    it.each(['inline', 'gcs'] as const)('caches explicitly marked %s image content', async (media) => {
+        const harness = makeDriver();
+        const prompt = balisePhotoPrompt('photo-one', 'Extract fields.', media);
+
+        const completion = await new GeminiModelDefinition(MODEL).requestTextCompletion(
+            harness.driver,
+            prompt,
+            cachedOptions(),
+        );
+
+        expect(harness.create.mock.calls[0][0].config?.contents).toEqual(prompt.contents.slice(0, 2));
+        expect(harness.requests[0].contents).toEqual([prompt.contents[2]]);
+        expect(completion.prompt_cache_diagnostic).toMatchObject({
+            path: 'created',
+            explicit_cache_used: true,
+            cacheable_part_count: 3,
+        });
+    });
+
+    it('keeps the explicit boundary aligned when conversation history is prepended', async () => {
+        const harness = makeDriver();
+        const prompt = balisePhotoPrompt();
+        const conversation: Content[] = [
+            { role: 'user', parts: [{ text: 'Earlier question.' }] },
+            { role: 'model', parts: [{ text: 'Earlier answer.' }] },
+        ];
+
+        await new GeminiModelDefinition(MODEL).requestTextCompletion(
+            harness.driver,
+            prompt,
+            cachedOptions({ conversation }),
+        );
+
+        expect(harness.create.mock.calls[0][0].config?.contents).toEqual([
+            ...conversation,
+            ...balisePhotoPrompt().contents.slice(0, 2),
+        ]);
+        expect(harness.requests[0].contents).toEqual([balisePhotoPrompt().contents[2]]);
     });
 
     it('reuses the memoized cache without listing or creating again', async () => {
@@ -621,7 +705,28 @@ describe('Gemini explicit context caching', () => {
         expect(completion.prompt_cache_diagnostic).toMatchObject({
             path: 'fallback_provider_error',
             provider_status: 503,
+            provider_code: 'UNAVAILABLE',
+            failure_reason: 'provider_rejected',
         });
+    });
+
+    it('classifies a provider model-turn rejection without exposing its message', async () => {
+        const { driver, create } = makeDriver();
+        create.mockRejectedValue(apiError(400, 'Requests ending with a model turn are not supported. gs://secret'));
+
+        const completion = await new GeminiModelDefinition(MODEL).requestTextCompletion(
+            driver,
+            balisePhotoPrompt(),
+            cachedOptions(),
+        );
+
+        expect(completion.prompt_cache_diagnostic).toMatchObject({
+            path: 'fallback_provider_error',
+            provider_status: 400,
+            provider_code: 'REQUEST_ENDS_WITH_MODEL_TURN',
+            failure_reason: 'provider_rejected',
+        });
+        expect(JSON.stringify(completion.prompt_cache_diagnostic)).not.toContain('gs://secret');
     });
 });
 
@@ -671,6 +776,70 @@ describe('Gemini distributed context cache coordination', () => {
 
         expect(route.create.mock.calls.length + extraction.create.mock.calls.length).toBe(1);
         expect(route.requests[0].config?.cachedContent).toBe(extraction.requests[0].config?.cachedContent);
+    });
+
+    it('shares one image cache across route and extraction for the same photo', async () => {
+        const coordinator = new FakeDistributedCoordinator();
+        const route = makeDriver(coordinatedOptions(coordinator));
+        const extraction = makeDriver(coordinatedOptions(coordinator));
+
+        await Promise.all([
+            new GeminiModelDefinition(MODEL).requestTextCompletion(
+                route.driver,
+                balisePhotoPrompt('same-photo', 'Route this photo.'),
+                cachedOptions(),
+            ),
+            new GeminiModelDefinition(MODEL).requestTextCompletion(
+                extraction.driver,
+                balisePhotoPrompt('same-photo', 'Extract fields.'),
+                cachedOptions(),
+            ),
+        ]);
+
+        expect(route.create.mock.calls.length + extraction.create.mock.calls.length).toBe(1);
+        expect(route.requests[0].config?.cachedContent).toBe(extraction.requests[0].config?.cachedContent);
+        expect(route.requests[0].contents).toEqual([{ role: 'user', parts: [{ text: 'Route this photo.' }] }]);
+        expect(extraction.requests[0].contents).toEqual([{ role: 'user', parts: [{ text: 'Extract fields.' }] }]);
+    });
+
+    it('creates distinct resources for different photos even when logical keys match', async () => {
+        const coordinator = new FakeDistributedCoordinator();
+        const first = makeDriver(coordinatedOptions(coordinator));
+        const second = makeDriver(coordinatedOptions(coordinator));
+
+        await Promise.all([
+            new GeminiModelDefinition(MODEL).requestTextCompletion(
+                first.driver,
+                balisePhotoPrompt('photo-one'),
+                cachedOptions(),
+            ),
+            new GeminiModelDefinition(MODEL).requestTextCompletion(
+                second.driver,
+                balisePhotoPrompt('photo-two'),
+                cachedOptions(),
+            ),
+        ]);
+
+        expect(first.create.mock.calls.length + second.create.mock.calls.length).toBe(2);
+        expect(coordinator.entries.size).toBe(2);
+    });
+
+    it('coordinates eight concurrent calls for one photo into one create', async () => {
+        const coordinator = new FakeDistributedCoordinator();
+        const harnesses = Array.from({ length: 8 }, () => makeDriver(coordinatedOptions(coordinator)));
+
+        const completions = await Promise.all(
+            harnesses.map(({ driver }, index) =>
+                new GeminiModelDefinition(MODEL).requestTextCompletion(
+                    driver,
+                    balisePhotoPrompt('same-photo', index % 2 === 0 ? 'Route this photo.' : 'Extract fields.'),
+                    cachedOptions(),
+                ),
+            ),
+        );
+
+        expect(harnesses.reduce((sum, harness) => sum + harness.create.mock.calls.length, 0)).toBe(1);
+        expect(completions.every((result) => result.prompt_cache_diagnostic?.explicit_cache_used)).toBe(true);
     });
 
     it('never shares a resource for different cache contents even when keys match', async () => {
@@ -809,6 +978,18 @@ describe('Gemini PromptSegment cache breakpoint', () => {
         { role: PromptRole.user, content: 'Route this photo.', files: [image()] },
     ];
 
+    const cacheablePhotoSegments = (): PromptSegment[] => [
+        { role: PromptRole.system, content: 'Route each photo to a domain.' },
+        { role: PromptRole.user, content: CATALOG_TEXT },
+        {
+            role: PromptRole.user,
+            content: 'Stable photo.',
+            files: [image()],
+            cache_control: { type: 'ephemeral' },
+        },
+        { role: PromptRole.user, content: 'Route this photo.' },
+    ];
+
     it('keeps stable user text in cachedContents and the image task in both provider paths', async () => {
         const blocking = makeDriver();
         const streaming = makeDriver();
@@ -837,6 +1018,27 @@ describe('Gemini PromptSegment cache breakpoint', () => {
                 },
             ]);
         }
+    });
+
+    it('translates the segment marker into a media-inclusive Gemini boundary', async () => {
+        const harness = makeDriver();
+        const model = new GeminiModelDefinition(MODEL);
+        const prompt = await model.createPrompt(harness.driver, cacheablePhotoSegments(), cachedOptions());
+
+        expect(prompt.cacheBoundaryContentCount).toBe(2);
+        await model.requestTextCompletion(harness.driver, prompt, cachedOptions());
+
+        expect(harness.create.mock.calls[0][0].config?.contents).toEqual([
+            { role: 'user', parts: [{ text: CATALOG_TEXT }] },
+            {
+                role: 'user',
+                parts: [
+                    { text: 'Stable photo.' },
+                    { fileData: { fileUri: 'gs://balise-dev/photo.jpg', mimeType: 'image/jpeg' } },
+                ],
+            },
+        ]);
+        expect(harness.requests[0].contents).toEqual([{ role: 'user', parts: [{ text: 'Route this photo.' }] }]);
     });
 
     it('keeps a trailing model segment out of cachedContents.create', async () => {
@@ -902,6 +1104,33 @@ describe('Gemini explicit context caching opt-out', () => {
             ),
         ).rejects.toBeInstanceOf(GeminiContextCacheRequiredError);
         expect(generateContent).not.toHaveBeenCalled();
+    });
+
+    it('reports an invalid explicit boundary in auto and required modes', async () => {
+        const automatic = makeDriver();
+        const required = makeDriver();
+        const prompt = balisePhotoPrompt();
+        prompt.cacheBoundaryContentCount = prompt.contents.length;
+
+        const completion = await new GeminiModelDefinition(MODEL).requestTextCompletion(
+            automatic.driver,
+            prompt,
+            cachedOptions(),
+        );
+
+        expect(automatic.create).not.toHaveBeenCalled();
+        expect(completion.prompt_cache_diagnostic).toMatchObject({
+            path: 'fallback_provider_error',
+            failure_reason: 'invalid_cache_boundary',
+        });
+        await expect(
+            new GeminiModelDefinition(MODEL).requestTextCompletion(
+                required.driver,
+                prompt,
+                cachedOptions({ prompt_cache_mode: 'required' }),
+            ),
+        ).rejects.toThrow('fallback_provider_error: invalid_cache_boundary');
+        expect(required.generateContent).not.toHaveBeenCalled();
     });
 
     it('exposes no registry when the driver kill switch is off', () => {

--- a/drivers/src/vertexai/models/gemini-context-cache.ts
+++ b/drivers/src/vertexai/models/gemini-context-cache.ts
@@ -8,7 +8,12 @@ import type {
     Tool,
     ToolConfig,
 } from '@google/genai';
-import type { ExecutionOptions, PromptCacheDiagnostic, PromptCachePath } from '@llumiverse/core';
+import type {
+    ExecutionOptions,
+    PromptCacheDiagnostic,
+    PromptCacheFailureReason,
+    PromptCachePath,
+} from '@llumiverse/core';
 import type { GenerateContentPrompt, VertexAIDriver } from '../index.js';
 
 /**
@@ -32,9 +37,15 @@ import type { GenerateContentPrompt, VertexAIDriver } from '../index.js';
  * per-call fragment creates a brand-new cache resource on every call. So the policy here is
  * deliberately more conservative than Claude's `content[-2]` breakpoint:
  *
+ * Without an explicit segment marker, the conservative legacy policy remains:
+ *
  *   prefix = systemInstruction + the leading `Content` blocks that hold nothing but static text,
- *            stopping before the first block containing a non-text part (image, file, tool call,
- *            signed thought) or before the final block, whichever comes first.
+ *            stopping before the first block containing a non-text part or the final block.
+ *
+ * A caller can instead put `cache_control: {type: 'ephemeral'}` on a `PromptSegment`. The Gemini
+ * renderer preserves that boundary and permits text, `fileData`, and `inlineData` through it. Tool
+ * traffic, thoughts, and unknown future part kinds remain ineligible. This is what lets two calls
+ * share `[system, catalog, photo]` while keeping their route/extract instruction as a dynamic suffix.
  *
  * The final block is never cached: it is the turn that changes from call to call. Prompt content
  * blocks are never merged, so the boundary the caller expressed by sending separate segments
@@ -171,6 +182,8 @@ interface GeminiContextCacheResolution {
     path: PromptCachePath;
     waitLatencyMs?: number;
     providerStatus?: number;
+    providerCode?: string;
+    failureReason?: PromptCacheFailureReason;
 }
 
 /**
@@ -306,12 +319,45 @@ function isStaticTextPart(part: Part): boolean {
     return true;
 }
 
-/**
- * Derive the cacheable prefix of a Gemini prompt. See the module comment for the policy.
- * Returns `undefined` when there is nothing worth caching.
- */
-export function deriveGeminiCachePrefix(prompt: GenerateContentPrompt): GeminiCachePrefix | undefined {
+function isExplicitlyCacheablePart(part: Part): boolean {
+    if (isStaticTextPart(part)) return true;
+    let mediaKey: 'fileData' | 'inlineData';
+    if (part.fileData && typeof part.fileData.fileUri === 'string' && part.fileData.fileUri.length > 0) {
+        mediaKey = 'fileData';
+    } else if (part.inlineData && typeof part.inlineData.data === 'string' && part.inlineData.data.length > 0) {
+        mediaKey = 'inlineData';
+    } else return false;
+    for (const [key, value] of Object.entries(part)) {
+        if (key === mediaKey) continue;
+        if (value !== undefined && value !== null && value !== false) return false;
+    }
+    return true;
+}
+
+interface GeminiCachePrefixAnalysis {
+    prefix?: GeminiCachePrefix;
+    failureReason?: PromptCacheFailureReason;
+}
+
+function analyzeGeminiCachePrefix(prompt: GenerateContentPrompt): GeminiCachePrefixAnalysis {
     const contents = prompt.contents ?? [];
+    const boundary = prompt.cacheBoundaryContentCount;
+    if (boundary !== undefined) {
+        if (!Number.isInteger(boundary) || boundary <= 0 || boundary >= contents.length) {
+            return { failureReason: 'invalid_cache_boundary' };
+        }
+        const prefix = contents.slice(0, boundary);
+        if (prefix.at(-1)?.role === 'model') {
+            return { failureReason: 'cache_ends_with_model_turn' };
+        }
+        const parts = prefix.flatMap((content) => content.parts ?? []);
+        if (parts.length === 0) return { failureReason: 'no_cacheable_prefix' };
+        if (!parts.every(isExplicitlyCacheablePart)) {
+            return { failureReason: 'unsupported_cache_part' };
+        }
+        return { prefix: { system: prompt.system, contents: prefix, partCount: parts.length } };
+    }
+
     const prefix: Content[] = [];
     let partCount = 0;
     // `contents.length - 1`: the last block is this call's dynamic turn and is never cached.
@@ -326,8 +372,16 @@ export function deriveGeminiCachePrefix(prompt: GenerateContentPrompt): GeminiCa
     while (prefix.at(-1)?.role === 'model') {
         partCount -= prefix.pop()?.parts?.length ?? 0;
     }
-    if (!prompt.system && prefix.length === 0) return undefined;
-    return { system: prompt.system, contents: prefix, partCount };
+    if (partCount === 0) return { failureReason: 'no_cacheable_prefix' };
+    return { prefix: { system: prompt.system, contents: prefix, partCount } };
+}
+
+/**
+ * Derive the cacheable prefix of a Gemini prompt. See the module comment for the policy.
+ * Returns `undefined` when there is nothing worth caching.
+ */
+export function deriveGeminiCachePrefix(prompt: GenerateContentPrompt): GeminiCachePrefix | undefined {
+    return analyzeGeminiCachePrefix(prompt).prefix;
 }
 
 /**
@@ -373,6 +427,35 @@ function errorMessage(error: unknown): string {
         if (typeof message === 'string') return message;
     }
     return String(error);
+}
+
+function providerErrorCode(error: unknown): string | undefined {
+    const errorRecord = error && typeof error === 'object' ? (error as Record<string, unknown>) : undefined;
+    const nestedError =
+        errorRecord?.error && typeof errorRecord.error === 'object'
+            ? (errorRecord.error as Record<string, unknown>)
+            : undefined;
+    for (const value of [errorRecord?.code, errorRecord?.status, nestedError?.code, nestedError?.status]) {
+        if (typeof value === 'string' && /^[A-Z][A-Z0-9_]{0,63}$/.test(value)) return value;
+    }
+
+    const message = errorMessage(error);
+    if (/requests? ending with (?:a )?model turn (?:are|is) not supported/i.test(message)) {
+        return 'REQUEST_ENDS_WITH_MODEL_TURN';
+    }
+    for (const code of [
+        'INVALID_ARGUMENT',
+        'FAILED_PRECONDITION',
+        'RESOURCE_EXHAUSTED',
+        'PERMISSION_DENIED',
+        'UNAUTHENTICATED',
+        'DEADLINE_EXCEEDED',
+        'UNAVAILABLE',
+        'NOT_FOUND',
+    ]) {
+        if (message.includes(code)) return code;
+    }
+    return undefined;
 }
 
 /**
@@ -424,7 +507,10 @@ export interface GeminiContextCacheExecution<T> {
 
 export class GeminiContextCacheRequiredError extends Error {
     constructor(readonly diagnostic: PromptCacheDiagnostic) {
-        super(`Gemini explicit context cache was required but unavailable (${diagnostic.path})`);
+        const detail = diagnostic.provider_code ?? diagnostic.failure_reason;
+        super(
+            `Gemini explicit context cache was required but unavailable (${diagnostic.path}${detail ? `: ${detail}` : ''})`,
+        );
         this.name = 'GeminiContextCacheRequiredError';
     }
 }
@@ -510,8 +596,16 @@ async function planGeminiContextCache(
     if (!manager) return { diagnostic: baseDiagnostic('disabled') };
     if (!Array.isArray(payload.contents)) return { diagnostic: baseDiagnostic('fallback_provider_error') };
 
-    const prefix = deriveGeminiCachePrefix(prompt);
-    if (!prefix) return { diagnostic: baseDiagnostic('fallback_provider_error') };
+    const prefixAnalysis = analyzeGeminiCachePrefix(prompt);
+    const prefix = prefixAnalysis.prefix;
+    if (!prefix) {
+        return {
+            diagnostic: {
+                ...baseDiagnostic('fallback_provider_error'),
+                failure_reason: prefixAnalysis.failureReason ?? 'no_cacheable_prefix',
+            },
+        };
+    }
 
     // Vertex rejects a generateContent request that sets systemInstruction, tools or toolConfig
     // alongside cachedContent — those belong to the cache. So they are part of its identity.
@@ -542,7 +636,11 @@ async function planGeminiContextCache(
             { model: payload.model },
             '[VertexAI] Gemini context cache: request contents do not match the derived prefix, sending un-cached',
         );
-        return { diagnostic: diagnostic('fallback_provider_error') };
+        return {
+            diagnostic: diagnostic('fallback_provider_error', {
+                failure_reason: 'request_contents_mismatch',
+            }),
+        };
     }
 
     const resolution = await manager.resolve(managerKey, () =>
@@ -566,6 +664,8 @@ async function planGeminiContextCache(
             diagnostic: diagnostic(resolution.path, {
                 wait_latency_ms: resolution.waitLatencyMs,
                 provider_status: resolution.providerStatus,
+                provider_code: resolution.providerCode,
+                failure_reason: resolution.failureReason,
             }),
         };
     }
@@ -877,7 +977,7 @@ async function createCache({
         const entry = toCacheEntry(created, ttlSeconds);
         if (!entry) {
             driver.logger.warn({ model }, '[VertexAI] Gemini context cache: create returned no resource name');
-            return { path: 'fallback_provider_error' };
+            return { path: 'fallback_provider_error', failureReason: 'provider_missing_resource_name' };
         }
         manager.set(managerKey, entry);
         return { entry, path: 'created' };
@@ -885,7 +985,11 @@ async function createCache({
         const status = errorStatus(error);
         if (isMinimumTokenCountError(error)) {
             manager.markUncacheable(managerKey);
-            return { path: 'minimum_token_rejection', providerStatus: status };
+            return {
+                path: 'minimum_token_rejection',
+                providerStatus: status,
+                providerCode: providerErrorCode(error),
+            };
         }
 
         // This is not a provider retry loop. In auto mode the cache-create 429 is swallowed so the
@@ -895,10 +999,15 @@ async function createCache({
             const untilMs = Date.now() + (retryAfterMilliseconds(error) ?? DEFAULT_QUOTA_COOLDOWN_MS);
             if (coordinator && coordinationKey) await coordinator.setCooldownUntil(coordinationKey, untilMs);
             else manager.setLocalCooldownUntil(untilMs);
-            return { path: 'fallback_quota', providerStatus: status };
+            return { path: 'fallback_quota', providerStatus: status, providerCode: providerErrorCode(error) };
         }
 
-        return { path: 'fallback_provider_error', providerStatus: status };
+        return {
+            path: 'fallback_provider_error',
+            providerStatus: status,
+            providerCode: providerErrorCode(error),
+            failureReason: 'provider_rejected',
+        };
     }
 }
 
@@ -1025,6 +1134,8 @@ export async function generateWithGeminiContextCache<T>(
                 model: payload.model,
                 preparation_latency_ms: 0,
                 provider_status: errorStatus(error),
+                provider_code: providerErrorCode(error),
+                failure_reason: 'provider_rejected',
             },
         };
     });
@@ -1085,6 +1196,8 @@ export async function generateWithGeminiContextCache<T>(
             path: 'fallback_provider_error',
             explicit_cache_used: false,
             provider_status: errorStatus(error),
+            provider_code: providerErrorCode(error),
+            failure_reason: 'provider_rejected',
         };
         logCacheDiagnostic(driver, diagnostic);
         if (options.prompt_cache_mode === 'required') throw new GeminiContextCacheRequiredError(diagnostic);

--- a/drivers/src/vertexai/models/gemini.ts
+++ b/drivers/src/vertexai/models/gemini.ts
@@ -575,10 +575,12 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
         const schema = options.result_schema;
         let contents: Content[] = [];
         let system: Content | undefined = { role: 'user', parts: [] }; // Single content block for system messages
+        let cacheBoundaryContentCount: number | undefined;
 
         const safety: Content[] = [];
 
         for (const msg of segments) {
+            const contentCountBefore = contents.length;
             // Role specific handling
             if (msg.role === PromptRole.system) {
                 // Text only for system messages
@@ -650,6 +652,11 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
                     }
                 }
             }
+
+            if (msg.cache_control && contents.length > contentCountBefore) {
+                // Multiple markers are legal; the last one defines the largest reusable prefix.
+                cacheBoundaryContentCount = contents.length;
+            }
         }
 
         // Adding JSON Schema to system message
@@ -684,7 +691,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
 
         // Preserve PromptSegment boundaries through the provider request. Besides retaining the
         // explicit-cache breakpoint, this avoids changing the caller's conversation turn shape.
-        return { contents, system };
+        return { contents, system, cacheBoundaryContentCount };
     }
 
     usageMetadataToTokenUsage(
@@ -748,7 +755,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
             prompt.system = existingSystem;
         }
 
-        const conversation = updateConversation(options.conversation, prompt.contents);
+        const conversation = updatePromptConversation(options.conversation, prompt);
         prompt.contents = conversation;
 
         // TODO: Remove hack, use global endpoint manually if needed.
@@ -864,7 +871,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
         }
 
         // Include conversation history in prompt contents (same as non-streaming)
-        const conversation = updateConversation(options.conversation, prompt.contents);
+        const conversation = updatePromptConversation(options.conversation, prompt);
         prompt.contents = conversation;
 
         if (options.model.includes('gemini-2.5-flash-image')) {
@@ -1217,6 +1224,15 @@ function updateConversation(conversation: unknown, prompt: Content[]): Content[]
     const unwrapped = unwrapConversationArray<Content>(conversation);
     const convArray = unwrapped ?? ((conversation as Content[]) || []);
     return convArray.concat(prompt);
+}
+
+function updatePromptConversation(conversation: unknown, prompt: GenerateContentPrompt): Content[] {
+    const promptContentCount = prompt.contents.length;
+    const updated = updateConversation(conversation, prompt.contents);
+    if (prompt.cacheBoundaryContentCount !== undefined) {
+        prompt.cacheBoundaryContentCount += updated.length - promptContentCount;
+    }
+    return updated;
 }
 
 const SYSTEM_KEY = '_llumiverse_system';


### PR DESCRIPTION
## Summary
- add a provider-neutral prompt segment cache boundary
- let Gemini explicit caches include marked inline and GCS media while preserving the conservative unmarked policy
- keep cache identity content-addressed and expose safe provider failure codes
- preserve explicit boundaries when prior conversation history is prepended

## Test Plan
- pnpm --filter @llumiverse/common test (240 passed)
- pnpm --filter @llumiverse/common typecheck:test
- pnpm --filter @llumiverse/common lint
- pnpm --filter @llumiverse/common build
- pnpm --filter @llumiverse/drivers exec vitest run src (547 passed, 17 skipped)
- pnpm --filter @llumiverse/drivers typecheck:test
- pnpm --filter @llumiverse/drivers lint
- pnpm --filter @llumiverse/drivers build

The unfiltered driver test command also schedules credentialed live suites; 23 Bedrock live tests could not run because no usable AWS SSO profile was available.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes explicit Vertex `cachedContents` prefix selection and request splitting; mis-set boundaries could cause cache misses or provider rejections, though auto mode still falls back uncached.
> 
> **Overview**
> Adds a provider-neutral **`cache_control: { type: 'ephemeral' }`** on **`PromptSegment`** so callers can mark the end of a reusable prefix (including supported media), not only static text.
> 
> **Gemini explicit context caching** now honors that boundary: marked prefixes can include **inline and GCS image parts**, while the legacy unmarked policy still stops at the first non-text part. **`cacheBoundaryContentCount`** on the Gemini prompt tracks the boundary through **`createPrompt`**, and **`updatePromptConversation`** shifts it when prior conversation history is prepended so cached vs dynamic suffixes stay aligned.
> 
> **Prompt cache diagnostics** gain optional **`failure_reason`** (typed enum) and **`provider_code`** (safe uppercase codes, no raw provider messages or secrets). Cache preparation and **`GeminiContextCacheRequiredError`** surface these details; invalid explicit boundaries fail in auto mode with **`invalid_cache_boundary`** and block **`required`** mode.
> 
> Distributed coordination tests cover sharing one image cache across route/extract for the same photo, distinct caches per photo, and concurrent creates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3956edb6ea823c2e0c2a4d495fdd9ef01796aec8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->