### PR TITLE
fix: reject malformed streamed tool calls

### DIFF
--- a/core/src/CompletionStream.ts
+++ b/core/src/CompletionStream.ts
@@ -14,6 +14,50 @@ import type { AbstractDriver } from './Driver.js';
 
 type StreamingToolUse = ToolUse<unknown> & { _actual_id?: string };
 
+export function finalizeStreamingToolUse(
+    toolUseArray: StreamingToolUse[] | undefined,
+    finishReason: string | undefined,
+    context: { provider: string; model: string },
+): ToolUse<unknown>[] | undefined {
+    if (!toolUseArray) return undefined;
+
+    const malformedToolIds = new Set<string>();
+    let parseError: unknown;
+    for (const tool of toolUseArray) {
+        if (tool._actual_id) {
+            tool.id = tool._actual_id;
+            delete tool._actual_id;
+        }
+        if (typeof tool.tool_input === 'string') {
+            try {
+                tool.tool_input = JSON.parse(tool.tool_input);
+            } catch (error: unknown) {
+                malformedToolIds.add(tool.id);
+                parseError ??= error;
+            }
+        }
+    }
+
+    if (malformedToolIds.size === 0) return toolUseArray;
+
+    // A length stop means the model ran out of tokens mid-call. The partial call must not be
+    // returned, but other complete calls from the same response remain usable.
+    if (finishReason === 'length') {
+        const completeTools = toolUseArray.filter((tool) => !malformedToolIds.has(tool.id));
+        return completeTools.length > 0 ? completeTools : undefined;
+    }
+
+    // Without an explicit length stop, malformed arguments indicate an incomplete or corrupt
+    // provider stream. Never coerce them to {}, because that can execute a tool with invented
+    // arguments. Surface a retryable stream error instead.
+    throw new LlumiverseError(
+        `[${context.provider}] Received malformed JSON arguments for a streamed tool call`,
+        true,
+        { ...context, operation: 'stream' },
+        parseError,
+    );
+}
+
 /**
  * Merge a single streamed `tool_use` fragment into the accumulator map keyed by tool id.
  *
@@ -269,40 +313,11 @@ export class DefaultCompletionStream<PromptT = unknown> implements CompletionStr
                   }
                 : undefined;
 
-        // Convert accumulated tool_use Map to array
-        let toolUseArray = accumulatedToolUse.size > 0 ? Array.from(accumulatedToolUse.values()) : undefined;
-
-        // Finalize tool calls: restore actual IDs and parse JSON arguments
-        if (toolUseArray) {
-            const truncatedToolIds = new Set<string>();
-            for (const tool of toolUseArray) {
-                // Restore actual ID from OpenAI (was stored in _actual_id during streaming)
-                if (tool._actual_id) {
-                    tool.id = tool._actual_id;
-                    delete tool._actual_id;
-                }
-                // Parse tool_input strings as JSON if needed (streaming sends arguments as string chunks)
-                if (typeof tool.tool_input === 'string') {
-                    try {
-                        tool.tool_input = JSON.parse(tool.tool_input);
-                    } catch {
-                        // JSON parse failed — tool_input was likely truncated by max_tokens.
-                        // Set to empty object to prevent string tool_input from corrupting the conversation.
-                        tool.tool_input = {};
-                        truncatedToolIds.add(tool.id);
-                    }
-                }
-            }
-
-            // If finish_reason is "length" (max_tokens hit), drop truncated tool calls entirely —
-            // they were cut off mid-generation and would produce invalid results.
-            if (finish_reason === 'length' && truncatedToolIds.size > 0) {
-                toolUseArray = toolUseArray.filter((t) => !truncatedToolIds.has(t.id));
-                if (toolUseArray.length === 0) {
-                    toolUseArray = undefined;
-                }
-            }
-        }
+        const toolUseArray = finalizeStreamingToolUse(
+            accumulatedToolUse.size > 0 ? Array.from(accumulatedToolUse.values()) : undefined,
+            finish_reason,
+            { provider: this.driver.provider, model: this.options.model },
+        );
 
         this.completion = {
             result: accumulatedResults, // Return the accumulated CompletionResult[] instead of text

--- a/core/test/tool-use-accumulate-signature.test.ts
+++ b/core/test/tool-use-accumulate-signature.test.ts
@@ -1,6 +1,6 @@
-import type { ToolUse } from '@llumiverse/common';
+import { LlumiverseError, type ToolUse } from '@llumiverse/common';
 import { describe, expect, test } from 'vitest';
-import { accumulateToolUseChunk } from '../src/CompletionStream.js';
+import { accumulateToolUseChunk, finalizeStreamingToolUse } from '../src/CompletionStream.js';
 
 type StreamingToolUse = ToolUse<unknown> & { _actual_id?: string };
 
@@ -84,5 +84,44 @@ describe('streaming tool_use thought_signature reassembly', () => {
 
         // A single-fragment signature must round-trip unchanged (not concatenated with itself).
         expect(result?.thought_signature).toBe(fullSignature);
+    });
+});
+
+describe('streaming tool_use argument finalization', () => {
+    const context = { provider: 'bedrock', model: 'anthropic.claude-sonnet-4-5' };
+
+    test('parses complete streamed JSON arguments', () => {
+        const tools: StreamingToolUse[] = [
+            { id: 'write', tool_name: 'write_artifact', tool_input: '{"name":"report","type":"text"}' },
+        ];
+
+        expect(finalizeStreamingToolUse(tools, 'tool_use', context)).toEqual([
+            {
+                id: 'write',
+                tool_name: 'write_artifact',
+                tool_input: { name: 'report', type: 'text' },
+            },
+        ]);
+    });
+
+    test('rejects malformed arguments as retryable when the stream has no finish reason', () => {
+        const tools: StreamingToolUse[] = [{ id: 'write', tool_name: 'write_artifact', tool_input: '' }];
+
+        try {
+            finalizeStreamingToolUse(tools, undefined, context);
+            throw new Error('Expected malformed tool input to be rejected');
+        } catch (error: unknown) {
+            expect(LlumiverseError.isLlumiverseError(error)).toBe(true);
+            if (LlumiverseError.isLlumiverseError(error)) {
+                expect(error.retryable).toBe(true);
+                expect(error.context).toEqual({ ...context, operation: 'stream' });
+            }
+        }
+    });
+
+    test('drops malformed arguments when the provider reports a length stop', () => {
+        const tools: StreamingToolUse[] = [{ id: 'write', tool_name: 'write_artifact', tool_input: '{"name":' }];
+
+        expect(finalizeStreamingToolUse(tools, 'length', context)).toBeUndefined();
     });
 });

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -1474,7 +1474,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
 
         //If last message is "```json", add corresponding ``` as a stop sequence.
         if (prompt.messages && prompt.messages.length > 0) {
-            if (prompt.messages[prompt.messages.length - 1].content?.[0].text === '```json') {
+            if (prompt.messages[prompt.messages.length - 1].content?.[0]?.text === '```json') {
                 const stopSeq = model_options.stop_sequence;
                 if (!stopSeq) {
                     model_options.stop_sequence = ['```'];

--- a/drivers/test/bedrock-toolconfig-checkpoint.test.ts
+++ b/drivers/test/bedrock-toolconfig-checkpoint.test.ts
@@ -128,6 +128,20 @@ describe('Bedrock - convertToolBlocksToText', () => {
         const result = convertToolBlocksToText(messages);
         expect(result).toEqual(messages);
     });
+
+    test('preparePayload tolerates an empty final message content array', () => {
+        const driver = new BedrockDriver({ region: 'us-east-1' });
+        const prompt: ConverseRequest = {
+            modelId: 'anthropic.claude-sonnet-4-20250514',
+            messages: [{ role: 'assistant', content: [] }],
+        };
+
+        expect(() =>
+            driver.preparePayload(prompt, {
+                model: 'anthropic.claude-sonnet-4-20250514',
+            } as ExecutionOptions),
+        ).not.toThrow();
+    });
 });
 
 // ─── VertexAI Claude ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- reject malformed streamed tool arguments as retryable provider-stream failures
- preserve length-stop behavior by discarding incomplete tool calls
- tolerate empty Bedrock message content while preparing payloads

## Test plan
- [x] core test (145 passed)
- [x] drivers test (313 passed, 19 skipped)
- [x] core and drivers lint
- [x] core and drivers typecheck
- [x] core and drivers build