### PR TITLE
feat: forward compatible provider options

### DIFF
--- a/common/src/model-directory.test.ts
+++ b/common/src/model-directory.test.ts
@@ -16,6 +16,9 @@ describe('central model directory', () => {
         expect(capabilities.tool_support).toBe(true);
         expect(options._option_id).toBe('openai-text');
         expect(options.options.map((option) => option.name)).not.toContain('service_tier');
+        expect(options.options.find((option) => option.name === 'extra_body')).toMatchObject({
+            type: 'json_object',
+        });
         expect(options.options.map((option) => option.name)).not.toContain('thinking_level');
         expect(options.options.find((option) => option.name === 'max_tokens')).toMatchObject({ max: 65_535 });
         expect(options.options.find((option) => option.name === 'effort')).toMatchObject({

--- a/common/src/options/current-model-options.test.ts
+++ b/common/src/options/current-model-options.test.ts
@@ -37,13 +37,16 @@ describe('current reasoning model options', () => {
     });
 
     it('does not advertise unverified effort for unknown OpenAI-compatible models', () => {
-        expect(
-            getOptions('custom-reasoning-model', Providers.openai_compatible).options.map((option) => option.name),
-        ).not.toContain(SharedOptions.effort);
+        const options = getOptions('custom-reasoning-model', Providers.openai_compatible).options;
+        expect(options.map((option) => option.name)).not.toContain(SharedOptions.effort);
+        expect(options.find((option) => option.name === 'extra_body')).toMatchObject({
+            type: OptionType.json_object,
+        });
     });
 
     it('advertises the native Mistral options that its transport serializes', () => {
         const options = getOptions('mistral-small-latest', Providers.mistralai);
+        const optionNames = options.options.map((option) => option.name);
         expect(options._option_id).toBe('mistral-text');
         expect(options.options.map((option) => option.name)).toEqual(
             expect.arrayContaining([
@@ -62,7 +65,8 @@ describe('current reasoning model options', () => {
                 'include_thoughts',
             ]),
         );
-        expect(options.options.map((option) => option.name)).not.toContain('image_detail');
+        expect(optionNames).not.toContain('image_detail');
+        expect(optionNames).not.toContain('extra_body');
         expect(effortValues('mistral-small-latest', Providers.mistralai)).toEqual(['none', 'high']);
     });
 

--- a/common/src/options/mistral.ts
+++ b/common/src/options/mistral.ts
@@ -21,7 +21,7 @@ export function getMistralOptions(
     const compatible = getOpenAiCompatibleOptions(model, options, profile);
     const supportsReasoning = profile.reasoning_effort_levels?.length;
     const compatibleOptions = compatible.options
-        .filter((item) => item.name !== 'image_detail')
+        .filter((item) => item.name !== 'image_detail' && item.name !== 'extra_body')
         .map((item): ModelOptionInfoItem => {
             if (item.name !== SharedOptions.max_tokens || profile.max_output_tokens !== undefined) return item;
             const { max: _unverifiedMax, ...withoutMax } = item as ModelOptionInfoItem & { max?: number };

--- a/common/src/options/openai.ts
+++ b/common/src/options/openai.ts
@@ -378,10 +378,10 @@ export function getOpenAiCompatibleOptions(
         })
         .filter((item): item is ModelOptionInfoItem => item !== null);
     if (profileOptions.some((item) => item.name === SharedOptions.effort) || options._option_id !== 'openai-text') {
-        return { ...options, options: profileOptions };
+        return withCompatibleExtraBody({ ...options, options: profileOptions });
     }
-    if (!profileEffortLevels) return { ...options, options: profileOptions };
-    return {
+    if (!profileEffortLevels) return withCompatibleExtraBody({ ...options, options: profileOptions });
+    return withCompatibleExtraBody({
         ...options,
         options: [
             ...profileOptions,
@@ -390,6 +390,21 @@ export function getOpenAiCompatibleOptions(
                 type: OptionType.enum,
                 enum: Object.fromEntries([...profileEffortLevels].map((value) => [value, value])),
                 description: 'How much effort the model should put into reasoning, when supported by the endpoint.',
+            },
+        ],
+    });
+}
+
+function withCompatibleExtraBody(options: ModelOptionsInfo): ModelOptionsInfo {
+    return {
+        ...options,
+        options: [
+            ...options.options,
+            {
+                name: 'extra_body',
+                type: OptionType.json_object,
+                description:
+                    'Additional provider-specific fields merged into the request body. Standard model options take precedence.',
             },
         ],
     };

--- a/common/src/schemas/model-options.test.ts
+++ b/common/src/schemas/model-options.test.ts
@@ -137,4 +137,23 @@ describe('ModelOptionsSchema', () => {
             ModelOptionsSchema.safeParse({ _option_id: 'bedrock-twelvelabs-pegasus', service_tier: 'flex' }).success,
         ).toBe(true);
     });
+
+    it('accepts provider-specific objects for OpenAI-compatible option schemas', () => {
+        expect(
+            ModelOptionsSchema.safeParse({
+                _option_id: 'openai-text',
+                extra_body: {
+                    provider: { sort: 'throughput', allow_fallbacks: false },
+                    baseten: { performance: 'max' },
+                },
+            }).success,
+        ).toBe(true);
+        expect(
+            ModelOptionsSchema.safeParse({
+                _option_id: 'openai-thinking',
+                extra_body: { provider_extension: { enabled: true } },
+            }).success,
+        ).toBe(true);
+        expect(ModelOptionsSchema.safeParse({ _option_id: 'openai-text', extra_body: [] }).success).toBe(false);
+    });
 });

--- a/common/src/schemas/model-options.ts
+++ b/common/src/schemas/model-options.ts
@@ -33,6 +33,10 @@ const ServiceTierSchema = z
     .min(1)
     .describe('Provider-defined processing tier. Unknown non-empty values are preserved for forward compatibility.');
 
+const ExtraBodySchema = z
+    .record(z.string(), z.unknown())
+    .describe('Additional provider-specific fields merged into the OpenAI-compatible request body.');
+
 // ===== fallback =====
 
 export const TextFallbackOptionsSchema = z
@@ -302,6 +306,7 @@ export const OpenAiThinkingOptionsSchema = z
         image_detail: z.enum(['low', 'high', 'auto']).optional(),
         include_thoughts: z.boolean().optional(),
         service_tier: ServiceTierSchema.optional(),
+        extra_body: ExtraBodySchema.optional(),
     })
     .meta({ id: 'OpenAiThinkingOptions' });
 
@@ -319,6 +324,7 @@ export const OpenAiTextOptionsSchema = z
         image_detail: z.enum(['low', 'high', 'auto']).optional(),
         include_thoughts: z.boolean().optional(),
         service_tier: ServiceTierSchema.optional(),
+        extra_body: ExtraBodySchema.optional(),
     })
     .meta({ id: 'OpenAiTextOptions' });
 

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -734,6 +734,7 @@ export enum OptionType {
     enum = 'enum',
     boolean = 'boolean',
     string_list = 'string_list',
+    json_object = 'json_object',
 }
 
 // Derived from the schema, like the option types that use it. Restating the seven values here made
@@ -761,7 +762,12 @@ export interface ModelOptionsInfo {
     _option_id: string; //Should follow same ids as ModelOptions
 }
 
-export type ModelOptionInfoItem = NumericOptionInfo | EnumOptionInfo | BooleanOptionInfo | StringListOptionInfo;
+export type ModelOptionInfoItem =
+    | NumericOptionInfo
+    | EnumOptionInfo
+    | BooleanOptionInfo
+    | StringListOptionInfo
+    | JSONObjectOptionInfo;
 interface OptionInfoPrototype {
     type: OptionType;
     name: string;
@@ -799,6 +805,12 @@ export interface StringListOptionInfo extends OptionInfoPrototype {
     type: OptionType.string_list;
     value?: string[];
     default?: string[];
+}
+
+export interface JSONObjectOptionInfo extends OptionInfoPrototype {
+    type: OptionType.json_object;
+    value?: JSONObject;
+    default?: JSONObject;
 }
 
 // ============== Prompts ===============

--- a/drivers/src/openai/extra_body.test.ts
+++ b/drivers/src/openai/extra_body.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { getOpenAIExtraBody, mergeOpenAIExtraBody } from './extra_body.js';
+
+describe('OpenAI-compatible extra body', () => {
+    it('extracts only object-shaped extension fields', () => {
+        expect(getOpenAIExtraBody({ extra_body: { provider: { sort: 'price' } } })).toEqual({
+            provider: { sort: 'price' },
+        });
+        expect(getOpenAIExtraBody({ extra_body: ['invalid'] })).toBeUndefined();
+        expect(getOpenAIExtraBody(undefined)).toBeUndefined();
+    });
+
+    it('merges extensions at the top level while preserving core request fields', () => {
+        expect(
+            mergeOpenAIExtraBody(
+                { model: 'actual-model', stream: false },
+                { provider: { sort: 'throughput' }, model: 'override', stream: true },
+            ),
+        ).toEqual({
+            provider: { sort: 'throughput' },
+            model: 'actual-model',
+            stream: false,
+        });
+    });
+});

--- a/drivers/src/openai/extra_body.ts
+++ b/drivers/src/openai/extra_body.ts
@@ -1,0 +1,17 @@
+export type OpenAIExtraBody = Record<string, unknown>;
+
+export function getOpenAIExtraBody(options: unknown): OpenAIExtraBody | undefined {
+    if (typeof options !== 'object' || options === null || !('extra_body' in options)) return undefined;
+    const extraBody = options.extra_body;
+    return typeof extraBody === 'object' && extraBody !== null && !Array.isArray(extraBody)
+        ? (extraBody as OpenAIExtraBody)
+        : undefined;
+}
+
+/** Merge provider extensions below Llumiverse-owned fields so extensions cannot replace the request contract. */
+export function mergeOpenAIExtraBody<RequestT extends object>(
+    request: RequestT,
+    extraBody: OpenAIExtraBody | undefined,
+): RequestT {
+    return extraBody ? ({ ...extraBody, ...request } as RequestT) : request;
+}

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -41,6 +41,7 @@ import {
 import type OpenAI from 'openai';
 import type { AzureOpenAI } from 'openai';
 import { resolveModelListingMetadata } from '../shared/model-listing.js';
+import { mergeOpenAIExtraBody, type OpenAIExtraBody } from './extra_body.js';
 import { OpenAICompatibleDriverBase } from './openai_compatible.js';
 import { formatOpenAILikeMultimodalPrompt } from './openai_format.js';
 import { formatOpenAISchema } from './schema.js';
@@ -57,6 +58,7 @@ type OpenAIRequestOptions = Partial<TextFallbackOptions> & {
     prompt_cache_key?: string;
     prompt_cache_retention?: 'in_memory' | '24h';
     service_tier?: string;
+    extra_body?: OpenAIExtraBody;
 };
 
 function asOpenAIResponseServiceTier(serviceTier?: string): OpenAIResponseServiceTier {
@@ -261,27 +263,30 @@ export class OpenAIResponsesProtocol {
             driver.getResponsesRequestModel(options.model),
             promptCacheKey,
         );
-        const request: OpenAI.Responses.ResponseCreateParamsStreaming = {
-            stream: true,
-            model: driver.getResponsesRequestModel(options.model),
-            prompt_cache_key: promptCacheKey,
-            prompt_cache_retention: promptCacheRetention,
-            prompt_cache_options: promptCache.options,
-            input: promptCache.input,
-            reasoning,
-            include: reasoning ? ['reasoning.encrypted_content'] : undefined,
-            temperature: isReasoningModel ? undefined : model_options?.temperature,
-            top_p: isReasoningModel ? undefined : model_options?.top_p,
-            max_output_tokens: model_options?.max_tokens,
-            service_tier: asOpenAIResponseServiceTier(model_options?.service_tier),
-            tools: useTools ? toolDefs : undefined,
-            text: buildResponseTextConfig(
-                parsedSchema,
-                strictMode,
-                model_options?.verbosity,
-                options.prompt_cache_schema_suffix === true && !!options.result_schema,
-            ),
-        };
+        const request = mergeOpenAIExtraBody<OpenAI.Responses.ResponseCreateParamsStreaming>(
+            {
+                stream: true,
+                model: driver.getResponsesRequestModel(options.model),
+                prompt_cache_key: promptCacheKey,
+                prompt_cache_retention: promptCacheRetention,
+                prompt_cache_options: promptCache.options,
+                input: promptCache.input,
+                reasoning,
+                include: reasoning ? ['reasoning.encrypted_content'] : undefined,
+                temperature: isReasoningModel ? undefined : model_options?.temperature,
+                top_p: isReasoningModel ? undefined : model_options?.top_p,
+                max_output_tokens: model_options?.max_tokens,
+                service_tier: asOpenAIResponseServiceTier(model_options?.service_tier),
+                tools: useTools ? toolDefs : undefined,
+                text: buildResponseTextConfig(
+                    parsedSchema,
+                    strictMode,
+                    model_options?.verbosity,
+                    options.prompt_cache_schema_suffix === true && !!options.result_schema,
+                ),
+            },
+            model_options?.extra_body,
+        );
         const requestOptions = this.resolveRequestOptions(options, signal);
         const stream = requestOptions
             ? await driver.service.responses.create(request, requestOptions)
@@ -352,27 +357,30 @@ export class OpenAIResponsesProtocol {
             driver.getResponsesRequestModel(options.model),
             promptCacheKey,
         );
-        const request = {
-            stream: false,
-            model: driver.getResponsesRequestModel(options.model),
-            prompt_cache_key: promptCacheKey,
-            prompt_cache_retention: promptCacheRetention,
-            prompt_cache_options: promptCache.options,
-            input: promptCache.input,
-            reasoning,
-            include: reasoning ? ['reasoning.encrypted_content'] : undefined,
-            temperature: isReasoningModel ? undefined : model_options?.temperature,
-            top_p: isReasoningModel ? undefined : model_options?.top_p,
-            max_output_tokens: model_options?.max_tokens,
-            service_tier: asOpenAIResponseServiceTier(model_options?.service_tier),
-            tools: useTools ? toolDefs : undefined,
-            text: buildResponseTextConfig(
-                parsedSchema,
-                strictMode,
-                model_options?.verbosity,
-                options.prompt_cache_schema_suffix === true && !!options.result_schema,
-            ),
-        } as OpenAI.Responses.ResponseCreateParamsNonStreaming;
+        const request = mergeOpenAIExtraBody<OpenAI.Responses.ResponseCreateParamsNonStreaming>(
+            {
+                stream: false,
+                model: driver.getResponsesRequestModel(options.model),
+                prompt_cache_key: promptCacheKey,
+                prompt_cache_retention: promptCacheRetention,
+                prompt_cache_options: promptCache.options,
+                input: promptCache.input,
+                reasoning,
+                include: reasoning ? ['reasoning.encrypted_content'] : undefined,
+                temperature: isReasoningModel ? undefined : model_options?.temperature,
+                top_p: isReasoningModel ? undefined : model_options?.top_p,
+                max_output_tokens: model_options?.max_tokens,
+                service_tier: asOpenAIResponseServiceTier(model_options?.service_tier),
+                tools: useTools ? toolDefs : undefined,
+                text: buildResponseTextConfig(
+                    parsedSchema,
+                    strictMode,
+                    model_options?.verbosity,
+                    options.prompt_cache_schema_suffix === true && !!options.result_schema,
+                ),
+            },
+            model_options?.extra_body,
+        );
         const requestOptions = this.resolveRequestOptions(options, signal);
         const res = requestOptions
             ? await driver.service.responses.create(request, requestOptions)

--- a/drivers/src/openai/openai_chat_completions.test.ts
+++ b/drivers/src/openai/openai_chat_completions.test.ts
@@ -190,7 +190,7 @@ describe('OpenAIChatCompletionsProtocol', () => {
         expect(chunks[0].choices[0].delta.reasoning).toBe('streaming reasoning');
     });
 
-    it('forwards token fields, penalties, stop sequences, and extra_body to the transport', async () => {
+    it('combines static and per-execution extra body fields for the transport', async () => {
         const model = new TestOpenAIChatCompletionsProtocol(
             {
                 id: 'chatcmpl-1',
@@ -213,10 +213,14 @@ describe('OpenAIChatCompletionsProtocol', () => {
         await model.requestTextCompletion(undefined, prompt, {
             ...options,
             model_options: {
-                _option_id: 'text-fallback',
+                _option_id: 'openai-text',
                 presence_penalty: 0.1,
                 frequency_penalty: 0.2,
                 stop_sequence: ['END'],
+                extra_body: {
+                    provider: { sort: 'latency' },
+                    baseten: { performance: 'max' },
+                },
             },
         });
 
@@ -226,7 +230,11 @@ describe('OpenAIChatCompletionsProtocol', () => {
                 presence_penalty: 0.1,
                 frequency_penalty: 0.2,
                 stop: ['END'],
-                extra_body: { google: { model_safety_settings: { enabled: false } } },
+                extra_body: {
+                    google: { model_safety_settings: { enabled: false } },
+                    provider: { sort: 'latency' },
+                    baseten: { performance: 'max' },
+                },
             }),
         );
     });

--- a/drivers/src/openai/openai_chat_completions.ts
+++ b/drivers/src/openai/openai_chat_completions.ts
@@ -34,6 +34,7 @@ import {
 import { transformSSEStream } from '@llumiverse/core/async';
 import OpenAI from 'openai';
 import { resolveModelListingMetadata } from '../shared/model-listing.js';
+import { getOpenAIExtraBody, mergeOpenAIExtraBody } from './extra_body.js';
 import { OpenAICompatibleDriverBase } from './openai_compatible.js';
 import { formatOpenAISchema, limitedSchemaFormat } from './schema.js';
 
@@ -1178,8 +1179,9 @@ export abstract class OpenAIChatCompletionsProtocol<DriverT> {
             stream,
         };
 
-        if (this.options.extraBody) {
-            payload.extra_body = this.options.extraBody;
+        const executionExtraBody = getOpenAIExtraBody(modelOptions);
+        if (this.options.extraBody || executionExtraBody) {
+            payload.extra_body = { ...this.options.extraBody, ...executionExtraBody };
         }
 
         const toolsPayload = convertToolsToOpenAIChatCompletionsFormat(options.tools, this.options.toolSchemaMode);
@@ -1337,29 +1339,31 @@ function toOpenAISDKMessage(message: OpenAIChatCompletionsRequestMessage): OpenA
 function toOpenAINonStreamingPayload(
     payload: OpenAIChatCompletionsPayload,
 ): OpenAI.Chat.ChatCompletionCreateParamsNonStreaming {
-    const { messages, stream: _stream, ...body } = payload;
-    const request = {
-        ...body,
-        messages: messages.map(toOpenAISDKMessage),
-        stream: false,
-    } satisfies OpenAI.Chat.ChatCompletionCreateParamsNonStreaming & {
-        extra_body?: Record<string, unknown>;
-    };
+    const { messages, stream: _stream, extra_body, ...body } = payload;
+    const request = mergeOpenAIExtraBody(
+        {
+            ...body,
+            messages: messages.map(toOpenAISDKMessage),
+            stream: false,
+        } satisfies OpenAI.Chat.ChatCompletionCreateParamsNonStreaming,
+        extra_body,
+    );
     return request;
 }
 
 function toOpenAIStreamingPayload(
     payload: OpenAIChatCompletionsPayload,
 ): OpenAI.Chat.ChatCompletionCreateParamsStreaming {
-    const { messages, stream: _stream, ...body } = payload;
-    const request = {
-        ...body,
-        messages: messages.map(toOpenAISDKMessage),
-        stream: true,
-        stream_options: { include_usage: true },
-    } satisfies OpenAI.Chat.ChatCompletionCreateParamsStreaming & {
-        extra_body?: Record<string, unknown>;
-    };
+    const { messages, stream: _stream, extra_body, ...body } = payload;
+    const request = mergeOpenAIExtraBody(
+        {
+            ...body,
+            messages: messages.map(toOpenAISDKMessage),
+            stream: true,
+            stream_options: { include_usage: true },
+        } satisfies OpenAI.Chat.ChatCompletionCreateParamsStreaming,
+        extra_body,
+    );
     return request;
 }
 

--- a/drivers/src/openai/responses-reasoning.test.ts
+++ b/drivers/src/openai/responses-reasoning.test.ts
@@ -84,6 +84,36 @@ describe('OpenAI Responses reasoning', () => {
         );
     });
 
+    it('merges provider-specific extra body fields without allowing core request overrides', async () => {
+        const create = vi.fn(async (_request: unknown) => response());
+        const driver = new TestResponsesDriver(create, Providers.openai_compatible);
+
+        await driver.requestTextCompletion([{ type: 'message', role: 'user', content: 'question' }], {
+            model: 'openrouter/model',
+            model_options: {
+                _option_id: 'openai-text',
+                max_tokens: 256,
+                extra_body: {
+                    provider: { sort: 'throughput', allow_fallbacks: false },
+                    baseten: { performance: 'max' },
+                    model: 'must-not-override',
+                    stream: true,
+                },
+            },
+        });
+
+        expect(create).toHaveBeenCalledWith(
+            expect.objectContaining({
+                model: 'openrouter/model',
+                stream: false,
+                max_output_tokens: 256,
+                provider: { sort: 'throughput', allow_fallbacks: false },
+                baseten: { performance: 'max' },
+            }),
+        );
+        expect(create.mock.calls[0][0]).not.toHaveProperty('extra_body');
+    });
+
     it.each(['gpt-5.4', 'gpt-5.5', 'gpt-5.6', 'gpt-5.6-sol', 'gpt-5.7'])(
         'uses current-turn reasoning context for %s',
         async (model) => {


### PR DESCRIPTION
## Summary
- add an open-ended `extra_body` object to OpenAI-compatible text and reasoning model options
- flatten provider-specific fields into Responses and Chat Completions requests while protecting Llumiverse-owned fields
- expose JSON-object option metadata for compatible endpoints and keep native Mistral options schema-aligned

## Test Plan
- [x] `pnpm --filter @llumiverse/common lint`
- [x] `pnpm --filter @llumiverse/common build`
- [x] `pnpm --filter @llumiverse/common typecheck:test`
- [x] `pnpm --filter @llumiverse/common test` (239 passed)
- [x] `pnpm --filter @llumiverse/core build`
- [x] `pnpm --filter @llumiverse/drivers lint`
- [x] `pnpm --filter @llumiverse/drivers build`
- [x] `pnpm --filter @llumiverse/drivers typecheck:test`
- [x] `pnpm --filter @llumiverse/drivers test` (625 passed, 19 skipped)
