### PR TITLE
feat: add native OpenRouter support

### DIFF
--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -10,6 +10,7 @@ export * from './options/fallback.js';
 export * from './options/groq.js';
 export * from './options/mistral.js';
 export * from './options/openai.js';
+export * from './options/openrouter.js';
 export * from './options/shared-parsing.js';
 export * from './options/version-parsing.js';
 export * from './options/vertexai.js';

--- a/common/src/model-directory.test.ts
+++ b/common/src/model-directory.test.ts
@@ -5,6 +5,22 @@ import { getOptions } from './options.js';
 import { Providers } from './types.js';
 
 describe('central model directory', () => {
+    it('preserves source-model semantics through the native OpenRouter transport', () => {
+        const profile = resolveModelProfile('google/gemini-3.5-flash', Providers.openrouter);
+        const options = getOptions(profile.model_id, Providers.openrouter);
+
+        expect(profile).toMatchObject({
+            family: 'gemini',
+            source_provider: 'google',
+            reasoning_effort_levels: ['minimal', 'low', 'medium', 'high'],
+        });
+        expect(options._option_id).toBe('openrouter-text');
+        expect(options.options.map((option) => option.name)).toEqual(
+            expect.arrayContaining(['provider_sort', 'provider_order', 'provider_allow_fallbacks']),
+        );
+        expect(options.options.map((option) => option.name)).not.toContain('extra_body');
+    });
+
     it('resolves provider-qualified Gemini models through OpenAI-compatible transport', () => {
         const profile = resolveModelProfile('google/gemini-3.5-flash', Providers.openai_compatible);
         const capabilities = getModelCapabilities('google/gemini-3.5-flash', Providers.openai_compatible);
@@ -17,6 +33,9 @@ describe('central model directory', () => {
         expect(options._option_id).toBe('openai-text');
         expect(options.options.map((option) => option.name)).not.toContain('service_tier');
         expect(options.options.map((option) => option.name)).not.toContain('thinking_level');
+        expect(options.options.find((option) => option.name === 'extra_body')).toMatchObject({
+            type: 'json_object',
+        });
         expect(options.options.find((option) => option.name === 'max_tokens')).toMatchObject({ max: 65_535 });
         expect(options.options.find((option) => option.name === 'effort')).toMatchObject({
             enum: { minimal: 'minimal', low: 'low', medium: 'medium', high: 'high' },

--- a/common/src/model-directory.ts
+++ b/common/src/model-directory.ts
@@ -338,7 +338,7 @@ function applyProviderOverlay(
 
     // OpenRouter and other OpenAI-compatible transports retain the source model's semantic
     // capabilities, but cannot expose provider-native fields such as Vertex Flex or thinking_level.
-    if (provider === Providers.openai_compatible) {
+    if (isOpenAICompatibleTransport(provider)) {
         return {
             capabilities: {
                 ...capabilities,
@@ -379,7 +379,7 @@ function getReasoningEffortLevels(model: string, family: string, provider: Provi
     if (family === 'gpt') {
         if (model.includes('gpt-oss')) {
             return provider === Providers.togetherai ||
-                provider === Providers.openai_compatible ||
+                isOpenAICompatibleTransport(provider) ||
                 provider === Providers.vertexai ||
                 provider === Providers.bedrock ||
                 provider === Providers.bedrock_mantle ||
@@ -390,7 +390,7 @@ function getReasoningEffortLevels(model: string, family: string, provider: Provi
         if (
             provider === Providers.openai ||
             provider === Providers.azure_openai ||
-            provider === Providers.openai_compatible ||
+            isOpenAICompatibleTransport(provider) ||
             provider === Providers.azure_foundry ||
             provider === Providers.bedrock_mantle
         ) {
@@ -399,7 +399,7 @@ function getReasoningEffortLevels(model: string, family: string, provider: Provi
         }
         return undefined;
     }
-    if (family === 'gemini' && provider === Providers.openai_compatible && isGeminiModelVersionGte(model, '3.5')) {
+    if (family === 'gemini' && isOpenAICompatibleTransport(provider) && isGeminiModelVersionGte(model, '3.5')) {
         return ['minimal', 'low', 'medium', 'high'];
     }
     if (provider === Providers.mistralai && family === 'mistral') {
@@ -414,6 +414,10 @@ function getReasoningEffortLevels(model: string, family: string, provider: Provi
         if (isSingleDigitGrokVersionGte(model, 4, 3)) return ['none', 'low', 'medium', 'high'];
     }
     return undefined;
+}
+
+function isOpenAICompatibleTransport(provider: Providers): boolean {
+    return provider === Providers.openai_compatible || provider === Providers.openrouter;
 }
 
 function isSingleDigitGrokVersionGte(model: string, targetMajor: number, targetMinor: number): boolean {

--- a/common/src/options.ts
+++ b/common/src/options.ts
@@ -7,6 +7,7 @@ import { textOptionsFallback } from './options/fallback.js';
 import { getGroqOptions } from './options/groq.js';
 import { getMistralOptions } from './options/mistral.js';
 import { getAzureOpenAiOptions, getOpenAiCompatibleOptions, getOpenAiOptions } from './options/openai.js';
+import { getOpenRouterOptions } from './options/openrouter.js';
 import { getVertexAiOptions } from './options/vertexai.js';
 import { getXAIOptions } from './options/xai.js';
 import { type ModelOptions, type ModelOptionsInfo, Providers } from './types.js';
@@ -29,6 +30,8 @@ export function getOptions(model: string, provider?: Providers, options?: ModelO
             return getOpenAiOptions(model, options, resolveModelProfile(model, provider));
         case Providers.azure_openai:
             return getAzureOpenAiOptions(model, options, resolveModelProfile(model, provider));
+        case Providers.openrouter:
+            return getOpenRouterOptions(model, options, resolveModelProfile(model, provider));
         case Providers.openai_compatible:
             return getOpenAiCompatibleOptions(model, options, resolveModelProfile(model, provider));
         case Providers.groq:

--- a/common/src/options/current-model-options.test.ts
+++ b/common/src/options/current-model-options.test.ts
@@ -37,15 +37,18 @@ describe('current reasoning model options', () => {
     });
 
     it('does not advertise unverified effort for unknown OpenAI-compatible models', () => {
-        expect(
-            getOptions('custom-reasoning-model', Providers.openai_compatible).options.map((option) => option.name),
-        ).not.toContain(SharedOptions.effort);
+        const options = getOptions('custom-reasoning-model', Providers.openai_compatible).options;
+        expect(options.map((option) => option.name)).not.toContain(SharedOptions.effort);
+        expect(options.find((option) => option.name === 'extra_body')).toMatchObject({
+            type: OptionType.json_object,
+        });
     });
 
     it('advertises the native Mistral options that its transport serializes', () => {
         const options = getOptions('mistral-small-latest', Providers.mistralai);
+        const optionNames = options.options.map((option) => option.name);
         expect(options._option_id).toBe('mistral-text');
-        expect(options.options.map((option) => option.name)).toEqual(
+        expect(optionNames).toEqual(
             expect.arrayContaining([
                 'max_tokens',
                 'temperature',
@@ -62,7 +65,8 @@ describe('current reasoning model options', () => {
                 'include_thoughts',
             ]),
         );
-        expect(options.options.map((option) => option.name)).not.toContain('image_detail');
+        expect(optionNames).not.toContain('image_detail');
+        expect(optionNames).not.toContain('extra_body');
         expect(effortValues('mistral-small-latest', Providers.mistralai)).toEqual(['none', 'high']);
     });
 

--- a/common/src/options/mistral.ts
+++ b/common/src/options/mistral.ts
@@ -21,7 +21,7 @@ export function getMistralOptions(
     const compatible = getOpenAiCompatibleOptions(model, options, profile);
     const supportsReasoning = profile.reasoning_effort_levels?.length;
     const compatibleOptions = compatible.options
-        .filter((item) => item.name !== 'image_detail')
+        .filter((item) => item.name !== 'image_detail' && item.name !== 'extra_body')
         .map((item): ModelOptionInfoItem => {
             if (item.name !== SharedOptions.max_tokens || profile.max_output_tokens !== undefined) return item;
             const { max: _unverifiedMax, ...withoutMax } = item as ModelOptionInfoItem & { max?: number };

--- a/common/src/options/openai.ts
+++ b/common/src/options/openai.ts
@@ -378,10 +378,10 @@ export function getOpenAiCompatibleOptions(
         })
         .filter((item): item is ModelOptionInfoItem => item !== null);
     if (profileOptions.some((item) => item.name === SharedOptions.effort) || options._option_id !== 'openai-text') {
-        return { ...options, options: profileOptions };
+        return withCompatibleExtraBody({ ...options, options: profileOptions });
     }
-    if (!profileEffortLevels) return { ...options, options: profileOptions };
-    return {
+    if (!profileEffortLevels) return withCompatibleExtraBody({ ...options, options: profileOptions });
+    return withCompatibleExtraBody({
         ...options,
         options: [
             ...profileOptions,
@@ -390,6 +390,21 @@ export function getOpenAiCompatibleOptions(
                 type: OptionType.enum,
                 enum: Object.fromEntries([...profileEffortLevels].map((value) => [value, value])),
                 description: 'How much effort the model should put into reasoning, when supported by the endpoint.',
+            },
+        ],
+    });
+}
+
+function withCompatibleExtraBody(options: ModelOptionsInfo): ModelOptionsInfo {
+    return {
+        ...options,
+        options: [
+            ...options.options,
+            {
+                name: 'extra_body',
+                type: OptionType.json_object,
+                description:
+                    'Additional provider-specific fields merged into the request body. Standard model options take precedence.',
             },
         ],
     };

--- a/common/src/options/openrouter.ts
+++ b/common/src/options/openrouter.ts
@@ -1,0 +1,72 @@
+import type { z } from 'zod';
+import { type ModelProfile, resolveModelProfile } from '../model-directory.js';
+import type { OpenRouterTextOptionsSchema } from '../schemas/model-options.js';
+import { type ModelOptionInfoItem, type ModelOptions, type ModelOptionsInfo, OptionType, Providers } from '../types.js';
+import { getOpenAiCompatibleOptions } from './openai.js';
+
+export type OpenRouterTextOptions = z.infer<typeof OpenRouterTextOptionsSchema>;
+
+const providerRoutingOptions: ModelOptionInfoItem[] = [
+    {
+        name: 'provider_sort',
+        type: OptionType.enum,
+        enum: { Price: 'price', Throughput: 'throughput', Latency: 'latency', Exacto: 'exacto' },
+        description: 'Sort OpenRouter endpoints by price, throughput, latency, or tool-calling quality.',
+    },
+    {
+        name: 'provider_order',
+        type: OptionType.string_list,
+        description: 'Provider slugs to try in order. When set, OpenRouter disables load balancing.',
+    },
+    {
+        name: 'provider_only',
+        type: OptionType.string_list,
+        description: 'Only route through these OpenRouter provider slugs.',
+    },
+    {
+        name: 'provider_ignore',
+        type: OptionType.string_list,
+        description: 'Do not route through these OpenRouter provider slugs.',
+    },
+    {
+        name: 'provider_allow_fallbacks',
+        type: OptionType.boolean,
+        default: true,
+        description: 'Allow OpenRouter to try backup providers when the preferred provider is unavailable.',
+    },
+    {
+        name: 'provider_require_parameters',
+        type: OptionType.boolean,
+        default: false,
+        description: 'Only use providers that support every parameter in the request.',
+    },
+    {
+        name: 'provider_data_collection',
+        type: OptionType.enum,
+        enum: { Allow: 'allow', Deny: 'deny' },
+        default: 'allow',
+        description: 'Control whether routed providers may collect request data.',
+    },
+    {
+        name: 'provider_zdr',
+        type: OptionType.boolean,
+        description: 'Only use zero-data-retention endpoints.',
+    },
+    {
+        name: 'provider_quantizations',
+        type: OptionType.string_list,
+        description: 'Only use endpoints with one of these quantization levels.',
+    },
+];
+
+export function getOpenRouterOptions(
+    model: string,
+    options?: ModelOptions,
+    profile: ModelProfile = resolveModelProfile(model, Providers.openrouter),
+): ModelOptionsInfo {
+    const compatible = getOpenAiCompatibleOptions(model, options, profile);
+    return {
+        _option_id: 'openrouter-text',
+        options: [...compatible.options.filter((option) => option.name !== 'extra_body'), ...providerRoutingOptions],
+    };
+}

--- a/common/src/schemas/model-options.test.ts
+++ b/common/src/schemas/model-options.test.ts
@@ -8,8 +8,8 @@ type Equals<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B 
 function assertType<T extends true>(_ok: T): void {}
 
 /**
- * `ModelOptions` is published by Vertesia as a discriminated-union component with twenty-four
- * members, each its own component. These pin the properties that a consumer of the published document
+ * `ModelOptions` is published by Vertesia as a discriminated union whose members are named components.
+ * These pin the properties that a consumer of the published document
  * depends on and that a careless edit here would break silently — the union is large enough that a
  * dropped member reads as a normal diff.
  */
@@ -82,6 +82,7 @@ describe('ModelOptionsSchema', () => {
             'BedrockMantleClaudeOptions',
             'OpenAiThinkingOptions',
             'OpenAiTextOptions',
+            'OpenRouterTextOptions',
             'OpenAiDalleOptions',
             'OpenAiGptImageOptions',
             'XAIGrokImageOptions',
@@ -136,5 +137,40 @@ describe('ModelOptionsSchema', () => {
         expect(
             ModelOptionsSchema.safeParse({ _option_id: 'bedrock-twelvelabs-pegasus', service_tier: 'flex' }).success,
         ).toBe(true);
+    });
+
+    it('validates OpenRouter provider routing options', () => {
+        expect(
+            ModelOptionsSchema.safeParse({
+                _option_id: 'openrouter-text',
+                provider_sort: 'throughput',
+                provider_order: ['google-vertex', 'amazon-bedrock'],
+                provider_allow_fallbacks: false,
+            }).success,
+        ).toBe(true);
+        expect(ModelOptionsSchema.safeParse({ _option_id: 'openrouter-text', provider_sort: 'random' }).success).toBe(
+            false,
+        );
+    });
+
+    it('accepts provider-specific extra body fields only as a JSON object', () => {
+        expect(
+            ModelOptionsSchema.safeParse({
+                _option_id: 'openai-text',
+                extra_body: {
+                    provider: { sort: 'throughput', allow_fallbacks: false },
+                    baseten: { performance: 'max' },
+                },
+            }).success,
+        ).toBe(true);
+        expect(
+            ModelOptionsSchema.safeParse({ _option_id: 'openai-thinking', extra_body: { custom_flag: true } }).success,
+        ).toBe(true);
+        expect(ModelOptionsSchema.safeParse({ _option_id: 'openai-text', extra_body: ['invalid'] }).success).toBe(
+            false,
+        );
+        expect(
+            ModelOptionsSchema.safeParse({ _option_id: 'openrouter-text', extra_body: { unsupported: true } }).success,
+        ).toBe(false);
     });
 });

--- a/common/src/schemas/model-options.ts
+++ b/common/src/schemas/model-options.ts
@@ -33,6 +33,10 @@ const ServiceTierSchema = z
     .min(1)
     .describe('Provider-defined processing tier. Unknown non-empty values are preserved for forward compatibility.');
 
+const ExtraBodySchema = z
+    .record(z.string(), z.unknown())
+    .describe('Additional provider-specific fields merged into the OpenAI-compatible request body.');
+
 // ===== fallback =====
 
 export const TextFallbackOptionsSchema = z
@@ -302,6 +306,7 @@ export const OpenAiThinkingOptionsSchema = z
         image_detail: z.enum(['low', 'high', 'auto']).optional(),
         include_thoughts: z.boolean().optional(),
         service_tier: ServiceTierSchema.optional(),
+        extra_body: ExtraBodySchema.optional(),
     })
     .meta({ id: 'OpenAiThinkingOptions' });
 
@@ -319,8 +324,41 @@ export const OpenAiTextOptionsSchema = z
         image_detail: z.enum(['low', 'high', 'auto']).optional(),
         include_thoughts: z.boolean().optional(),
         service_tier: ServiceTierSchema.optional(),
+        extra_body: ExtraBodySchema.optional(),
     })
     .meta({ id: 'OpenAiTextOptions' });
+
+export const OpenRouterTextOptionsSchema = OpenAiTextOptionsSchema.omit({ _option_id: true, extra_body: true })
+    .extend({
+        _option_id: z.literal('openrouter-text'),
+        provider_sort: z.enum(['price', 'throughput', 'latency', 'exacto']).optional(),
+        provider_order: z.array(z.string()).optional(),
+        provider_only: z.array(z.string()).optional(),
+        provider_ignore: z.array(z.string()).optional(),
+        provider_allow_fallbacks: z.boolean().optional(),
+        provider_require_parameters: z.boolean().optional(),
+        provider_data_collection: z.enum(['allow', 'deny']).optional(),
+        provider_zdr: z.boolean().optional(),
+        provider_quantizations: z
+            .array(
+                z.enum([
+                    'int4',
+                    'int8',
+                    'fp4',
+                    'mxfp4',
+                    'nvfp4',
+                    'fp6',
+                    'fp8',
+                    'mxfp8',
+                    'fp16',
+                    'bf16',
+                    'fp32',
+                    'unknown',
+                ]),
+            )
+            .optional(),
+    })
+    .meta({ id: 'OpenRouterTextOptions' });
 
 export const OpenAiDalleOptionsSchema = z
     .strictObject({
@@ -501,6 +539,7 @@ export const ModelOptionsSchema = z
         BedrockMantleClaudeOptionsSchema,
         OpenAiThinkingOptionsSchema,
         OpenAiTextOptionsSchema,
+        OpenRouterTextOptionsSchema,
         OpenAiDalleOptionsSchema,
         OpenAiGptImageOptionsSchema,
         XAIGrokImageOptionsSchema,

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -36,6 +36,7 @@ export enum Providers {
     watsonx = 'watsonx',
     xai = 'xai',
     anthropic = 'anthropic',
+    openrouter = 'openrouter',
 }
 
 export interface ProviderParams {
@@ -151,6 +152,13 @@ export const ProviderList: Record<Providers, ProviderParams> = {
     anthropic: {
         id: Providers.anthropic,
         name: 'Anthropic',
+        requiresApiKey: true,
+        requiresEndpointUrl: false,
+        supportSearch: false,
+    },
+    openrouter: {
+        id: Providers.openrouter,
+        name: 'OpenRouter',
         requiresApiKey: true,
         requiresEndpointUrl: false,
         supportSearch: false,
@@ -738,6 +746,7 @@ export enum OptionType {
     enum = 'enum',
     boolean = 'boolean',
     string_list = 'string_list',
+    json_object = 'json_object',
 }
 
 // Derived from the schema, like the option types that use it. Restating the seven values here made
@@ -765,7 +774,12 @@ export interface ModelOptionsInfo {
     _option_id: string; //Should follow same ids as ModelOptions
 }
 
-export type ModelOptionInfoItem = NumericOptionInfo | EnumOptionInfo | BooleanOptionInfo | StringListOptionInfo;
+export type ModelOptionInfoItem =
+    | NumericOptionInfo
+    | EnumOptionInfo
+    | BooleanOptionInfo
+    | StringListOptionInfo
+    | JSONObjectOptionInfo;
 interface OptionInfoPrototype {
     type: OptionType;
     name: string;
@@ -803,6 +817,12 @@ export interface StringListOptionInfo extends OptionInfoPrototype {
     type: OptionType.string_list;
     value?: string[];
     default?: string[];
+}
+
+export interface JSONObjectOptionInfo extends OptionInfoPrototype {
+    type: OptionType.json_object;
+    value?: JSONObject;
+    default?: JSONObject;
 }
 
 // ============== Prompts ===============

--- a/drivers/package.json
+++ b/drivers/package.json
@@ -18,6 +18,10 @@
             "types": "./lib/openai/drivers.d.ts",
             "default": "./lib/openai/drivers.js"
         },
+        "./openrouter": {
+            "types": "./lib/openrouter/index.d.ts",
+            "default": "./lib/openrouter/index.js"
+        },
         "./azure": {
             "types": "./lib/azure/azure_foundry.d.ts",
             "default": "./lib/azure/azure_foundry.js"
@@ -134,6 +138,7 @@
         "@llumiverse/common": "workspace:*",
         "@llumiverse/core": "workspace:*",
         "@mistralai/mistralai": "^2.6.3",
+        "@openrouter/sdk": "^1.2.54",
         "@vertesia/api-fetch-client": "^1.4.1",
         "eventsource": "^5.1.0",
         "google-auth-library": "catalog:",

--- a/drivers/src/index.ts
+++ b/drivers/src/index.ts
@@ -9,6 +9,7 @@ export * from './openai/azure_openai.js';
 export * from './openai/openai.js';
 export * from './openai/openai_chat_completions.js';
 export * from './openai/openai_responses.js';
+export * from './openrouter/index.js';
 export * from './replicate.js';
 export * from './test-driver/index.js';
 export * from './togetherai/index.js';

--- a/drivers/src/openai/extra_body.test.ts
+++ b/drivers/src/openai/extra_body.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { getOpenAIExtraBody, mergeOpenAIExtraBody } from './extra_body.js';
+
+describe('OpenAI-compatible extra body', () => {
+    it('extracts only object-shaped extension fields', () => {
+        expect(getOpenAIExtraBody({ extra_body: { provider: { sort: 'price' } } })).toEqual({
+            provider: { sort: 'price' },
+        });
+        expect(getOpenAIExtraBody({ extra_body: ['invalid'] })).toBeUndefined();
+        expect(getOpenAIExtraBody(undefined)).toBeUndefined();
+    });
+
+    it('merges extensions at the top level while preserving core request fields', () => {
+        expect(
+            mergeOpenAIExtraBody(
+                { model: 'actual-model', stream: false },
+                { provider: { sort: 'throughput' }, model: 'override', stream: true },
+            ),
+        ).toEqual({
+            provider: { sort: 'throughput' },
+            model: 'actual-model',
+            stream: false,
+        });
+    });
+});

--- a/drivers/src/openai/extra_body.ts
+++ b/drivers/src/openai/extra_body.ts
@@ -1,0 +1,17 @@
+export type OpenAIExtraBody = Record<string, unknown>;
+
+export function getOpenAIExtraBody(options: unknown): OpenAIExtraBody | undefined {
+    if (typeof options !== 'object' || options === null || !('extra_body' in options)) return undefined;
+    const extraBody = options.extra_body;
+    return typeof extraBody === 'object' && extraBody !== null && !Array.isArray(extraBody)
+        ? (extraBody as OpenAIExtraBody)
+        : undefined;
+}
+
+/** Merge provider extensions below Llumiverse-owned fields so extensions cannot replace the request contract. */
+export function mergeOpenAIExtraBody<RequestT extends object>(
+    request: RequestT,
+    extraBody: OpenAIExtraBody | undefined,
+): RequestT {
+    return extraBody ? ({ ...extraBody, ...request } as RequestT) : request;
+}

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -41,6 +41,7 @@ import {
 import type OpenAI from 'openai';
 import type { AzureOpenAI } from 'openai';
 import { resolveModelListingMetadata } from '../shared/model-listing.js';
+import { mergeOpenAIExtraBody, type OpenAIExtraBody } from './extra_body.js';
 import { OpenAICompatibleDriverBase } from './openai_compatible.js';
 import { formatOpenAILikeMultimodalPrompt } from './openai_format.js';
 import { formatOpenAISchema } from './schema.js';
@@ -57,6 +58,7 @@ type OpenAIRequestOptions = Partial<TextFallbackOptions> & {
     prompt_cache_key?: string;
     prompt_cache_retention?: 'in_memory' | '24h';
     service_tier?: string;
+    extra_body?: OpenAIExtraBody;
 };
 
 function asOpenAIResponseServiceTier(serviceTier?: string): OpenAIResponseServiceTier {
@@ -261,27 +263,30 @@ export class OpenAIResponsesProtocol {
             driver.getResponsesRequestModel(options.model),
             promptCacheKey,
         );
-        const request: OpenAI.Responses.ResponseCreateParamsStreaming = {
-            stream: true,
-            model: driver.getResponsesRequestModel(options.model),
-            prompt_cache_key: promptCacheKey,
-            prompt_cache_retention: promptCacheRetention,
-            prompt_cache_options: promptCache.options,
-            input: promptCache.input,
-            reasoning,
-            include: reasoning ? ['reasoning.encrypted_content'] : undefined,
-            temperature: isReasoningModel ? undefined : model_options?.temperature,
-            top_p: isReasoningModel ? undefined : model_options?.top_p,
-            max_output_tokens: model_options?.max_tokens,
-            service_tier: asOpenAIResponseServiceTier(model_options?.service_tier),
-            tools: useTools ? toolDefs : undefined,
-            text: buildResponseTextConfig(
-                parsedSchema,
-                strictMode,
-                model_options?.verbosity,
-                options.prompt_cache_schema_suffix === true && !!options.result_schema,
-            ),
-        };
+        const request = mergeOpenAIExtraBody<OpenAI.Responses.ResponseCreateParamsStreaming>(
+            {
+                stream: true,
+                model: driver.getResponsesRequestModel(options.model),
+                prompt_cache_key: promptCacheKey,
+                prompt_cache_retention: promptCacheRetention,
+                prompt_cache_options: promptCache.options,
+                input: promptCache.input,
+                reasoning,
+                include: reasoning ? ['reasoning.encrypted_content'] : undefined,
+                temperature: isReasoningModel ? undefined : model_options?.temperature,
+                top_p: isReasoningModel ? undefined : model_options?.top_p,
+                max_output_tokens: model_options?.max_tokens,
+                service_tier: asOpenAIResponseServiceTier(model_options?.service_tier),
+                tools: useTools ? toolDefs : undefined,
+                text: buildResponseTextConfig(
+                    parsedSchema,
+                    strictMode,
+                    model_options?.verbosity,
+                    options.prompt_cache_schema_suffix === true && !!options.result_schema,
+                ),
+            },
+            model_options?.extra_body,
+        );
         const requestOptions = this.resolveRequestOptions(options, signal);
         const stream = requestOptions
             ? await driver.service.responses.create(request, requestOptions)
@@ -352,27 +357,30 @@ export class OpenAIResponsesProtocol {
             driver.getResponsesRequestModel(options.model),
             promptCacheKey,
         );
-        const request = {
-            stream: false,
-            model: driver.getResponsesRequestModel(options.model),
-            prompt_cache_key: promptCacheKey,
-            prompt_cache_retention: promptCacheRetention,
-            prompt_cache_options: promptCache.options,
-            input: promptCache.input,
-            reasoning,
-            include: reasoning ? ['reasoning.encrypted_content'] : undefined,
-            temperature: isReasoningModel ? undefined : model_options?.temperature,
-            top_p: isReasoningModel ? undefined : model_options?.top_p,
-            max_output_tokens: model_options?.max_tokens,
-            service_tier: asOpenAIResponseServiceTier(model_options?.service_tier),
-            tools: useTools ? toolDefs : undefined,
-            text: buildResponseTextConfig(
-                parsedSchema,
-                strictMode,
-                model_options?.verbosity,
-                options.prompt_cache_schema_suffix === true && !!options.result_schema,
-            ),
-        } as OpenAI.Responses.ResponseCreateParamsNonStreaming;
+        const request = mergeOpenAIExtraBody<OpenAI.Responses.ResponseCreateParamsNonStreaming>(
+            {
+                stream: false,
+                model: driver.getResponsesRequestModel(options.model),
+                prompt_cache_key: promptCacheKey,
+                prompt_cache_retention: promptCacheRetention,
+                prompt_cache_options: promptCache.options,
+                input: promptCache.input,
+                reasoning,
+                include: reasoning ? ['reasoning.encrypted_content'] : undefined,
+                temperature: isReasoningModel ? undefined : model_options?.temperature,
+                top_p: isReasoningModel ? undefined : model_options?.top_p,
+                max_output_tokens: model_options?.max_tokens,
+                service_tier: asOpenAIResponseServiceTier(model_options?.service_tier),
+                tools: useTools ? toolDefs : undefined,
+                text: buildResponseTextConfig(
+                    parsedSchema,
+                    strictMode,
+                    model_options?.verbosity,
+                    options.prompt_cache_schema_suffix === true && !!options.result_schema,
+                ),
+            },
+            model_options?.extra_body,
+        );
         const requestOptions = this.resolveRequestOptions(options, signal);
         const res = requestOptions
             ? await driver.service.responses.create(request, requestOptions)

--- a/drivers/src/openai/openai_chat_completions.test.ts
+++ b/drivers/src/openai/openai_chat_completions.test.ts
@@ -190,7 +190,7 @@ describe('OpenAIChatCompletionsProtocol', () => {
         expect(chunks[0].choices[0].delta.reasoning).toBe('streaming reasoning');
     });
 
-    it('forwards token fields, penalties, stop sequences, and extra_body to the transport', async () => {
+    it('combines static and per-execution extra body fields for the transport', async () => {
         const model = new TestOpenAIChatCompletionsProtocol(
             {
                 id: 'chatcmpl-1',
@@ -213,10 +213,14 @@ describe('OpenAIChatCompletionsProtocol', () => {
         await model.requestTextCompletion(undefined, prompt, {
             ...options,
             model_options: {
-                _option_id: 'text-fallback',
+                _option_id: 'openai-text',
                 presence_penalty: 0.1,
                 frequency_penalty: 0.2,
                 stop_sequence: ['END'],
+                extra_body: {
+                    provider: { sort: 'latency' },
+                    baseten: { performance: 'max' },
+                },
             },
         });
 
@@ -226,7 +230,11 @@ describe('OpenAIChatCompletionsProtocol', () => {
                 presence_penalty: 0.1,
                 frequency_penalty: 0.2,
                 stop: ['END'],
-                extra_body: { google: { model_safety_settings: { enabled: false } } },
+                extra_body: {
+                    google: { model_safety_settings: { enabled: false } },
+                    provider: { sort: 'latency' },
+                    baseten: { performance: 'max' },
+                },
             }),
         );
     });

--- a/drivers/src/openai/openai_chat_completions.ts
+++ b/drivers/src/openai/openai_chat_completions.ts
@@ -34,6 +34,7 @@ import {
 import { transformSSEStream } from '@llumiverse/core/async';
 import OpenAI from 'openai';
 import { resolveModelListingMetadata } from '../shared/model-listing.js';
+import { getOpenAIExtraBody, mergeOpenAIExtraBody } from './extra_body.js';
 import { OpenAICompatibleDriverBase } from './openai_compatible.js';
 import { formatOpenAISchema, limitedSchemaFormat } from './schema.js';
 
@@ -1180,8 +1181,9 @@ export abstract class OpenAIChatCompletionsProtocol<DriverT> {
             stream,
         };
 
-        if (this.options.extraBody) {
-            payload.extra_body = this.options.extraBody;
+        const executionExtraBody = getOpenAIExtraBody(modelOptions);
+        if (this.options.extraBody || executionExtraBody) {
+            payload.extra_body = { ...this.options.extraBody, ...executionExtraBody };
         }
 
         const toolsPayload = convertToolsToOpenAIChatCompletionsFormat(options.tools, this.options.toolSchemaMode);
@@ -1339,29 +1341,31 @@ function toOpenAISDKMessage(message: OpenAIChatCompletionsRequestMessage): OpenA
 function toOpenAINonStreamingPayload(
     payload: OpenAIChatCompletionsPayload,
 ): OpenAI.Chat.ChatCompletionCreateParamsNonStreaming {
-    const { messages, stream: _stream, ...body } = payload;
-    const request = {
-        ...body,
-        messages: messages.map(toOpenAISDKMessage),
-        stream: false,
-    } satisfies OpenAI.Chat.ChatCompletionCreateParamsNonStreaming & {
-        extra_body?: Record<string, unknown>;
-    };
+    const { messages, stream: _stream, extra_body, ...body } = payload;
+    const request = mergeOpenAIExtraBody(
+        {
+            ...body,
+            messages: messages.map(toOpenAISDKMessage),
+            stream: false,
+        } satisfies OpenAI.Chat.ChatCompletionCreateParamsNonStreaming,
+        extra_body,
+    );
     return request;
 }
 
 function toOpenAIStreamingPayload(
     payload: OpenAIChatCompletionsPayload,
 ): OpenAI.Chat.ChatCompletionCreateParamsStreaming {
-    const { messages, stream: _stream, ...body } = payload;
-    const request = {
-        ...body,
-        messages: messages.map(toOpenAISDKMessage),
-        stream: true,
-        stream_options: { include_usage: true },
-    } satisfies OpenAI.Chat.ChatCompletionCreateParamsStreaming & {
-        extra_body?: Record<string, unknown>;
-    };
+    const { messages, stream: _stream, extra_body, ...body } = payload;
+    const request = mergeOpenAIExtraBody(
+        {
+            ...body,
+            messages: messages.map(toOpenAISDKMessage),
+            stream: true,
+            stream_options: { include_usage: true },
+        } satisfies OpenAI.Chat.ChatCompletionCreateParamsStreaming,
+        extra_body,
+    );
     return request;
 }
 

--- a/drivers/src/openai/responses-reasoning.test.ts
+++ b/drivers/src/openai/responses-reasoning.test.ts
@@ -96,6 +96,36 @@ describe('OpenAI Responses reasoning', () => {
         );
     });
 
+    it('merges provider-specific extra body fields without allowing core request overrides', async () => {
+        const create = vi.fn(async (_request: unknown) => response());
+        const driver = new TestResponsesDriver(create, Providers.openai_compatible);
+
+        await driver.requestTextCompletion([{ type: 'message', role: 'user', content: 'question' }], {
+            model: 'openrouter/model',
+            model_options: {
+                _option_id: 'openai-text',
+                max_tokens: 256,
+                extra_body: {
+                    provider: { sort: 'throughput', allow_fallbacks: false },
+                    baseten: { performance: 'max' },
+                    model: 'must-not-override',
+                    stream: true,
+                },
+            },
+        });
+
+        expect(create).toHaveBeenCalledWith(
+            expect.objectContaining({
+                model: 'openrouter/model',
+                stream: false,
+                max_output_tokens: 256,
+                provider: { sort: 'throughput', allow_fallbacks: false },
+                baseten: { performance: 'max' },
+            }),
+        );
+        expect(create.mock.calls[0][0]).not.toHaveProperty('extra_body');
+    });
+
     it.each(['gpt-5.4', 'gpt-5.5', 'gpt-5.6', 'gpt-5.6-sol', 'gpt-5.7'])(
         'uses current-turn reasoning context for %s',
         async (model) => {

--- a/drivers/src/openrouter/index.test.ts
+++ b/drivers/src/openrouter/index.test.ts
@@ -1,0 +1,328 @@
+import { Base64DataSource, ModelType, PromptRole, Providers } from '@llumiverse/core';
+import { RequestTimeoutError } from '@openrouter/sdk/models/errors';
+import { describe, expect, it, vi } from 'vitest';
+import { OpenRouterDriver } from './index.js';
+
+function setService(driver: OpenRouterDriver, service: unknown): void {
+    driver.service = service as OpenRouterDriver['service'];
+}
+
+describe('OpenRouterDriver native SDK transport', () => {
+    it('requires an API key', () => {
+        expect(() => new OpenRouterDriver({ apiKey: '' })).toThrow('apiKey is required');
+    });
+
+    it('maps chat, structured output, tools, timeout, and the native response', async () => {
+        const driver = new OpenRouterDriver({ apiKey: 'test-key' });
+        const response = {
+            id: 'generation-1',
+            object: 'chat.completion' as const,
+            created: 1,
+            model: 'anthropic/claude-sonnet-5',
+            serviceTier: 'priority',
+            systemFingerprint: null,
+            choices: [
+                {
+                    index: 0,
+                    finishReason: 'tool_calls',
+                    logprobs: null,
+                    message: {
+                        role: 'assistant' as const,
+                        content: null,
+                        reasoning: 'checking',
+                        toolCalls: [
+                            {
+                                id: 'call_1',
+                                type: 'function' as const,
+                                function: { name: 'lookup', arguments: '{"city":"Paris"}' },
+                            },
+                        ],
+                    },
+                },
+            ],
+            usage: { promptTokens: 4, completionTokens: 3, totalTokens: 7 },
+        };
+        const send = vi.fn(async (_request: unknown, _options?: unknown) => response);
+        setService(driver, { chat: { send } });
+
+        const completion = await driver.requestTextCompletion(
+            {
+                _is_openai_chat_completions: true,
+                messages: [
+                    {
+                        role: 'user',
+                        content: [
+                            { type: 'text', text: 'Weather?' },
+                            { type: 'image_url', image_url: { url: 'https://example.test/map.png' } },
+                        ],
+                    },
+                ],
+            },
+            {
+                model: response.model,
+                httpTimeout: { headersTimeout: 1_200_000, bodyTimeout: 1_800_000 },
+                include_original_response: true,
+                model_options: {
+                    _option_id: 'openrouter-text',
+                    max_tokens: 64,
+                    effort: 'high',
+                    service_tier: 'priority',
+                    provider_sort: 'throughput',
+                    provider_order: ['google-vertex', 'amazon-bedrock'],
+                    provider_allow_fallbacks: false,
+                },
+                result_schema: {
+                    type: 'object',
+                    properties: { answer: { type: 'string' } },
+                    required: ['answer'],
+                },
+                tools: [{ name: 'lookup', description: 'Lookup weather', input_schema: { type: 'object' } }],
+            },
+        );
+
+        const [request, requestOptions] = send.mock.calls[0];
+        expect(request).toMatchObject({
+            chatRequest: {
+                model: response.model,
+                maxTokens: 64,
+                reasoningEffort: 'high',
+                serviceTier: 'priority',
+                stream: false,
+                messages: [
+                    {
+                        role: 'user',
+                        content: [
+                            { type: 'text', text: 'Weather?' },
+                            { type: 'image_url', imageUrl: { url: 'https://example.test/map.png' } },
+                        ],
+                    },
+                ],
+                responseFormat: {
+                    type: 'json_schema',
+                    jsonSchema: expect.objectContaining({ name: 'output', strict: false }),
+                },
+                provider: {
+                    sort: 'throughput',
+                    order: ['google-vertex', 'amazon-bedrock'],
+                    allowFallbacks: false,
+                },
+                tools: [
+                    {
+                        type: 'function',
+                        function: expect.objectContaining({ name: 'lookup' }),
+                    },
+                ],
+            },
+        });
+        expect(requestOptions).toEqual({ timeoutMs: 1_800_000 });
+        expect(completion).toMatchObject({
+            finish_reason: 'tool_use',
+            token_usage: { prompt: 4, result: 3, total: 7 },
+            tool_use: [{ id: 'call_1', tool_name: 'lookup', tool_input: { city: 'Paris' } }],
+            original_response: response,
+        });
+    });
+
+    it('normalizes streaming reasoning, tool calls, usage, and cancellation', async () => {
+        const driver = new OpenRouterDriver({ apiKey: 'test-key' });
+        const cancel = vi.fn(async () => undefined);
+        const chunks = [
+            {
+                id: 'chunk-1',
+                object: 'chat.completion.chunk' as const,
+                created: 1,
+                model: 'openai/gpt-5.6-sol',
+                choices: [
+                    {
+                        index: 0,
+                        finishReason: null,
+                        delta: {
+                            role: 'assistant' as const,
+                            reasoning: 'thinking',
+                            toolCalls: [
+                                {
+                                    index: 0,
+                                    id: 'call_actual',
+                                    type: 'function' as const,
+                                    function: { name: 'lookup', arguments: '{"city"' },
+                                },
+                            ],
+                        },
+                    },
+                ],
+            },
+            {
+                id: 'chunk-2',
+                object: 'chat.completion.chunk' as const,
+                created: 1,
+                model: 'openai/gpt-5.6-sol',
+                choices: [
+                    {
+                        index: 0,
+                        finishReason: 'tool_calls',
+                        delta: {
+                            toolCalls: [{ index: 0, function: { name: '', arguments: ':"Paris"}' } }],
+                        },
+                    },
+                ],
+                usage: { promptTokens: 2, completionTokens: 1, totalTokens: 3 },
+            },
+        ];
+        const nativeStream = {
+            cancel,
+            async *[Symbol.asyncIterator]() {
+                yield* chunks;
+            },
+        };
+        const send = vi.fn(async (_request: unknown, _options?: unknown) => nativeStream);
+        setService(driver, { chat: { send } });
+
+        const options = {
+            model: 'openai/gpt-5.6-sol',
+            tools: [{ name: 'lookup', input_schema: { type: 'object' } }],
+        };
+        const stream = await driver.stream([{ role: PromptRole.user, content: 'Weather?' }], options);
+        for await (const _chunk of stream) {
+            // Consume all native chunks so the final completion and conversation are assembled.
+        }
+
+        expect(send.mock.calls[0][0]).toEqual({
+            chatRequest: expect.objectContaining({
+                stream: true,
+                streamOptions: { includeUsage: true },
+            }),
+        });
+        expect(stream.completion?.result).toContainEqual({ type: 'thoughts', value: 'thinking' });
+        expect(stream.completion?.token_usage).toEqual({ prompt: 2, result: 1, total: 3 });
+        expect(stream.completion?.tool_use).toEqual([
+            { id: 'call_actual', tool_name: 'lookup', tool_input: { city: 'Paris' } },
+        ]);
+    });
+
+    it('maps the native model catalog and excludes dedicated inference models', async () => {
+        const driver = new OpenRouterDriver({ apiKey: 'test-key' });
+        const models = [
+            openRouterModel({
+                id: 'future-lab/vision-chat-v1',
+                name: 'Vision Chat',
+                inputModalities: ['text', 'image'],
+                outputModalities: ['text'],
+                supportedParameters: ['tools'],
+            }),
+            openRouterModel({
+                id: 'openai/text-embedding-3-small',
+                name: 'Embedding',
+                inputModalities: ['text'],
+                outputModalities: ['embeddings'],
+            }),
+            openRouterModel({
+                id: 'openai/gpt-image-1',
+                name: 'Image',
+                inputModalities: ['text'],
+                outputModalities: ['image'],
+            }),
+        ];
+        const list = vi.fn(async () => ({ result: { data: models } }));
+        setService(driver, { models: { list } });
+
+        await expect(driver.listModels()).resolves.toEqual([
+            expect.objectContaining({
+                id: 'future-lab/vision-chat-v1',
+                name: 'Vision Chat',
+                owner: 'future-lab',
+                provider: Providers.openrouter,
+                type: ModelType.Text,
+                input_modalities: ['text', 'image'],
+                output_modalities: ['text'],
+                is_multimodal: true,
+                tool_support: true,
+            }),
+        ]);
+        expect(list).toHaveBeenCalledWith({ limit: 1_000 });
+    });
+
+    it('uses the native embeddings transport and preserves input order', async () => {
+        const driver = new OpenRouterDriver({ apiKey: 'test-key' });
+        const generate = vi.fn(async () => ({
+            object: 'list' as const,
+            model: 'openai/text-embedding-3-small',
+            data: [
+                { object: 'embedding' as const, index: 1, embedding: [0.3, 0.4] },
+                { object: 'embedding' as const, index: 0, embedding: [0.1, 0.2] },
+                { object: 'embedding' as const, index: 2, embedding: [0.5, 0.6] },
+            ],
+            usage: {
+                promptTokens: 5,
+                totalTokens: 5,
+                promptTokensDetails: { textTokens: 3, imageTokens: 2 },
+            },
+        }));
+        setService(driver, { embeddings: { generate } });
+
+        const result = await driver.generateEmbeddings({
+            model: 'openai/text-embedding-3-small',
+            dimensions: 128,
+            task_type: 'query',
+            inputs: [
+                { type: 'text', text: 'first' },
+                { type: 'text', text: 'second' },
+                { type: 'image', source: new Base64DataSource('pixel.png', 'image/png', 'aW1hZ2U=') },
+            ],
+        });
+
+        expect(generate).toHaveBeenCalledWith({
+            requestBody: {
+                model: 'openai/text-embedding-3-small',
+                input: [
+                    { content: [{ type: 'text', text: 'first' }] },
+                    { content: [{ type: 'text', text: 'second' }] },
+                    { content: [{ type: 'image_url', imageUrl: { url: 'data:image/png;base64,aW1hZ2U=' } }] },
+                ],
+                inputType: 'query',
+                dimensions: 128,
+                encodingFormat: 'float',
+            },
+        });
+        expect(result).toEqual({
+            model: 'openai/text-embedding-3-small',
+            results: [
+                { outputs: [{ values: [0.1, 0.2], modality: 'text' }] },
+                { outputs: [{ values: [0.3, 0.4], modality: 'text' }] },
+                { outputs: [{ values: [0.5, 0.6], modality: 'image' }] },
+            ],
+            usage: { input_tokens: 5, input_text_tokens: 3, input_image_tokens: 2 },
+        });
+    });
+
+    it('classifies native request timeouts as retryable', () => {
+        const driver = new OpenRouterDriver({ apiKey: 'test-key' });
+        const error = driver.formatLlumiverseError(new RequestTimeoutError('timed out'), {
+            provider: driver.provider,
+            model: 'openai/gpt-5.6-sol',
+            operation: 'execute',
+        });
+
+        expect(error).toMatchObject({ name: 'RequestTimeoutError', retryable: true });
+    });
+});
+
+interface OpenRouterModelFixture {
+    id: string;
+    name: string;
+    inputModalities: string[];
+    outputModalities: string[];
+    supportedParameters?: string[];
+}
+
+function openRouterModel(fixture: OpenRouterModelFixture): Record<string, unknown> {
+    return {
+        id: fixture.id,
+        name: fixture.name,
+        description: `${fixture.name} description`,
+        architecture: {
+            inputModalities: fixture.inputModalities,
+            outputModalities: fixture.outputModalities,
+        },
+        supportedParameters: fixture.supportedParameters ?? [],
+    };
+}

--- a/drivers/src/openrouter/index.ts
+++ b/drivers/src/openrouter/index.ts
@@ -1,0 +1,502 @@
+import {
+    type AIModel,
+    dataSourceToBase64,
+    type EmbeddingResultItem,
+    type EmbeddingsOptions,
+    type EmbeddingsResult,
+    type ExecutionOptions,
+    isDedicatedInferenceModel,
+    isEmbeddingModel,
+    ModelType,
+    normalizeEmbeddingsOptions,
+    Providers,
+} from '@llumiverse/core';
+import { HTTPClient, OpenRouter } from '@openrouter/sdk';
+import type {
+    ChatContentItems,
+    ChatFunctionTool,
+    ChatMessages,
+    ChatRequest,
+    ChatResult,
+    ChatStreamChunk,
+    ChatUsage,
+    Model as OpenRouterModel,
+    ProviderPreferences,
+} from '@openrouter/sdk/models';
+import type { Input as OpenRouterEmbeddingInput } from '@openrouter/sdk/models/operations';
+import {
+    OpenAIChatCompletionsDriverBase,
+    type OpenAIChatCompletionsDriverOptions,
+    type OpenAIChatCompletionsPayload,
+    type OpenAIChatCompletionsRequestMessage,
+    type OpenAIChatCompletionsResponse,
+    type OpenAIChatCompletionsStreamResponse,
+    openAIChatCompletionsStreamToSSE,
+    preserveOpenAIChatCompletionsOriginalResponse,
+} from '../openai/openai_chat_completions.js';
+import { resolveModelListingMetadata } from '../shared/model-listing.js';
+
+export interface OpenRouterDriverOptions extends OpenAIChatCompletionsDriverOptions {
+    apiKey: string;
+    endpoint?: string;
+    httpReferer?: string;
+    appTitle?: string;
+    appCategories?: string;
+}
+
+/** OpenRouter transport backed by the provider's native TypeScript SDK. */
+export class OpenRouterDriver extends OpenAIChatCompletionsDriverBase<OpenRouterDriverOptions> {
+    static readonly PROVIDER = Providers.openrouter;
+    readonly provider = Providers.openrouter;
+    service: OpenRouter;
+
+    constructor(options: OpenRouterDriverOptions) {
+        super({ ...options, resultSchemaMode: 'response_format', toolSchemaMode: 'compatible' });
+        if (!options.apiKey) {
+            throw new Error('apiKey is required');
+        }
+
+        this.service = new OpenRouter({
+            apiKey: options.apiKey,
+            ...(options.endpoint ? { serverURL: options.endpoint } : {}),
+            ...(options.httpReferer ? { httpReferer: options.httpReferer } : {}),
+            ...(options.appTitle ? { appTitle: options.appTitle } : {}),
+            ...(options.appCategories ? { appCategories: options.appCategories } : {}),
+            httpClient: new HTTPClient({ fetcher: this.getDriverFetch() }),
+            retryConfig: { strategy: 'none' },
+            timeoutMs: this.getDriverRequestTimeoutMs(),
+        });
+    }
+
+    async _postChatCompletion(
+        payload: OpenAIChatCompletionsPayload,
+        options: ExecutionOptions,
+        signal?: AbortSignal,
+    ): Promise<OpenAIChatCompletionsResponse> {
+        const response = await this.service.chat.send(
+            { chatRequest: toOpenRouterRequest(payload, false, options.model_options) },
+            this.getOpenRouterRequestOptions(options, signal),
+        );
+        const result = asOpenRouterChatResult(response);
+        return preserveOpenAIChatCompletionsOriginalResponse(normalizeOpenRouterResponse(result), result);
+    }
+
+    async _postChatCompletionStream(
+        payload: OpenAIChatCompletionsPayload,
+        options: ExecutionOptions,
+        signal?: AbortSignal,
+    ): Promise<ReadableStream> {
+        const response = await this.service.chat.send(
+            { chatRequest: toOpenRouterRequest(payload, true, options.model_options) },
+            this.getOpenRouterRequestOptions(options, signal),
+        );
+        const stream = asOpenRouterChatStream(response);
+        return openAIChatCompletionsStreamToSSE(normalizeOpenRouterStream(stream), () => void stream.cancel());
+    }
+
+    async listModels(): Promise<AIModel[]> {
+        const page = await this.service.models.list({ limit: 1_000 });
+        return page.result.data
+            .filter((model) => isOpenRouterChatModel(model, this.provider))
+            .map((model) => {
+                const metadata = resolveModelListingMetadata(model.id, this.provider, {
+                    input_modalities: model.architecture.inputModalities,
+                    output_modalities: model.architecture.outputModalities,
+                });
+                return {
+                    id: model.id,
+                    name: model.name,
+                    description: model.description,
+                    owner: model.id.split('/')[0],
+                    provider: this.provider,
+                    type: ModelType.Text,
+                    can_stream: true,
+                    is_multimodal: metadata.input_modalities.length > 1,
+                    ...metadata,
+                    tool_support: metadata.tool_support ?? model.supportedParameters.includes('tools'),
+                } satisfies AIModel;
+            })
+            .sort((left, right) => left.id.localeCompare(right.id));
+    }
+
+    async validateConnection(): Promise<boolean> {
+        try {
+            await this.service.models.list({ limit: 1 });
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    async generateEmbeddings(options: EmbeddingsOptions): Promise<EmbeddingsResult> {
+        const normalized = normalizeEmbeddingsOptions(options);
+        if (!normalized.model) {
+            throw new Error("Provider 'openrouter' requires an explicit embedding model.");
+        }
+        const inputs = await Promise.all(normalized.inputs.map(toOpenRouterEmbeddingInput));
+        const response = await this.service.embeddings.generate({
+            requestBody: {
+                model: normalized.model,
+                input: inputs,
+                encodingFormat: 'float',
+                ...(normalized.dimensions !== undefined ? { dimensions: normalized.dimensions } : {}),
+                ...(normalized.task_type ? { inputType: normalized.task_type } : {}),
+            },
+        });
+        if (typeof response === 'string') {
+            throw new Error(`OpenRouter embeddings returned an unexpected text response: ${response}`);
+        }
+
+        const results = [...response.data]
+            .sort((left, right) => (left.index ?? 0) - (right.index ?? 0))
+            .map((entry, index): EmbeddingResultItem => {
+                if (!Array.isArray(entry.embedding) || entry.embedding.length === 0) {
+                    throw new Error(`OpenRouter embedding empty or non-float for input index ${entry.index ?? index}`);
+                }
+                const inputIndex = entry.index ?? index;
+                const sourceInput = normalized.inputs[inputIndex];
+                if (!sourceInput) {
+                    throw new Error(`OpenRouter embedding references unknown input index ${inputIndex}`);
+                }
+                return { outputs: [{ values: entry.embedding, modality: sourceInput.type }] };
+            });
+        const promptTokenDetails = response.usage?.promptTokensDetails;
+        const onlyTextInputs = normalized.inputs.every((input) => input.type === 'text');
+        return {
+            model: response.model,
+            results,
+            ...(response.usage
+                ? {
+                      usage: {
+                          input_tokens: response.usage.promptTokens,
+                          ...(promptTokenDetails?.textTokens !== undefined || onlyTextInputs
+                              ? { input_text_tokens: promptTokenDetails?.textTokens ?? response.usage.promptTokens }
+                              : {}),
+                          ...(promptTokenDetails?.imageTokens !== undefined
+                              ? { input_image_tokens: promptTokenDetails.imageTokens }
+                              : {}),
+                      },
+                  }
+                : {}),
+        };
+    }
+
+    private getOpenRouterRequestOptions(
+        options: ExecutionOptions,
+        signal?: AbortSignal,
+    ): { signal?: AbortSignal; timeoutMs?: number } | undefined {
+        const timeoutMs = options.httpTimeout ? this.getDriverRequestTimeoutMs(options.httpTimeout) : undefined;
+        if (signal && timeoutMs !== undefined) return { signal, timeoutMs };
+        if (signal) return { signal };
+        if (timeoutMs !== undefined) return { timeoutMs };
+        return undefined;
+    }
+}
+
+async function toOpenRouterEmbeddingInput(
+    input: EmbeddingsOptions['inputs'][number],
+): Promise<OpenRouterEmbeddingInput> {
+    switch (input.type) {
+        case 'text':
+            return { content: [{ type: 'text', text: input.text }] };
+        case 'image':
+            return { content: [{ type: 'image_url', imageUrl: { url: await input.source.getURL() } }] };
+        case 'audio':
+            return {
+                content: [
+                    {
+                        type: 'input_audio',
+                        inputAudio: {
+                            data: await dataSourceToBase64(input.source),
+                            format: mediaFormat(input.source.mime_type),
+                        },
+                    },
+                ],
+            };
+        case 'video':
+            return {
+                content: [
+                    {
+                        type: 'input_video',
+                        inputVideo: {
+                            data: await dataSourceToBase64(input.source),
+                            format: mediaFormat(input.source.mime_type),
+                        },
+                    },
+                ],
+            };
+    }
+}
+
+function mediaFormat(mimeType: string): string {
+    return mimeType.split('/')[1] ?? mimeType;
+}
+
+function toOpenRouterRequest(
+    payload: OpenAIChatCompletionsPayload,
+    stream: false,
+    modelOptions: ExecutionOptions['model_options'],
+): ChatRequest & { stream: false };
+function toOpenRouterRequest(
+    payload: OpenAIChatCompletionsPayload,
+    stream: true,
+    modelOptions: ExecutionOptions['model_options'],
+): ChatRequest & { stream: true };
+function toOpenRouterRequest(
+    payload: OpenAIChatCompletionsPayload,
+    stream: boolean,
+    modelOptions: ExecutionOptions['model_options'],
+): ChatRequest {
+    return {
+        model: payload.model,
+        messages: payload.messages.map(toOpenRouterMessage),
+        maxTokens: payload.max_tokens ?? undefined,
+        temperature: payload.temperature ?? undefined,
+        topP: payload.top_p ?? undefined,
+        presencePenalty: payload.presence_penalty ?? undefined,
+        frequencyPenalty: payload.frequency_penalty ?? undefined,
+        stop: payload.stop ?? undefined,
+        seed: payload.seed ?? undefined,
+        reasoningEffort: payload.reasoning_effort,
+        serviceTier: payload.service_tier,
+        tools: payload.tools?.flatMap(toOpenRouterTool),
+        responseFormat: toOpenRouterResponseFormat(payload.response_format),
+        provider: toOpenRouterProviderPreferences(modelOptions),
+        stream,
+        ...(stream ? { streamOptions: { includeUsage: true } } : {}),
+    } as ChatRequest;
+}
+
+function toOpenRouterProviderPreferences(options: ExecutionOptions['model_options']): ProviderPreferences | undefined {
+    if (options?._option_id !== 'openrouter-text') return undefined;
+    const preferences: ProviderPreferences = {
+        sort: options.provider_sort,
+        order: options.provider_order,
+        only: options.provider_only,
+        ignore: options.provider_ignore,
+        allowFallbacks: options.provider_allow_fallbacks,
+        requireParameters: options.provider_require_parameters,
+        dataCollection: options.provider_data_collection,
+        zdr: options.provider_zdr,
+        quantizations: options.provider_quantizations,
+    };
+    return Object.values(preferences).some((value) => value !== undefined) ? preferences : undefined;
+}
+
+function toOpenRouterMessage(message: OpenAIChatCompletionsRequestMessage): ChatMessages {
+    const content = toOpenRouterContent(message.content);
+    switch (message.role) {
+        case 'assistant':
+            return {
+                role: 'assistant',
+                content,
+                reasoning: message.reasoning ?? message.reasoning_content,
+                toolCalls: message.tool_calls?.map((toolCall) => ({
+                    id: toolCall.id,
+                    type: 'function',
+                    function: toolCall.function,
+                })),
+            };
+        case 'developer':
+        case 'system':
+            return { role: message.role, content: toOpenRouterTextContent(message.content) };
+        case 'tool':
+            if (!message.tool_call_id) {
+                throw new TypeError('OpenRouter tool messages require tool_call_id');
+            }
+            return { role: 'tool', content: content ?? '', toolCallId: message.tool_call_id };
+        case 'user':
+            if (content === null || content === undefined) {
+                throw new TypeError('OpenRouter user messages require content');
+            }
+            return { role: 'user', content };
+        default:
+            throw new TypeError(`Unsupported OpenRouter message role: ${message.role}`);
+    }
+}
+
+function toOpenRouterContent(
+    content: OpenAIChatCompletionsRequestMessage['content'],
+): string | ChatContentItems[] | null | undefined {
+    if (!Array.isArray(content)) return content;
+    return content.map((part) =>
+        part.type === 'text'
+            ? { type: 'text' as const, text: part.text }
+            : { type: 'image_url' as const, imageUrl: { ...part.image_url } },
+    );
+}
+
+function toOpenRouterTextContent(
+    content: OpenAIChatCompletionsRequestMessage['content'],
+): string | { type: 'text'; text: string }[] {
+    if (typeof content === 'string') return content;
+    if (!Array.isArray(content)) return '';
+    return content.flatMap((part) => (part.type === 'text' ? [{ type: 'text' as const, text: part.text }] : []));
+}
+
+function toOpenRouterTool(tool: NonNullable<OpenAIChatCompletionsPayload['tools']>[number]): ChatFunctionTool[] {
+    if (tool.type !== 'function') return [];
+    return [
+        {
+            type: 'function',
+            function: {
+                name: tool.function.name,
+                description: tool.function.description,
+                parameters: tool.function.parameters ?? undefined,
+                strict: tool.function.strict,
+            },
+        },
+    ];
+}
+
+function toOpenRouterResponseFormat(
+    responseFormat: OpenAIChatCompletionsPayload['response_format'],
+): ChatRequest['responseFormat'] {
+    if (!responseFormat) return undefined;
+    if (responseFormat.type === 'json_schema') {
+        return {
+            type: 'json_schema',
+            jsonSchema: {
+                name: responseFormat.json_schema.name,
+                description: responseFormat.json_schema.description,
+                schema: responseFormat.json_schema.schema,
+                strict: responseFormat.json_schema.strict,
+            },
+        };
+    }
+    if (responseFormat.type === 'json_object') return { type: 'json_object' };
+    return { type: 'text' };
+}
+
+function normalizeOpenRouterResponse(response: ChatResult): OpenAIChatCompletionsResponse {
+    return {
+        id: response.id,
+        object: response.object,
+        created: response.created,
+        model: response.model,
+        service_tier: response.serviceTier as OpenAIChatCompletionsResponse['service_tier'],
+        system_fingerprint: response.systemFingerprint ?? undefined,
+        choices: response.choices.map((choice) => ({
+            index: choice.index,
+            finish_reason: choice.finishReason,
+            logprobs: choice.logprobs,
+            message: {
+                role: choice.message.role,
+                content: fromOpenRouterContent(choice.message.content),
+                reasoning: choice.message.reasoning,
+                tool_calls: choice.message.toolCalls?.map((toolCall) => ({
+                    id: toolCall.id,
+                    type: 'function',
+                    function: toolCall.function,
+                })),
+            },
+        })),
+        usage: normalizeOpenRouterChatUsage(response.usage),
+    };
+}
+
+async function* normalizeOpenRouterStream(
+    stream: AsyncIterable<ChatStreamChunk>,
+): AsyncIterable<OpenAIChatCompletionsStreamResponse> {
+    for await (const chunk of stream) {
+        if (chunk.error) {
+            throw new OpenRouterStreamError(chunk.error.message, chunk.error.code);
+        }
+        yield {
+            id: chunk.id,
+            object: chunk.object,
+            created: chunk.created,
+            model: chunk.model,
+            service_tier: chunk.serviceTier as OpenAIChatCompletionsStreamResponse['service_tier'],
+            system_fingerprint: chunk.systemFingerprint,
+            choices: chunk.choices.map((choice) => ({
+                index: choice.index,
+                finish_reason: choice.finishReason,
+                logprobs: choice.logprobs,
+                delta: {
+                    role: choice.delta.role,
+                    content: choice.delta.content,
+                    reasoning: choice.delta.reasoning,
+                    tool_calls: choice.delta.toolCalls?.map((toolCall) => ({
+                        index: toolCall.index,
+                        id: toolCall.id,
+                        type: toolCall.type,
+                        function: toolCall.function,
+                    })),
+                },
+            })),
+            usage: normalizeOpenRouterChatUsage(chunk.usage),
+        };
+    }
+}
+
+function normalizeOpenRouterChatUsage(usage: ChatUsage | undefined): OpenAIChatCompletionsResponse['usage'] {
+    return usage
+        ? {
+              prompt_tokens: usage.promptTokens,
+              completion_tokens: usage.completionTokens,
+              total_tokens: usage.totalTokens,
+          }
+        : undefined;
+}
+
+function fromOpenRouterContent(
+    content: ChatResult['choices'][number]['message']['content'],
+): OpenAIChatCompletionsResponse['choices'][number]['message']['content'] {
+    if (!Array.isArray(content)) return content;
+    const result: NonNullable<OpenAIChatCompletionsResponse['choices'][number]['message']['content']> = [];
+    for (const part of content) {
+        if (part.type === 'text' && 'text' in part) result.push({ type: 'text', text: part.text });
+        if (part.type === 'image_url' && 'imageUrl' in part) {
+            const nativeDetail = part.imageUrl.detail as string | undefined;
+            const detail: 'auto' | 'low' | 'high' | undefined =
+                nativeDetail === 'auto' || nativeDetail === 'low' || nativeDetail === 'high'
+                    ? nativeDetail
+                    : nativeDetail
+                      ? 'high'
+                      : undefined;
+            result.push({
+                type: 'image_url',
+                image_url: { url: part.imageUrl.url, ...(detail ? { detail } : {}) },
+            });
+        }
+    }
+    return result;
+}
+
+type OpenRouterChatStream = AsyncIterable<ChatStreamChunk> & { cancel(): Promise<void> };
+
+function asOpenRouterChatResult(response: ChatResult | OpenRouterChatStream): ChatResult {
+    if ('choices' in response) return response;
+    throw new TypeError('OpenRouter returned a stream for a non-streaming chat request');
+}
+
+function asOpenRouterChatStream(response: ChatResult | OpenRouterChatStream): OpenRouterChatStream {
+    if (Symbol.asyncIterator in response) return response;
+    throw new TypeError('OpenRouter returned a non-streaming result for a streaming chat request');
+}
+
+function isOpenRouterChatModel(model: OpenRouterModel, provider: Providers): boolean {
+    return (
+        model.architecture.outputModalities.includes('text') &&
+        !isEmbeddingModel(
+            {
+                id: model.id,
+                input_modalities: model.architecture.inputModalities,
+                output_modalities: model.architecture.outputModalities,
+            },
+            provider,
+        ) &&
+        !isDedicatedInferenceModel(model.id, provider)
+    );
+}
+
+class OpenRouterStreamError extends Error {
+    readonly statusCode: number;
+
+    constructor(message: string, statusCode: number) {
+        super(message);
+        this.name = 'OpenRouterStreamError';
+        this.statusCode = statusCode;
+    }
+}

--- a/drivers/test/model-smoke.live.test.ts
+++ b/drivers/test/model-smoke.live.test.ts
@@ -18,7 +18,7 @@ import {
     GroqDriver,
     MistralAIDriver,
     OpenAIDriver,
-    OpenAIResponsesDriver,
+    OpenRouterDriver,
     TogetherAIDriver,
     VertexAIDriver,
     WatsonxDriver,
@@ -174,9 +174,8 @@ if (process.env.WATSONX_API_KEY) {
 if (process.env.OPENROUTER_API_KEY) {
     drivers.push({
         name: 'openrouter',
-        driver: new OpenAIResponsesDriver({
+        driver: new OpenRouterDriver({
             apiKey: process.env.OPENROUTER_API_KEY,
-            endpoint: 'https://openrouter.ai/api/v1',
         }),
         models: [
             'moonshotai/kimi-k2.5',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,9 @@ importers:
       '@mistralai/mistralai':
         specifier: ^2.6.3
         version: 2.6.3(@opentelemetry/api@1.9.1)
+      '@openrouter/sdk':
+        specifier: ^1.2.54
+        version: 1.2.59
       '@vertesia/api-fetch-client':
         specifier: ^1.4.1
         version: 1.4.1
@@ -679,6 +682,9 @@ packages:
 
   '@nodable/entities@2.1.0':
     resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
+
+  '@openrouter/sdk@1.2.59':
+    resolution: {integrity: sha512-BpSFoIMbk32ZYcywa9GSUul9dCAy6uWLOSkBBnjF5waql1WRPMmtjEFhJifkL8mteFJfRjZyVMuZtxfDO/10bA==}
 
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
@@ -2853,6 +2859,10 @@ snapshots:
     optional: true
 
   '@nodable/entities@2.1.0': {}
+
+  '@openrouter/sdk@1.2.59':
+    dependencies:
+      zod: 4.4.3
 
   '@opentelemetry/api@1.9.1': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ packages:
   - ./examples
 verifyDepsBeforeRun: false
 allowBuilds:
+  '@openrouter/sdk': false
   '@google/genai': true
   esbuild: true
   protobufjs: true


### PR DESCRIPTION
## Summary
- add a native OpenRouter provider and `@openrouter/sdk` transport
- expose typed provider ordering, filtering, fallback, privacy, and quantization controls
- allow arbitrary provider-specific request fields through OpenAI-compatible `extra_body`
- cover native request conversion, streaming, tool calls, structured outputs, errors, and model listing

## Test Plan
- [x] `pnpm --filter @llumiverse/common lint`
- [x] `pnpm --filter @llumiverse/common build`
- [x] `pnpm --filter @llumiverse/common typecheck:test`
- [x] `pnpm --filter @llumiverse/common test` (241 passed)
- [x] `pnpm --filter @llumiverse/core build`
- [x] `pnpm --filter @llumiverse/drivers lint`
- [x] `pnpm --filter @llumiverse/drivers build`
- [x] `pnpm --filter @llumiverse/drivers typecheck:test`
- [x] `pnpm --filter @llumiverse/drivers test` (638 passed, 19 skipped)

Live provider smoke testing was not run because no OpenRouter API key was available in the local environment.
