### PR TITLE
fix(vertexai): recombine split parallel tool results into one Gemini turn

### DIFF
--- a/drivers/src/vertexai/models/gemini-orphaned-tool-result.test.ts
+++ b/drivers/src/vertexai/models/gemini-orphaned-tool-result.test.ts
@@ -11,7 +11,7 @@
 import type { Content } from '@google/genai';
 import type { ExecutionOptions } from '@llumiverse/core';
 import { describe, expect, test } from 'vitest';
-import { fixOrphanedToolResults, getGeminiPayload } from './gemini.js';
+import { fixOrphanedToolResults, getGeminiPayload, mergeFunctionResponseContents } from './gemini.js';
 
 const OPTIONS_WITH_TOOLS = {
     model: 'gemini-2.5-flash',
@@ -101,7 +101,10 @@ describe('fixOrphanedToolResults - Gemini', () => {
 });
 
 describe('getGeminiPayload - orphaned tool results', () => {
-    test('retains split parallel functionResponses without merging consecutive user contents', () => {
+    test('recombines split parallel functionResponses into one user turn matching the call turn', () => {
+        // Gemini rejects a function-call turn whose responses are split across consecutive user
+        // contents: "Please ensure that the number of function response parts is equal to the
+        // number of function call parts of the function call turn." (400 INVALID_ARGUMENT)
         const contents: Content[] = [
             {
                 role: 'model',
@@ -114,6 +117,77 @@ describe('getGeminiPayload - orphaned tool results', () => {
         const payload = getGeminiPayload(OPTIONS_WITH_TOOLS, { contents });
 
         expect(functionResponseNames(payload.contents as Content[])).toEqual(['a', 'b']);
-        expect(payload.contents).toHaveLength(3);
+        expect(payload.contents).toHaveLength(2);
+        expect((payload.contents as Content[])[1].parts).toHaveLength(2);
+    });
+});
+
+describe('mergeFunctionResponseContents', () => {
+    test('merges a run of function-response-only user contents into one turn', () => {
+        const contents: Content[] = [
+            { role: 'user', parts: [{ text: 'checkpoint summary' }] },
+            {
+                role: 'model',
+                parts: [
+                    { functionCall: { name: 'think', args: {} }, thoughtSignature: 'sig-1' },
+                    { functionCall: { name: 'wait_for', args: {} } },
+                ],
+            },
+            {
+                role: 'user',
+                parts: [{ functionResponse: { name: 'think', response: { ok: true } }, thoughtSignature: 'sig-1' }],
+            },
+            { role: 'user', parts: [{ functionResponse: { name: 'wait_for', response: { ok: true } } }] },
+        ];
+
+        const result = mergeFunctionResponseContents(contents);
+
+        expect(result).toHaveLength(3);
+        expect(result[2].role).toBe('user');
+        expect(result[2].parts).toHaveLength(2);
+        // Part-level metadata such as thoughtSignature survives the merge.
+        expect(result[2].parts?.[0].thoughtSignature).toBe('sig-1');
+        // The input contents are not mutated.
+        expect(contents).toHaveLength(4);
+        expect(contents[2].parts).toHaveLength(1);
+    });
+
+    test('leaves consecutive user text segments separate (cache breakpoints)', () => {
+        const contents: Content[] = [
+            { role: 'user', parts: [{ text: 'catalog' }] },
+            { role: 'user', parts: [{ text: 'task' }] },
+        ];
+        expect(mergeFunctionResponseContents(contents)).toEqual(contents);
+    });
+
+    test('does not merge a mixed text + functionResponse content into a response run', () => {
+        const contents: Content[] = [
+            { role: 'user', parts: [{ functionResponse: { name: 'a', response: {} } }] },
+            { role: 'user', parts: [{ functionResponse: { name: 'b', response: {} } }, { text: 'and also' }] },
+        ];
+        expect(mergeFunctionResponseContents(contents)).toEqual(contents);
+    });
+
+    test('merges independent response runs separately', () => {
+        const contents: Content[] = [
+            {
+                role: 'model',
+                parts: [{ functionCall: { name: 'a', args: {} } }, { functionCall: { name: 'b', args: {} } }],
+            },
+            { role: 'user', parts: [{ functionResponse: { name: 'a', response: {} } }] },
+            { role: 'user', parts: [{ functionResponse: { name: 'b', response: {} } }] },
+            {
+                role: 'model',
+                parts: [{ functionCall: { name: 'c', args: {} } }, { functionCall: { name: 'd', args: {} } }],
+            },
+            { role: 'user', parts: [{ functionResponse: { name: 'c', response: {} } }] },
+            { role: 'user', parts: [{ functionResponse: { name: 'd', response: {} } }] },
+        ];
+
+        const result = mergeFunctionResponseContents(contents);
+
+        expect(result).toHaveLength(4);
+        expect(result[1].parts).toHaveLength(2);
+        expect(result[3].parts).toHaveLength(2);
     });
 });

--- a/drivers/src/vertexai/models/gemini.ts
+++ b/drivers/src/vertexai/models/gemini.ts
@@ -234,7 +234,7 @@ export function getGeminiPayload(options: ExecutionOptions, prompt: GenerateCont
     // When no tools are provided but conversation contains functionCall/functionResponse parts
     // (e.g. checkpoint summary calls), convert them to text to avoid API errors.
     // Use a local variable to avoid mutating the caller's conversation object.
-    let payloadContents = prompt.contents ? [...prompt.contents] : [];
+    let payloadContents = mergeFunctionResponseContents(prompt.contents ?? []);
     if (!tools && payloadContents) {
         const hasToolParts = payloadContents.some((c) => c.parts?.some((p) => p.functionCall || p.functionResponse));
         if (hasToolParts) {
@@ -404,6 +404,38 @@ function collectToolUseParts(content: Content): ToolUse[] | undefined {
     return out.length > 0 ? out : undefined;
 }
 
+/** True when `content` is a user turn holding nothing but functionResponse parts. */
+function isFunctionResponseOnlyContent(content: Content): boolean {
+    return content.role === 'user' && !!content.parts?.length && content.parts.every((part) => part.functionResponse);
+}
+
+/**
+ * Recombine runs of consecutive user contents that hold nothing but functionResponse parts into a
+ * single user turn. The prompt builder emits one content per tool-result segment, but Gemini
+ * requires every response to a model function-call turn to arrive in ONE user turn whose
+ * functionResponse count equals the call count — split parallel results are rejected with 400
+ * INVALID_ARGUMENT ("Please ensure that the number of function response parts is equal to the
+ * number of function call parts of the function call turn"). Only function-response contents are
+ * merged: text segments keep their boundaries, which are explicit-cache breakpoints
+ * (see gemini-context-cache.ts) — and a cached prefix only ever holds static text parts, so this
+ * merge can never move the prefix boundary.
+ */
+export function mergeFunctionResponseContents(contents: Content[]): Content[] {
+    const result: Content[] = [];
+    for (const content of contents) {
+        const previous = result.at(-1);
+        if (previous && isFunctionResponseOnlyContent(previous) && isFunctionResponseOnlyContent(content)) {
+            result[result.length - 1] = {
+                ...previous,
+                parts: [...(previous.parts ?? []), ...(content.parts ?? [])],
+            };
+        } else {
+            result.push(content);
+        }
+    }
+    return result;
+}
+
 /**
  * Drop functionResponse parts whose name has no matching functionCall in the
  * immediately-preceding `model` content. Gemini pairs a functionResponse to its
@@ -412,9 +444,9 @@ function collectToolUseParts(content: Content): ToolUse[] | undefined {
  * causes the API to reject the request. Mirrors the same guard added to the
  * Claude, Bedrock, and OpenAI drivers.
  *
- * Consecutive user contents remain separate because they are also cache boundaries. The matching
- * model call set therefore remains active across a run of user function-response contents, which
- * preserves split parallel tool results without merging the caller's segments.
+ * The matching model call set remains active across a run of user function-response contents, so
+ * split parallel tool results are not mistaken for orphans even when this runs on contents that
+ * have not been through mergeFunctionResponseContents.
  */
 export function fixOrphanedToolResults(contents: Content[]): Content[] {
     if (contents.length === 0) return contents;


### PR DESCRIPTION
## Summary

- Since #615 removed `mergeConsecutiveRole` to preserve explicit-cache breakpoints, the Gemini driver sends one `user` Content per tool-result segment. When a model turn makes two or more parallel function calls, the responses now reach Vertex as consecutive single-part `functionResponse` turns, and Gemini rejects the request with `400 INVALID_ARGUMENT`: *"Please ensure that the number of function response parts is equal to the number of function call parts of the function call turn."* Any conversation resuming parallel tool calls fails non-retryably. Verified by replaying both shapes against Vertex `generateContent`: split turns → 400 on both `gemini-2.5-flash` and `gemini-3.1-flash-lite`, merged turn → 200.
- Fix: `mergeFunctionResponseContents()` in `getGeminiPayload` recombines runs of consecutive user contents holding nothing but `functionResponse` parts into a single user turn, for both the blocking and streaming paths. Text segments keep their boundaries — they are the explicit-cache breakpoints — and a cached prefix only ever holds static text parts (`deriveGeminiCachePrefix` stops at the first non-text part), so the merge cannot move a prefix boundary or change `stripLeadingParts` accounting.
- `fixOrphanedToolResults` keeps its cross-content `allowedNames` tolerance so split responses are still not mistaken for orphans if it ever runs on unmerged contents.

## Test Plan

- [x] `cd drivers && pnpm lint` — clean
- [x] `cd drivers && pnpm typecheck:test` — clean
- [x] `cd drivers && pnpm exec vitest run --exclude '**/*.live.test.ts' src/vertexai` — 15 files, 233 passed / 8 skipped, including new `mergeFunctionResponseContents` unit tests and the updated `getGeminiPayload` test asserting the recombined turn
- [x] `pnpm build` (drivers) — clean
- [x] Live replay of a real failing post-checkpoint conversation against Vertex: the merged shape this fix produces returns 200 on `gemini-2.5-flash` and `gemini-3.1-flash-lite`; the split shape reproduces the 400 verbatim