### PR TITLE
fix: isolate npm snapshot channels

### DIFF
--- a/.github/bin/lib-package-channel.sh
+++ b/.github/bin/lib-package-channel.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Resolve the npm dist-tag owned by a source track. Feature branches never own a
+# shared moving tag; their snapshot tag is derived from the immutable source SHA.
+resolve_package_channel() {
+  local ref="$1"
+  local release_type="$2"
+  local source_sha="$3"
+
+  if [[ ! "$release_type" =~ ^(release|snapshot)$ ]]; then
+    echo "Error: Release type must be 'release' or 'snapshot'." >&2
+    return 1
+  fi
+
+  if [ "$release_type" = "release" ]; then
+    printf '%s\n' "latest"
+    return
+  fi
+
+  if [ "$ref" = "main" ]; then
+    printf '%s\n' "dev"
+    return
+  fi
+
+  if [[ "$ref" =~ ^release/([0-9]+\.[0-9]+)$ ]]; then
+    printf 'dev-%s\n' "${BASH_REMATCH[1]}"
+    return
+  fi
+
+  if [[ ! "$source_sha" =~ ^[0-9a-fA-F]{7,40}$ ]]; then
+    echo "Error: A 7-40 character git SHA is required to publish an isolated branch or tag snapshot." >&2
+    return 1
+  fi
+
+  printf 'snapshot-%s\n' "${source_sha:0:7}"
+}

--- a/.github/bin/lib-package-channel.test.sh
+++ b/.github/bin/lib-package-channel.test.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib-package-channel.sh"
+
+assert_channel() {
+  local expected="$1"
+  shift
+  local actual
+  actual="$(resolve_package_channel "$@")"
+  if [ "$actual" != "$expected" ]; then
+    echo "Expected '$expected', got '$actual' for: $*" >&2
+    exit 1
+  fi
+}
+
+assert_channel latest release/1.5 release 0123456789abcdef0123456789abcdef01234567
+assert_channel dev main snapshot 0123456789abcdef0123456789abcdef01234567
+assert_channel dev-1.5 release/1.5 snapshot 0123456789abcdef0123456789abcdef01234567
+assert_channel snapshot-0123456 1.4 snapshot 0123456789abcdef0123456789abcdef01234567
+assert_channel snapshot-0123456 feat/provider-test snapshot 0123456789abcdef0123456789abcdef01234567
+assert_channel snapshot-0123456 feat/short-sha snapshot 0123456
+
+if resolve_package_channel feat/provider-test snapshot invalid >/dev/null 2>&1; then
+  echo 'Expected an invalid feature-branch SHA to fail' >&2
+  exit 1
+fi
+
+sha_error="$(resolve_package_channel feat/provider-test snapshot invalid 2>&1 || true)"
+if [[ "$sha_error" != *"7-40 character git SHA"* ]]; then
+  echo "Expected the SHA validation error to describe the accepted length, got: $sha_error" >&2
+  exit 1
+fi
+
+if resolve_package_channel main invalid 0123456789abcdef0123456789abcdef01234567 >/dev/null 2>&1; then
+  echo 'Expected an invalid release type to fail' >&2
+  exit 1
+fi
+
+echo 'Package channel tests passed'

--- a/.github/bin/publish-all-packages.sh
+++ b/.github/bin/publish-all-packages.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib-package-channel.sh"
+
 # Script to publish all llumiverse packages to NPM
 # Usage: publish-all-packages.sh --ref <ref> --release-type <type> --bump-type <type> [--dry-run [true|false]]
 #   --ref: Git reference (main for dev builds, release/X.Y for releases, e.g. release/1.4)
@@ -21,13 +24,6 @@ PACKAGES=(
 
 update_package_versions() {
   echo "=== Updating package versions ==="
-
-  # Determine npm tag based on release type
-  if [ "$RELEASE_TYPE" = "snapshot" ]; then
-    npm_tag="dev"
-  else
-    npm_tag="latest"
-  fi
 
   # Get current version and strip any existing -dev* suffix to get base version
   current_version=$(npm pkg get version | tr -d '"')
@@ -343,6 +339,14 @@ if [ "$DRY_RUN" = "true" ]; then
 else
   DRY_RUN_FLAG=""
 fi
+
+source_sha=$(git rev-parse HEAD)
+npm_tag=$(resolve_package_channel "$REF" "$RELEASE_TYPE" "$source_sha")
+
+echo "=== Package channel ==="
+echo "Source ref: ${REF}"
+echo "Source SHA: ${source_sha}"
+echo "Target tag: ${npm_tag}"
 
 # =============================================================================
 # Main flow

--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -73,6 +73,9 @@ jobs:
       - name: Install workspace dependencies
         run: pnpm install
 
+      - name: Test package channel selection
+        run: bash ./.github/bin/lib-package-channel.test.sh
+
       - name: Publish all packages
         env:
           RELEASE_TYPE: ${{ inputs.release_type }}


### PR DESCRIPTION
## Summary
- map snapshots from `main`, `release/X.Y`, and all other refs to `dev`, `dev-X.Y`, and isolated `snapshot-<sha>` channels respectively
- keep stable releases on `latest`
- validate the package-channel policy through Bash before publishing

## Test Plan
- [x] `bash .github/bin/lib-package-channel.test.sh`
- [x] `pnpm check`
- [x] `pnpm run lint:actions`
- [x] `shellcheck -e SC1091 .github/bin/lib-package-channel.sh .github/bin/lib-package-channel.test.sh .github/bin/publish-all-packages.sh`
- [x] `pnpm run format:check`
- [x] `pnpm build`
