### PR TITLE
feat: named tool choice across drivers with typed contract failures

### DIFF
--- a/common/src/schemas/model-options.test.ts
+++ b/common/src/schemas/model-options.test.ts
@@ -121,6 +121,16 @@ describe('ModelOptionsSchema', () => {
         expect(ModelOptionsSchema.safeParse({ _option_id: 'not-a-driver' }).success).toBe(false);
     });
 
+    it.each(['text-fallback', 'openai-thinking', 'openai-text'] as const)(
+        'accepts an explicit tool choice for %s',
+        (_option_id) => {
+            expect(ModelOptionsSchema.parse({ _option_id, tool_choice: 'required' })).toEqual({
+                _option_id,
+                tool_choice: 'required',
+            });
+        },
+    );
+
     it('accepts current and future service tiers for provider option schemas', () => {
         expect(ModelOptionsSchema.safeParse({ _option_id: 'openai-text', service_tier: 'flex' }).success).toBe(true);
         expect(ModelOptionsSchema.safeParse({ _option_id: 'openai-thinking', service_tier: 'priority' }).success).toBe(

--- a/common/src/schemas/model-options.ts
+++ b/common/src/schemas/model-options.ts
@@ -39,6 +39,7 @@ export const TextFallbackOptionsSchema = z
     .strictObject({
         _option_id: z.literal('text-fallback'),
         max_tokens: z.number().optional(),
+        tool_choice: z.enum(['auto', 'none', 'any', 'required']).optional(),
         temperature: z.number().optional(),
         top_p: z.number().optional(),
         top_k: z.number().optional(),
@@ -296,6 +297,7 @@ export const OpenAiThinkingOptionsSchema = z
     .strictObject({
         _option_id: z.literal('openai-thinking'),
         max_tokens: z.number().optional(),
+        tool_choice: z.enum(['auto', 'none', 'any', 'required']).optional(),
         stop_sequence: z.array(z.string()).optional(),
         effort: ReasoningEffortSchema.optional(),
         reasoning_effort: ReasoningEffortSchema.optional(),
@@ -309,6 +311,7 @@ export const OpenAiTextOptionsSchema = z
     .strictObject({
         _option_id: z.literal('openai-text'),
         max_tokens: z.number().optional(),
+        tool_choice: z.enum(['auto', 'none', 'any', 'required']).optional(),
         effort: ReasoningEffortSchema.optional(),
         reasoning_effort: ReasoningEffortSchema.optional(),
         temperature: z.number().optional(),

--- a/core/src/CompletionStream.thoughts.test.ts
+++ b/core/src/CompletionStream.thoughts.test.ts
@@ -34,6 +34,17 @@ class ThoughtsStreamDriver extends AbstractDriver<DriverOptions, string> {
 
     async requestTextCompletionStream(prompt: string): Promise<DriverCompletionStream> {
         const nativeAssistant = { role: 'assistant', id: prompt };
+        if (prompt === 'failed') {
+            return {
+                async *[Symbol.asyncIterator]() {
+                    yield {
+                        result: [],
+                        token_usage: { prompt: 10, prompt_cached: 4, prompt_new: 6, result: 2, total: 12 },
+                    };
+                    throw new Error('provider failed after usage');
+                },
+            };
+        }
         if (prompt === 'video') {
             return {
                 async *[Symbol.asyncIterator]() {
@@ -72,6 +83,24 @@ class ThoughtsStreamDriver extends AbstractDriver<DriverOptions, string> {
 }
 
 describe('DefaultCompletionStream thoughts', () => {
+    it('preserves terminal usage on a partial completion when the provider stream fails', async () => {
+        const driver = new ThoughtsStreamDriver({});
+        const stream = new DefaultCompletionStream(driver, 'failed', { model: 'test' });
+
+        await expect(async () => {
+            for await (const _chunk of stream) {
+                // drain
+            }
+        }).rejects.toThrow('provider failed after usage');
+        expect(stream.completion?.token_usage).toEqual({
+            prompt: 10,
+            prompt_cached: 4,
+            prompt_new: 6,
+            result: 2,
+            total: 12,
+        });
+    });
+
     it('streams visible thoughts before the answer while preserving typed results', async () => {
         const driver = new ThoughtsStreamDriver({});
         const stream = new DefaultCompletionStream(driver, 'one', { model: 'test' });

--- a/core/src/CompletionStream.ts
+++ b/core/src/CompletionStream.ts
@@ -15,6 +15,26 @@ import { DEFAULT_DRIVER_REQUEST_TIMEOUT_MS } from './http-agent.js';
 
 type StreamingToolUse = ToolUse<unknown> & { _actual_id?: string };
 
+export class MalformedStreamingToolArgumentsError extends LlumiverseError {
+    constructor(
+        tool: StreamingToolUse,
+        finishReason: string | undefined,
+        context: { provider: string; model: string },
+        originalError: unknown,
+    ) {
+        const argumentChars = typeof tool.tool_input === 'string' ? tool.tool_input.length : 0;
+        super(
+            `[${context.provider}] Received malformed JSON arguments for streamed tool "${tool.tool_name || 'unknown'}" ` +
+                `(finish_reason=${finishReason ?? 'unknown'}, argument_chars=${argumentChars})`,
+            false,
+            { ...context, operation: 'stream' },
+            originalError,
+            undefined,
+            'MalformedStreamingToolArgumentsError',
+        );
+    }
+}
+
 export const DEFAULT_COMPLETION_STREAM_START_TIMEOUT_MS = DEFAULT_DRIVER_REQUEST_TIMEOUT_MS;
 
 class CompletionStreamLease {
@@ -253,15 +273,13 @@ export function finalizeStreamingToolUse(
         return completeTools.length > 0 ? completeTools : undefined;
     }
 
-    // Without an explicit length stop, malformed arguments indicate an incomplete or corrupt
-    // provider stream. Never coerce them to {}, because that can execute a tool with invented
-    // arguments. Surface a retryable stream error instead.
-    throw new LlumiverseError(
-        `[${context.provider}] Received malformed JSON arguments for a streamed tool call`,
-        true,
-        { ...context, operation: 'stream' },
-        parseError,
-    );
+    // Without an explicit length stop, malformed arguments indicate model/provider output that
+    // must be regenerated with feedback. Never coerce them to {}, because that can execute a tool
+    // with invented arguments, and never let Temporal retry the identical opaque activity. The
+    // conversation controller owns one bounded corrective turn with this stable error identity.
+    const malformedTool = toolUseArray.find((tool) => malformedToolIds.has(tool.id));
+    if (!malformedTool) return toolUseArray;
+    throw new MalformedStreamingToolArgumentsError(malformedTool, finishReason, context, parseError);
 }
 
 /**

--- a/core/src/CompletionStream.ts
+++ b/core/src/CompletionStream.ts
@@ -255,6 +255,10 @@ export function finalizeStreamingToolUse(
             delete tool._actual_id;
         }
         if (typeof tool.tool_input === 'string') {
+            if (tool.tool_input.trim() === '') {
+                tool.tool_input = {};
+                continue;
+            }
             try {
                 tool.tool_input = JSON.parse(tool.tool_input);
             } catch (error: unknown) {

--- a/core/src/CompletionStream.ts
+++ b/core/src/CompletionStream.ts
@@ -328,6 +328,12 @@ export function accumulateToolUseChunk(
                 ...existingInput,
                 ...newInput,
             };
+        } else if (
+            (typeof existingInput === 'string' && isEmptyObject(newInput)) ||
+            (typeof newInput === 'string' && newInput.length === 0)
+        ) {
+            // Some OpenAI-compatible providers emit an empty placeholder between argument
+            // string fragments. It carries no information and must not erase prior bytes.
         } else {
             existing.tool_input = tool.tool_input;
         }
@@ -345,6 +351,10 @@ export function accumulateToolUseChunk(
     if (tool._actual_id) {
         existing._actual_id = tool._actual_id;
     }
+}
+
+function isEmptyObject(value: unknown): boolean {
+    return Boolean(value && typeof value === 'object' && !Array.isArray(value) && Object.keys(value).length === 0);
 }
 
 export class DefaultCompletionStream<PromptT = unknown> extends ManagedCompletionStream<PromptT> {

--- a/core/src/CompletionStream.ts
+++ b/core/src/CompletionStream.ts
@@ -540,6 +540,27 @@ export class DefaultCompletionStream<PromptT = unknown> extends ManagedCompletio
             }
         } catch (error: unknown) {
             if (this.abortSignal.aborted) return;
+            // Some transports report final usage immediately before a terminal error. Preserve
+            // that partial completion so server-side failed-call telemetry records the tokens
+            // that were actually billed even though no canonical conversation can be finalized.
+            if (resultTokens !== undefined) {
+                this.completion = {
+                    result: accumulatedResults,
+                    prompt: this.driver.formatDebugPrompt(this.prompt),
+                    execution_time: Date.now() - start,
+                    token_usage: {
+                        prompt: promptTokens,
+                        result: resultTokens,
+                        total: resultTokens + promptTokens,
+                        ...(promptCachedTokens != null && { prompt_cached: promptCachedTokens }),
+                        ...(promptCacheWriteTokens != null && { prompt_cache_write: promptCacheWriteTokens }),
+                        ...(promptNewTokens != null && { prompt_new: promptNewTokens }),
+                    },
+                    service_tier: serviceTier,
+                    finish_reason,
+                    chunks: this.chunks,
+                };
+            }
             // Don't wrap if already a LlumiverseError
             if (LlumiverseError.isLlumiverseError(error)) {
                 throw error;

--- a/core/test/tool-use-accumulate-signature.test.ts
+++ b/core/test/tool-use-accumulate-signature.test.ts
@@ -118,8 +118,16 @@ describe('streaming tool_use argument finalization', () => {
         expect(accumulated?.tool_input).toBe('{"name":"report"}');
     });
 
+    test('normalizes empty streamed arguments for parameterless tools', () => {
+        const tools: StreamingToolUse[] = [{ id: 'inspect', tool_name: 'inspect_status', tool_input: '' }];
+
+        expect(finalizeStreamingToolUse(tools, 'tool_use', context)).toEqual([
+            { id: 'inspect', tool_name: 'inspect_status', tool_input: {} },
+        ]);
+    });
+
     test('rejects malformed arguments with a stable non-retryable identity', () => {
-        const tools: StreamingToolUse[] = [{ id: 'write', tool_name: 'write_artifact', tool_input: '' }];
+        const tools: StreamingToolUse[] = [{ id: 'write', tool_name: 'write_artifact', tool_input: '{' }];
 
         try {
             finalizeStreamingToolUse(tools, undefined, context);
@@ -130,7 +138,7 @@ describe('streaming tool_use argument finalization', () => {
                 expect(error).toBeInstanceOf(MalformedStreamingToolArgumentsError);
                 expect(error.name).toBe('MalformedStreamingToolArgumentsError');
                 expect(error.message).toContain(
-                    'streamed tool "write_artifact" (finish_reason=unknown, argument_chars=0)',
+                    'streamed tool "write_artifact" (finish_reason=unknown, argument_chars=1)',
                 );
                 expect(error.retryable).toBe(false);
                 expect(error.context).toEqual({ ...context, operation: 'stream' });

--- a/core/test/tool-use-accumulate-signature.test.ts
+++ b/core/test/tool-use-accumulate-signature.test.ts
@@ -108,6 +108,16 @@ describe('streaming tool_use argument finalization', () => {
         ]);
     });
 
+    test('does not let an empty object placeholder erase accumulated argument bytes', () => {
+        const accumulated = accumulate([
+            { id: 'write', tool_name: 'write_artifact', tool_input: '{"name"' },
+            { id: 'write', tool_name: '', tool_input: {} },
+            { id: 'write', tool_name: '', tool_input: ':"report"}' },
+        ]);
+
+        expect(accumulated?.tool_input).toBe('{"name":"report"}');
+    });
+
     test('rejects malformed arguments with a stable non-retryable identity', () => {
         const tools: StreamingToolUse[] = [{ id: 'write', tool_name: 'write_artifact', tool_input: '' }];
 

--- a/core/test/tool-use-accumulate-signature.test.ts
+++ b/core/test/tool-use-accumulate-signature.test.ts
@@ -1,6 +1,10 @@
 import { LlumiverseError, type ToolUse } from '@llumiverse/common';
 import { describe, expect, test } from 'vitest';
-import { accumulateToolUseChunk, finalizeStreamingToolUse } from '../src/CompletionStream.js';
+import {
+    accumulateToolUseChunk,
+    finalizeStreamingToolUse,
+    MalformedStreamingToolArgumentsError,
+} from '../src/CompletionStream.js';
 
 type StreamingToolUse = ToolUse<unknown> & { _actual_id?: string };
 
@@ -104,7 +108,7 @@ describe('streaming tool_use argument finalization', () => {
         ]);
     });
 
-    test('rejects malformed arguments as retryable when the stream has no finish reason', () => {
+    test('rejects malformed arguments with a stable non-retryable identity', () => {
         const tools: StreamingToolUse[] = [{ id: 'write', tool_name: 'write_artifact', tool_input: '' }];
 
         try {
@@ -113,7 +117,12 @@ describe('streaming tool_use argument finalization', () => {
         } catch (error: unknown) {
             expect(LlumiverseError.isLlumiverseError(error)).toBe(true);
             if (LlumiverseError.isLlumiverseError(error)) {
-                expect(error.retryable).toBe(true);
+                expect(error).toBeInstanceOf(MalformedStreamingToolArgumentsError);
+                expect(error.name).toBe('MalformedStreamingToolArgumentsError');
+                expect(error.message).toContain(
+                    'streamed tool "write_artifact" (finish_reason=unknown, argument_chars=0)',
+                );
+                expect(error.retryable).toBe(false);
                 expect(error.context).toEqual({ ...context, operation: 'stream' });
             }
         }

--- a/drivers/src/azure/azure_foundry.test.ts
+++ b/drivers/src/azure/azure_foundry.test.ts
@@ -137,6 +137,7 @@ describe('AzureFoundryDriver protocol composition', () => {
         expect(path).toHaveBeenCalledWith('/chat/completions');
         expect(post).toHaveBeenCalledWith({
             timeout: 900_000,
+            headers: { 'extra-parameters': 'pass-through' },
             body: expect.objectContaining({
                 model: 'llama-deployment',
                 stream: false,

--- a/drivers/src/azure/azure_foundry.test.ts
+++ b/drivers/src/azure/azure_foundry.test.ts
@@ -3,7 +3,8 @@ import { PromptRole } from '@llumiverse/core';
 import type OpenAI from 'openai';
 import { describe, expect, it, vi } from 'vitest';
 import { exposePrivate } from '../../test/__helpers__/test-utils.js';
-import { AzureFoundryDriver } from './azure_foundry.js';
+import type { OpenAIChatCompletionsPayload } from '../openai/openai_chat_completions.js';
+import { AzureFoundryDriver, toAzureInferenceRequest } from './azure_foundry.js';
 
 const credential: TokenCredential = {
     getToken: vi.fn(async () => ({ token: 'test-token', expiresOnTimestamp: Date.now() + 60_000 })),
@@ -24,6 +25,27 @@ function createDriver(): AzureFoundryDriver {
 }
 
 describe('AzureFoundryDriver protocol composition', () => {
+    it('preserves required tool choice when adapting an OpenAI chat request', () => {
+        const body = toAzureInferenceRequest(
+            {
+                model: 'deployment',
+                messages: [{ role: 'user', content: 'Act now.' }],
+                tools: [
+                    {
+                        type: 'function',
+                        function: { name: 'write_artifact', parameters: { type: 'object', properties: {} } },
+                    },
+                ],
+                tool_choice: { type: 'function', function: { name: 'write_artifact' } },
+                parallel_tool_calls: false,
+                stream: false,
+            } satisfies OpenAIChatCompletionsPayload,
+            false,
+        );
+
+        expect(body.tool_choice).toEqual({ type: 'function', function: { name: 'write_artifact' } });
+        expect(body.parallel_tool_calls).toBe(false);
+    });
     it('parses string capability flags and excludes dedicated endpoint deployments from inference listing', async () => {
         const driver = createDriver();
         const deployments = [

--- a/drivers/src/azure/azure_foundry.ts
+++ b/drivers/src/azure/azure_foundry.ts
@@ -99,6 +99,7 @@ class AzureFoundryInferenceProtocolDriver extends OpenAIChatCompletionsDriverBas
     ): Promise<OpenAIChatCompletionsResponse> {
         const response = await this.service.path('/chat/completions').post({
             body: toAzureInferenceRequest(payload, false),
+            headers: { 'extra-parameters': 'pass-through' },
             timeout: this.getDriverRequestTimeoutMs(_options.httpTimeout),
             ...(signal ? { abortSignal: signal } : {}),
         });
@@ -122,6 +123,7 @@ class AzureFoundryInferenceProtocolDriver extends OpenAIChatCompletionsDriverBas
             .path('/chat/completions')
             .post({
                 body: toAzureInferenceRequest(payload, true),
+                headers: { 'extra-parameters': 'pass-through' },
                 timeout: this.getDriverRequestTimeoutMs(_options.httpTimeout),
                 ...(signal ? { abortSignal: signal } : {}),
             })

--- a/drivers/src/azure/azure_foundry.ts
+++ b/drivers/src/azure/azure_foundry.ts
@@ -571,10 +571,24 @@ function toAzureFoundryChatOptions(options: ExecutionOptions, deploymentName: st
     };
 }
 
-function toAzureInferenceRequest(
+type AzureInferenceRequestBody = GetChatCompletionsParameters['body'] & {
+    parallel_tool_calls?: boolean;
+};
+
+function toAzureToolChoice(
+    toolChoice: OpenAIChatCompletionsPayload['tool_choice'],
+): GetChatCompletionsParameters['body']['tool_choice'] {
+    if (typeof toolChoice === 'string') return toolChoice;
+    if (toolChoice?.type === 'function' && 'function' in toolChoice) {
+        return { type: 'function', function: { name: toolChoice.function.name } };
+    }
+    return undefined;
+}
+
+export function toAzureInferenceRequest(
     payload: OpenAIChatCompletionsPayload,
     stream: boolean,
-): GetChatCompletionsParameters['body'] {
+): AzureInferenceRequestBody {
     const responseFormat = payload.response_format
         ? ({ ...payload.response_format } satisfies ChatCompletionsResponseFormat)
         : undefined;
@@ -604,8 +618,10 @@ function toAzureInferenceRequest(
         seed: payload.seed ?? undefined,
         response_format: responseFormat,
         tools,
+        tool_choice: toAzureToolChoice(payload.tool_choice),
+        parallel_tool_calls: payload.parallel_tool_calls,
         stream,
-    } satisfies GetChatCompletionsParameters['body'];
+    } satisfies AzureInferenceRequestBody;
 }
 
 function parseCapabilityFlag(value: unknown): boolean | undefined {

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -1391,9 +1391,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
             options.model_options as BedrockClaudeOptions | undefined,
         );
         const disableClaudeThinkingForForcedTool = options.model.includes('claude') && forcedToolRequested;
-        const hasSamplingRestriction = disableClaudeThinkingForForcedTool
-            ? false
-            : claudeThinking.hasSamplingRestriction;
+        const hasSamplingRestriction = claudeThinking.hasSamplingRestriction;
 
         if (options.model.includes('amazon')) {
             supportsJSONPrefill = true;
@@ -1403,6 +1401,9 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
             }
         } else if (options.model.includes('claude')) {
             const claude_options = model_options as ModelOptions as BedrockClaudeOptions;
+            if (disableClaudeThinkingForForcedTool) {
+                additionalField = { ...additionalField, reasoning_config: { type: 'disabled' } };
+            }
             // Claude never uses JSON prefill: newer models (4.6+) reject assistant
             // message prefill outright, and every supported Claude follows the
             // schema instruction injected into the prompt — so the model-version
@@ -1598,13 +1599,12 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
         }
 
         const supportsForcedToolChoice = options.model.includes('claude') || options.model.includes('amazon.nova');
+        if (forcedToolRequested && !supportsForcedToolChoice) {
+            throw new Error(
+                `Bedrock model ${options.model} cannot enforce the requested tool choice; use a tool-choice-capable model.`,
+            );
+        }
         if (tool_defs?.length) {
-            if (forcedToolRequested && !supportsForcedToolChoice) {
-                this.logger.warn(
-                    { model: options.model },
-                    '[Bedrock] Model family does not support forced Converse tool choice; using automatic tool choice',
-                );
-            }
             request.toolConfig = {
                 tools: tool_defs,
                 ...(supportsForcedToolChoice && privateToolOptions.required_tool_name

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -1583,9 +1583,18 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
             };
         }
 
-        if (tool_defs?.length) {
+        const privateToolOptions = model_options as typeof model_options & {
+            tool_choice?: 'auto' | 'none' | 'any' | 'required';
+            required_tool_name?: string;
+        };
+        if (tool_defs?.length && privateToolOptions.tool_choice !== 'none') {
             request.toolConfig = {
                 tools: tool_defs,
+                ...(privateToolOptions.required_tool_name
+                    ? { toolChoice: { tool: { name: privateToolOptions.required_tool_name } } }
+                    : privateToolOptions.tool_choice === 'required' || privateToolOptions.tool_choice === 'any'
+                      ? { toolChoice: { any: {} } }
+                      : {}),
             };
         } else if (request.messages && messagesContainToolBlocks(request.messages)) {
             // Bedrock requires toolConfig when conversation contains toolUse/toolResult blocks.

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -50,6 +50,7 @@ import {
     type NovaCanvasOptions,
     type PromptSegment,
     Providers,
+    parseClaudeVersion,
     type StatelessExecutionOptions,
     stripBinaryFromConversation,
     stripHeartbeatsFromConversation,
@@ -70,6 +71,7 @@ import { logClaudeTruncation } from '../shared/claude-stop-reason.js';
 import { resolveClaudeThinking } from '../shared/claude-thinking.js';
 import { truncateBinaryForDebug, uint8ArrayToBase64ForDebug } from '../shared/debug-prompt.js';
 import { resolveModelListingMetadata } from '../shared/model-listing.js';
+import { createToolChoiceConfigurationError } from '../shared/tool-choice-error.js';
 import {
     converseConcatMessages,
     converseJSONprefill,
@@ -1381,6 +1383,13 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
             privateToolOptions.required_tool_name !== undefined ||
             privateToolOptions.tool_choice === 'required' ||
             privateToolOptions.tool_choice === 'any';
+        const tool_defs = getToolDefinitions(options.tools);
+        if (forcedToolRequested && !tool_defs?.length) {
+            throw createToolChoiceConfigurationError(
+                'A forced Bedrock tool turn requires at least one tool definition.',
+                { provider: this.provider, model: options.model, operation: 'stream' },
+            );
+        }
 
         let additionalField: Record<string, unknown> = {};
         let supportsJSONPrefill = false;
@@ -1390,7 +1399,19 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
             options.model,
             options.model_options as BedrockClaudeOptions | undefined,
         );
-        const disableClaudeThinkingForForcedTool = options.model.includes('claude') && forcedToolRequested;
+        const claudeVersion = parseClaudeVersion(options.model);
+        const onlySupportsAdaptiveThinking = claudeVersion?.variant === 'fable' || claudeVersion?.variant === 'mythos';
+        if (options.model.includes('claude') && forcedToolRequested && onlySupportsAdaptiveThinking) {
+            throw createToolChoiceConfigurationError(
+                `Bedrock model ${options.model} cannot combine its required adaptive thinking with forced tool choice.`,
+                { provider: this.provider, model: options.model, operation: 'stream' },
+            );
+        }
+        // Bedrock only permits auto/none tool choice while thinking is active. Disable thinking
+        // for the constrained turn on models that support the disabled form. Adaptive-only
+        // families are rejected above because neither legal payload can satisfy both contracts.
+        const disableClaudeThinkingForForcedTool =
+            options.model.includes('claude') && forcedToolRequested && claudeThinking.supportsThinking;
         const hasSamplingRestriction = claudeThinking.hasSamplingRestriction;
 
         if (options.model.includes('amazon')) {
@@ -1526,11 +1547,6 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
             }
         }
 
-        const tool_defs = getToolDefinitions(options.tools);
-        if (forcedToolRequested && !tool_defs?.length) {
-            throw new Error('A forced Bedrock tool turn requires at least one tool definition.');
-        }
-
         // Use prefill when there is a schema and tools are not being used
         if (
             supportsJSONPrefill &&
@@ -1600,8 +1616,9 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
 
         const supportsForcedToolChoice = options.model.includes('claude') || options.model.includes('amazon.nova');
         if (forcedToolRequested && !supportsForcedToolChoice) {
-            throw new Error(
+            throw createToolChoiceConfigurationError(
                 `Bedrock model ${options.model} cannot enforce the requested tool choice; use a tool-choice-capable model.`,
+                { provider: this.provider, model: options.model, operation: 'stream' },
             );
         }
         if (tool_defs?.length) {

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -1587,12 +1587,16 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
             tool_choice?: 'auto' | 'none' | 'any' | 'required';
             required_tool_name?: string;
         };
-        if (tool_defs?.length && privateToolOptions.tool_choice !== 'none') {
+        const thinkingEnabled = claudeThinking.thinking !== undefined && claudeThinking.thinking.type !== 'disabled';
+        const supportsForcedToolChoice =
+            (options.model.includes('claude') && !thinkingEnabled) || options.model.includes('amazon.nova');
+        if (tool_defs?.length) {
             request.toolConfig = {
                 tools: tool_defs,
-                ...(privateToolOptions.required_tool_name
+                ...(supportsForcedToolChoice && privateToolOptions.required_tool_name
                     ? { toolChoice: { tool: { name: privateToolOptions.required_tool_name } } }
-                    : privateToolOptions.tool_choice === 'required' || privateToolOptions.tool_choice === 'any'
+                    : supportsForcedToolChoice &&
+                        (privateToolOptions.tool_choice === 'required' || privateToolOptions.tool_choice === 'any')
                       ? { toolChoice: { any: {} } }
                       : {}),
             };

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -1401,17 +1401,18 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
         );
         const claudeVersion = parseClaudeVersion(options.model);
         const onlySupportsAdaptiveThinking = claudeVersion?.variant === 'fable' || claudeVersion?.variant === 'mythos';
-        if (options.model.includes('claude') && forcedToolRequested && onlySupportsAdaptiveThinking) {
-            throw createToolChoiceConfigurationError(
-                `Bedrock model ${options.model} cannot combine its required adaptive thinking with forced tool choice.`,
-                { provider: this.provider, model: options.model, operation: 'stream' },
-            );
-        }
+        const useAutomaticToolChoiceForAdaptiveClaude =
+            options.model.includes('claude') && forcedToolRequested && onlySupportsAdaptiveThinking;
         // Bedrock only permits auto/none tool choice while thinking is active. Disable thinking
         // for the constrained turn on models that support the disabled form. Adaptive-only
-        // families are rejected above because neither legal payload can satisfy both contracts.
+        // families keep thinking and use automatic tool choice; the caller's required-tool
+        // validator remains authoritative and triggers the bounded recovery path if the model
+        // does not call the requested tool.
         const disableClaudeThinkingForForcedTool =
-            options.model.includes('claude') && forcedToolRequested && claudeThinking.supportsThinking;
+            options.model.includes('claude') &&
+            forcedToolRequested &&
+            claudeThinking.supportsThinking &&
+            !useAutomaticToolChoiceForAdaptiveClaude;
         const hasSamplingRestriction = claudeThinking.hasSamplingRestriction;
 
         if (options.model.includes('amazon')) {
@@ -1624,9 +1625,12 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
         if (tool_defs?.length) {
             request.toolConfig = {
                 tools: tool_defs,
-                ...(supportsForcedToolChoice && privateToolOptions.required_tool_name
+                ...(supportsForcedToolChoice &&
+                !useAutomaticToolChoiceForAdaptiveClaude &&
+                privateToolOptions.required_tool_name
                     ? { toolChoice: { tool: { name: privateToolOptions.required_tool_name } } }
                     : supportsForcedToolChoice &&
+                        !useAutomaticToolChoiceForAdaptiveClaude &&
                         (privateToolOptions.tool_choice === 'required' || privateToolOptions.tool_choice === 'any')
                       ? { toolChoice: { any: {} } }
                       : {}),

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -1373,6 +1373,14 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
         const model_options: TextFallbackOptions = (options.model_options as TextFallbackOptions) ?? {
             _option_id: 'text-fallback',
         };
+        const privateToolOptions = model_options as typeof model_options & {
+            tool_choice?: 'auto' | 'none' | 'any' | 'required';
+            required_tool_name?: string;
+        };
+        const forcedToolRequested =
+            privateToolOptions.required_tool_name !== undefined ||
+            privateToolOptions.tool_choice === 'required' ||
+            privateToolOptions.tool_choice === 'any';
 
         let additionalField: Record<string, unknown> = {};
         let supportsJSONPrefill = false;
@@ -1382,7 +1390,10 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
             options.model,
             options.model_options as BedrockClaudeOptions | undefined,
         );
-        const hasSamplingRestriction = claudeThinking.hasSamplingRestriction;
+        const disableClaudeThinkingForForcedTool = options.model.includes('claude') && forcedToolRequested;
+        const hasSamplingRestriction = disableClaudeThinkingForForcedTool
+            ? false
+            : claudeThinking.hasSamplingRestriction;
 
         if (options.model.includes('amazon')) {
             supportsJSONPrefill = true;
@@ -1399,7 +1410,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
             // they have no native JSON adherence.
 
             // Claude 3.7+ supports thinking — use shared helper for reasoning_config
-            if (claudeThinking.supportsThinking) {
+            if (claudeThinking.supportsThinking && !disableClaudeThinkingForForcedTool) {
                 if (claudeThinking.thinking) {
                     additionalField = {
                         ...additionalField,
@@ -1419,7 +1430,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
                 }
             }
             // Add effort parameter via output_config (Opus 4.5+, Sonnet 4.6+, all 4.7+)
-            if (claudeThinking.outputConfig) {
+            if (claudeThinking.outputConfig && !disableClaudeThinkingForForcedTool) {
                 additionalField = {
                     ...additionalField,
                     output_config: claudeThinking.outputConfig,
@@ -1515,6 +1526,9 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
         }
 
         const tool_defs = getToolDefinitions(options.tools);
+        if (forcedToolRequested && !tool_defs?.length) {
+            throw new Error('A forced Bedrock tool turn requires at least one tool definition.');
+        }
 
         // Use prefill when there is a schema and tools are not being used
         if (
@@ -1583,14 +1597,14 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
             };
         }
 
-        const privateToolOptions = model_options as typeof model_options & {
-            tool_choice?: 'auto' | 'none' | 'any' | 'required';
-            required_tool_name?: string;
-        };
-        const thinkingEnabled = claudeThinking.thinking !== undefined && claudeThinking.thinking.type !== 'disabled';
-        const supportsForcedToolChoice =
-            (options.model.includes('claude') && !thinkingEnabled) || options.model.includes('amazon.nova');
+        const supportsForcedToolChoice = options.model.includes('claude') || options.model.includes('amazon.nova');
         if (tool_defs?.length) {
+            if (forcedToolRequested && !supportsForcedToolChoice) {
+                this.logger.warn(
+                    { model: options.model },
+                    '[Bedrock] Model family does not support forced Converse tool choice; using automatic tool choice',
+                );
+            }
             request.toolConfig = {
                 tools: tool_defs,
                 ...(supportsForcedToolChoice && privateToolOptions.required_tool_name

--- a/drivers/src/bedrock/streaming-tool-use.test.ts
+++ b/drivers/src/bedrock/streaming-tool-use.test.ts
@@ -194,27 +194,25 @@ describe('BedrockDriver private tool-choice mapping', () => {
         expect(payload.additionalModelRequestFields).toEqual({ reasoning_config: { type: 'disabled' } });
     });
 
-    it('rejects forced tool choice for adaptive-only Claude families on Bedrock', () => {
+    it('degrades forced tool choice to auto for adaptive-only Claude families on Bedrock', () => {
         const driver = new BedrockDriver({ region: 'us-east-1' });
-        expect(() =>
-            driver.preparePayload(prompt, {
-                model: 'anthropic.claude-fable-5',
-                tools,
-                model_options: {
-                    _option_id: 'bedrock-claude',
-                    effort: 'medium',
-                    tool_choice: 'required',
-                    required_tool_name: 'write_artifact',
-                },
-            } as unknown as ExecutionOptions),
-        ).toThrowError(
-            expect.objectContaining({
-                name: 'ToolChoiceConfigurationError',
-                retryable: false,
-                code: 400,
-                message: expect.stringContaining('required adaptive thinking'),
-            }),
-        );
+        const payload = driver.preparePayload(prompt, {
+            model: 'anthropic.claude-fable-5',
+            tools,
+            model_options: {
+                _option_id: 'bedrock-claude',
+                effort: 'medium',
+                tool_choice: 'required',
+                required_tool_name: 'write_artifact',
+            },
+        } as unknown as ExecutionOptions);
+
+        expect(payload.toolConfig?.tools).toHaveLength(1);
+        expect(payload.toolConfig?.toolChoice).toBeUndefined();
+        expect(payload.additionalModelRequestFields).toEqual({
+            reasoning_config: { type: 'adaptive', display: 'omitted' },
+            output_config: { effort: 'medium' },
+        });
     });
 
     it('rejects a forced Converse tool turn when no tools are available', () => {

--- a/drivers/src/bedrock/streaming-tool-use.test.ts
+++ b/drivers/src/bedrock/streaming-tool-use.test.ts
@@ -147,7 +147,7 @@ describe('BedrockDriver private tool-choice mapping', () => {
         expect(payload.toolConfig?.toolChoice).toEqual({ tool: { name: 'write_artifact' } });
     });
 
-    it('omits Converse tools for a private no-tool completion turn', () => {
+    it('keeps Converse tools in auto mode for a private no-tool completion turn', () => {
         const driver = new BedrockDriver({ region: 'us-east-1' });
         const payload = driver.preparePayload(prompt, {
             model: 'anthropic.claude-sonnet-4-6',
@@ -155,7 +155,41 @@ describe('BedrockDriver private tool-choice mapping', () => {
             model_options: { _option_id: 'bedrock-claude', tool_choice: 'none' },
         } as unknown as ExecutionOptions);
 
-        expect(payload.toolConfig).toBeUndefined();
+        expect(payload.toolConfig?.tools).toHaveLength(1);
+        expect(payload.toolConfig?.toolChoice).toBeUndefined();
+    });
+
+    it('does not force a Claude tool choice while thinking is enabled', () => {
+        const driver = new BedrockDriver({ region: 'us-east-1' });
+        const payload = driver.preparePayload(prompt, {
+            model: 'anthropic.claude-sonnet-4-6',
+            tools,
+            model_options: {
+                _option_id: 'bedrock-claude',
+                effort: 'medium',
+                tool_choice: 'required',
+                required_tool_name: 'write_artifact',
+            },
+        } as unknown as ExecutionOptions);
+
+        expect(payload.toolConfig?.tools).toHaveLength(1);
+        expect(payload.toolConfig?.toolChoice).toBeUndefined();
+    });
+
+    it('does not force tool choice on unsupported Converse model families', () => {
+        const driver = new BedrockDriver({ region: 'us-east-1' });
+        const payload = driver.preparePayload({ ...prompt, modelId: 'meta.llama3-3-70b-instruct-v1:0' }, {
+            model: 'meta.llama3-3-70b-instruct-v1:0',
+            tools,
+            model_options: {
+                _option_id: 'text-fallback',
+                tool_choice: 'required',
+                required_tool_name: 'write_artifact',
+            },
+        } as unknown as ExecutionOptions);
+
+        expect(payload.toolConfig?.tools).toHaveLength(1);
+        expect(payload.toolConfig?.toolChoice).toBeUndefined();
     });
 });
 

--- a/drivers/src/bedrock/streaming-tool-use.test.ts
+++ b/drivers/src/bedrock/streaming-tool-use.test.ts
@@ -13,7 +13,7 @@ import {
     type PromptSegment,
 } from '@llumiverse/common';
 import { AbstractDriver } from '@llumiverse/core/driver';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Tree } from '../../test/__helpers__/test-utils.js';
 import { BedrockDriver, type BedrockPrompt } from './index.js';
 
@@ -159,7 +159,7 @@ describe('BedrockDriver private tool-choice mapping', () => {
         expect(payload.toolConfig?.toolChoice).toBeUndefined();
     });
 
-    it('does not force a Claude tool choice while thinking is enabled', () => {
+    it('disables Claude thinking for a forced tool turn', () => {
         const driver = new BedrockDriver({ region: 'us-east-1' });
         const payload = driver.preparePayload(prompt, {
             model: 'anthropic.claude-sonnet-4-6',
@@ -173,11 +173,28 @@ describe('BedrockDriver private tool-choice mapping', () => {
         } as unknown as ExecutionOptions);
 
         expect(payload.toolConfig?.tools).toHaveLength(1);
-        expect(payload.toolConfig?.toolChoice).toBeUndefined();
+        expect(payload.toolConfig?.toolChoice).toEqual({ tool: { name: 'write_artifact' } });
+        expect(payload.additionalModelRequestFields).toBeUndefined();
+    });
+
+    it('rejects a forced Converse tool turn when no tools are available', () => {
+        const driver = new BedrockDriver({ region: 'us-east-1' });
+
+        expect(() =>
+            driver.preparePayload(prompt, {
+                model: 'anthropic.claude-sonnet-4-6',
+                model_options: {
+                    _option_id: 'bedrock-claude',
+                    tool_choice: 'required',
+                    required_tool_name: 'write_artifact',
+                },
+            } as unknown as ExecutionOptions),
+        ).toThrow('requires at least one tool definition');
     });
 
     it('does not force tool choice on unsupported Converse model families', () => {
         const driver = new BedrockDriver({ region: 'us-east-1' });
+        const warn = vi.spyOn((driver as unknown as { logger: { warn: (...args: unknown[]) => void } }).logger, 'warn');
         const payload = driver.preparePayload({ ...prompt, modelId: 'meta.llama3-3-70b-instruct-v1:0' }, {
             model: 'meta.llama3-3-70b-instruct-v1:0',
             tools,
@@ -190,6 +207,10 @@ describe('BedrockDriver private tool-choice mapping', () => {
 
         expect(payload.toolConfig?.tools).toHaveLength(1);
         expect(payload.toolConfig?.toolChoice).toBeUndefined();
+        expect(warn).toHaveBeenCalledWith(
+            { model: 'meta.llama3-3-70b-instruct-v1:0' },
+            expect.stringContaining('does not support forced Converse tool choice'),
+        );
     });
 });
 

--- a/drivers/src/bedrock/streaming-tool-use.test.ts
+++ b/drivers/src/bedrock/streaming-tool-use.test.ts
@@ -1,3 +1,4 @@
+import type { ConverseRequest } from '@aws-sdk/client-bedrock-runtime';
 import {
     type AIModel,
     type Completion,
@@ -121,6 +122,40 @@ describe('BedrockDriver getExtractedStream — tool use', () => {
         );
 
         expect(chunk.finish_reason).toBe('tool_use');
+    });
+});
+
+describe('BedrockDriver private tool-choice mapping', () => {
+    const prompt = {
+        modelId: 'anthropic.claude-sonnet-4-6',
+        messages: [{ role: 'user', content: [{ text: 'Act now.' }] }],
+    } satisfies ConverseRequest;
+    const tools = [{ name: 'write_artifact', description: '', input_schema: { type: 'object', properties: {} } }];
+
+    it('requires a named Converse tool when the private hint names one', () => {
+        const driver = new BedrockDriver({ region: 'us-east-1' });
+        const payload = driver.preparePayload(prompt, {
+            model: 'anthropic.claude-sonnet-4-6',
+            tools,
+            model_options: {
+                _option_id: 'bedrock-claude',
+                tool_choice: 'required',
+                required_tool_name: 'write_artifact',
+            },
+        } as unknown as ExecutionOptions);
+
+        expect(payload.toolConfig?.toolChoice).toEqual({ tool: { name: 'write_artifact' } });
+    });
+
+    it('omits Converse tools for a private no-tool completion turn', () => {
+        const driver = new BedrockDriver({ region: 'us-east-1' });
+        const payload = driver.preparePayload(prompt, {
+            model: 'anthropic.claude-sonnet-4-6',
+            tools,
+            model_options: { _option_id: 'bedrock-claude', tool_choice: 'none' },
+        } as unknown as ExecutionOptions);
+
+        expect(payload.toolConfig).toBeUndefined();
     });
 });
 

--- a/drivers/src/bedrock/streaming-tool-use.test.ts
+++ b/drivers/src/bedrock/streaming-tool-use.test.ts
@@ -13,7 +13,7 @@ import {
     type PromptSegment,
 } from '@llumiverse/common';
 import { AbstractDriver } from '@llumiverse/core/driver';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import type { Tree } from '../../test/__helpers__/test-utils.js';
 import { BedrockDriver, type BedrockPrompt } from './index.js';
 
@@ -174,7 +174,29 @@ describe('BedrockDriver private tool-choice mapping', () => {
 
         expect(payload.toolConfig?.tools).toHaveLength(1);
         expect(payload.toolConfig?.toolChoice).toEqual({ tool: { name: 'write_artifact' } });
-        expect(payload.additionalModelRequestFields).toBeUndefined();
+        expect(payload.additionalModelRequestFields).toEqual({ reasoning_config: { type: 'disabled' } });
+    });
+
+    it('keeps sampling parameters suppressed for a forced future-Claude Converse turn', () => {
+        const driver = new BedrockDriver({ region: 'us-east-1' });
+        const payload = driver.preparePayload(prompt, {
+            model: 'anthropic.claude-fable-5',
+            tools,
+            model_options: {
+                _option_id: 'bedrock-claude',
+                effort: 'medium',
+                temperature: 0.4,
+                top_p: 0.8,
+                top_k: 20,
+                tool_choice: 'required',
+                required_tool_name: 'write_artifact',
+            },
+        } as unknown as ExecutionOptions);
+
+        expect(payload.toolConfig?.toolChoice).toEqual({ tool: { name: 'write_artifact' } });
+        expect(payload.additionalModelRequestFields).toEqual({ reasoning_config: { type: 'disabled' } });
+        expect(payload.inferenceConfig).not.toHaveProperty('temperature');
+        expect(payload.inferenceConfig).not.toHaveProperty('topP');
     });
 
     it('rejects a forced Converse tool turn when no tools are available', () => {
@@ -192,25 +214,19 @@ describe('BedrockDriver private tool-choice mapping', () => {
         ).toThrow('requires at least one tool definition');
     });
 
-    it('does not force tool choice on unsupported Converse model families', () => {
+    it('fails explicitly when a Converse model family cannot enforce tool choice', () => {
         const driver = new BedrockDriver({ region: 'us-east-1' });
-        const warn = vi.spyOn((driver as unknown as { logger: { warn: (...args: unknown[]) => void } }).logger, 'warn');
-        const payload = driver.preparePayload({ ...prompt, modelId: 'meta.llama3-3-70b-instruct-v1:0' }, {
-            model: 'meta.llama3-3-70b-instruct-v1:0',
-            tools,
-            model_options: {
-                _option_id: 'text-fallback',
-                tool_choice: 'required',
-                required_tool_name: 'write_artifact',
-            },
-        } as unknown as ExecutionOptions);
-
-        expect(payload.toolConfig?.tools).toHaveLength(1);
-        expect(payload.toolConfig?.toolChoice).toBeUndefined();
-        expect(warn).toHaveBeenCalledWith(
-            { model: 'meta.llama3-3-70b-instruct-v1:0' },
-            expect.stringContaining('does not support forced Converse tool choice'),
-        );
+        expect(() =>
+            driver.preparePayload({ ...prompt, modelId: 'meta.llama3-3-70b-instruct-v1:0' }, {
+                model: 'meta.llama3-3-70b-instruct-v1:0',
+                tools,
+                model_options: {
+                    _option_id: 'text-fallback',
+                    tool_choice: 'required',
+                    required_tool_name: 'write_artifact',
+                },
+            } as unknown as ExecutionOptions),
+        ).toThrow('cannot enforce the requested tool choice');
     });
 });
 

--- a/drivers/src/bedrock/streaming-tool-use.test.ts
+++ b/drivers/src/bedrock/streaming-tool-use.test.ts
@@ -159,7 +159,7 @@ describe('BedrockDriver private tool-choice mapping', () => {
         expect(payload.toolConfig?.toolChoice).toBeUndefined();
     });
 
-    it('disables Claude thinking for a forced tool turn', () => {
+    it('disables adaptive Claude thinking for a forced tool turn on Bedrock', () => {
         const driver = new BedrockDriver({ region: 'us-east-1' });
         const payload = driver.preparePayload(prompt, {
             model: 'anthropic.claude-sonnet-4-6',
@@ -177,17 +177,14 @@ describe('BedrockDriver private tool-choice mapping', () => {
         expect(payload.additionalModelRequestFields).toEqual({ reasoning_config: { type: 'disabled' } });
     });
 
-    it('keeps sampling parameters suppressed for a forced future-Claude Converse turn', () => {
+    it('disables only legacy manual extended thinking for a forced tool turn', () => {
         const driver = new BedrockDriver({ region: 'us-east-1' });
         const payload = driver.preparePayload(prompt, {
-            model: 'anthropic.claude-fable-5',
+            model: 'anthropic.claude-3-7-sonnet',
             tools,
             model_options: {
                 _option_id: 'bedrock-claude',
-                effort: 'medium',
-                temperature: 0.4,
-                top_p: 0.8,
-                top_k: 20,
+                thinking_budget_tokens: 8_000,
                 tool_choice: 'required',
                 required_tool_name: 'write_artifact',
             },
@@ -195,8 +192,29 @@ describe('BedrockDriver private tool-choice mapping', () => {
 
         expect(payload.toolConfig?.toolChoice).toEqual({ tool: { name: 'write_artifact' } });
         expect(payload.additionalModelRequestFields).toEqual({ reasoning_config: { type: 'disabled' } });
-        expect(payload.inferenceConfig).not.toHaveProperty('temperature');
-        expect(payload.inferenceConfig).not.toHaveProperty('topP');
+    });
+
+    it('rejects forced tool choice for adaptive-only Claude families on Bedrock', () => {
+        const driver = new BedrockDriver({ region: 'us-east-1' });
+        expect(() =>
+            driver.preparePayload(prompt, {
+                model: 'anthropic.claude-fable-5',
+                tools,
+                model_options: {
+                    _option_id: 'bedrock-claude',
+                    effort: 'medium',
+                    tool_choice: 'required',
+                    required_tool_name: 'write_artifact',
+                },
+            } as unknown as ExecutionOptions),
+        ).toThrowError(
+            expect.objectContaining({
+                name: 'ToolChoiceConfigurationError',
+                retryable: false,
+                code: 400,
+                message: expect.stringContaining('required adaptive thinking'),
+            }),
+        );
     });
 
     it('rejects a forced Converse tool turn when no tools are available', () => {
@@ -211,7 +229,13 @@ describe('BedrockDriver private tool-choice mapping', () => {
                     required_tool_name: 'write_artifact',
                 },
             } as unknown as ExecutionOptions),
-        ).toThrow('requires at least one tool definition');
+        ).toThrowError(
+            expect.objectContaining({
+                name: 'ToolChoiceConfigurationError',
+                retryable: false,
+                code: 400,
+            }),
+        );
     });
 
     it('fails explicitly when a Converse model family cannot enforce tool choice', () => {
@@ -226,7 +250,13 @@ describe('BedrockDriver private tool-choice mapping', () => {
                     required_tool_name: 'write_artifact',
                 },
             } as unknown as ExecutionOptions),
-        ).toThrow('cannot enforce the requested tool choice');
+        ).toThrowError(
+            expect.objectContaining({
+                name: 'ToolChoiceConfigurationError',
+                retryable: false,
+                code: 400,
+            }),
+        );
     });
 });
 

--- a/drivers/src/groq/index.test.ts
+++ b/drivers/src/groq/index.test.ts
@@ -189,7 +189,7 @@ describe('GroqDriver shared Chat Completions transport', () => {
         expect(emitted[0].tool_use?.[0]).toEqual(
             expect.objectContaining({ id: 'tool_0', _actual_id: 'call_actual', tool_name: 'lookup' }),
         );
-        expect(emitted.at(-1)?.token_usage).toEqual({ prompt: 2, result: 1, total: 3 });
+        expect(emitted.at(-1)?.token_usage).toEqual({ prompt: 2, prompt_new: 2, result: 1, total: 3 });
     });
 
     it('validates with model listing and reports the missing embedding transport', async () => {

--- a/drivers/src/mistral/index.test.ts
+++ b/drivers/src/mistral/index.test.ts
@@ -1,4 +1,4 @@
-import { Base64DataSource, ModelType, PromptRole, Providers } from '@llumiverse/core';
+import { Base64DataSource, type ExecutionOptions, ModelType, PromptRole, Providers } from '@llumiverse/core';
 import { InvalidRequestError, RequestTimeoutError } from '@mistralai/mistralai/models/errors';
 import { describe, expect, it, vi } from 'vitest';
 import { MistralAIDriver } from './index.js';
@@ -141,6 +141,34 @@ describe('MistralAIDriver official SDK transport', () => {
         );
 
         expect(complete).toHaveBeenCalledWith(expect.objectContaining({ reasoningEffort: 'high' }));
+    });
+
+    it('maps the private required-tool hint to a named Mistral tool choice', async () => {
+        const driver = new MistralAIDriver({ apiKey: 'test-key' });
+        const complete = vi.fn(async () => ({
+            choices: [{ index: 0, finishReason: 'stop', message: { role: 'assistant' as const, content: 'Done' } }],
+            usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+        }));
+        Object.defineProperty(driver.client.chat, 'complete', { value: complete });
+
+        await driver.requestTextCompletion(
+            { messages: [{ role: 'user', content: 'Act now.' }] },
+            {
+                model: 'mistral-small-latest',
+                model_options: {
+                    _option_id: 'mistral-text',
+                    tool_choice: 'required',
+                    required_tool_name: 'write_artifact',
+                } as ExecutionOptions['model_options'] & { required_tool_name: string },
+                tools: [{ name: 'write_artifact', input_schema: { type: 'object', properties: {} } }],
+            },
+        );
+
+        expect(complete).toHaveBeenCalledWith(
+            expect.objectContaining({
+                toolChoice: { type: 'function', function: { name: 'write_artifact' } },
+            }),
+        );
     });
 
     it('preserves signed thinking for replay after JSON roundtrip while projecting thoughts by default', async () => {

--- a/drivers/src/mistral/index.ts
+++ b/drivers/src/mistral/index.ts
@@ -389,10 +389,12 @@ function buildMistralRequest(
     // Continue reading effort from the previously advertised OpenAI-compatible shape so persisted configurations
     // remain usable; Mistral-native fields are only accepted through the transport-specific discriminator.
     const modelOptions = options.model_options as
-        | MistralTextOptions
-        | (TextFallbackOptions & { effort?: unknown })
+        | ((MistralTextOptions | (TextFallbackOptions & { effort?: unknown })) & { required_tool_name?: string })
         | undefined;
     const mistralOptions = modelOptions?._option_id === 'mistral-text' ? modelOptions : undefined;
+    const toolChoice = modelOptions?.required_tool_name
+        ? ({ type: 'function', function: { name: modelOptions.required_tool_name } } as const)
+        : mistralOptions?.tool_choice;
     return {
         model: options.model,
         messages: conversation.messages,
@@ -405,7 +407,7 @@ function buildMistralRequest(
         randomSeed: mistralOptions?.random_seed,
         safePrompt: mistralOptions?.safe_prompt,
         parallelToolCalls: mistralOptions?.parallel_tool_calls,
-        toolChoice: mistralOptions?.tool_choice,
+        toolChoice,
         promptMode: mistralOptions?.prompt_mode,
         promptCacheKey: options.prompt_cache_key,
         n: 1,

--- a/drivers/src/openai/error-handling.test.ts
+++ b/drivers/src/openai/error-handling.test.ts
@@ -76,6 +76,61 @@ describe('OpenAIResponsesDriverBase usage mapping', () => {
     });
 });
 
+describe('OpenAI Responses failed-response handling', () => {
+    const failedResponse = (error: { code: string; message: string }) =>
+        ({
+            id: 'resp_failed_123',
+            status: 'failed',
+            error,
+            output: [],
+            usage: null,
+        }) as unknown as OpenAI.Responses.Response;
+
+    it('surfaces the provider cause for blocking failed responses', () => {
+        const driver = new TestOpenAIResponsesDriver();
+
+        expect(() =>
+            driver.extractDataFromResponse(
+                { model: 'gpt-5.6-sol' },
+                failedResponse({ code: 'invalid_prompt', message: 'Schema keyword is not supported.' }),
+            ),
+        ).toThrow(
+            '[OpenAI Responses API] Schema keyword is not supported. (invalid_prompt) [response resp_failed_123]',
+        );
+    });
+
+    it('surfaces the provider cause from response.failed streams before result validation', async () => {
+        const driver = new TestOpenAIResponsesDriver();
+        const response = failedResponse({ code: 'server_error', message: 'Provider could not generate a response.' });
+        driver.service = {
+            responses: {
+                create: vi.fn().mockResolvedValue(
+                    (async function* () {
+                        yield { type: 'response.failed', sequence_number: 1, response };
+                    })(),
+                ),
+            },
+        } as unknown as OpenAI;
+
+        const stream = await driver.requestTextCompletionStream([{ role: 'user', content: 'hello' }], {
+            model: 'gpt-5.6-sol',
+        });
+        const consume = async () => {
+            for await (const _chunk of stream) {
+                // Consume the provider stream.
+            }
+        };
+
+        await expect(consume()).rejects.toMatchObject({
+            name: 'OpenAIResponseError',
+            code: 'server_error',
+            status: 500,
+            message:
+                '[OpenAI Responses API] Provider could not generate a response. (server_error) [response resp_failed_123]',
+        });
+    });
+});
+
 describe('OpenAIResponsesDriverBase prompt caching', () => {
     it('passes prompt_cache_key to blocking Responses requests', async () => {
         const driver = new TestOpenAIResponsesDriver();

--- a/drivers/src/openai/error-handling.test.ts
+++ b/drivers/src/openai/error-handling.test.ts
@@ -99,6 +99,26 @@ describe('OpenAI Responses failed-response handling', () => {
         );
     });
 
+    it('treats an unknown failed-response code as non-retryable', () => {
+        const driver = new TestOpenAIResponsesDriver();
+        let thrown: unknown;
+
+        try {
+            driver.extractDataFromResponse(
+                { model: 'gpt-5.6-sol' },
+                failedResponse({ code: 'provider_specific_failure', message: 'Request rejected.' }),
+            );
+        } catch (error: unknown) {
+            thrown = error;
+        }
+
+        expect(thrown).toMatchObject({
+            name: 'OpenAIResponseError',
+            code: 'provider_specific_failure',
+            status: 400,
+        });
+    });
+
     it('surfaces the provider cause from response.failed streams before result validation', async () => {
         const driver = new TestOpenAIResponsesDriver();
         const response = failedResponse({ code: 'server_error', message: 'Provider could not generate a response.' });

--- a/drivers/src/openai/error-handling.test.ts
+++ b/drivers/src/openai/error-handling.test.ts
@@ -121,7 +121,10 @@ describe('OpenAI Responses failed-response handling', () => {
 
     it('surfaces the provider cause from response.failed streams before result validation', async () => {
         const driver = new TestOpenAIResponsesDriver();
-        const response = failedResponse({ code: 'server_error', message: 'Provider could not generate a response.' });
+        const response = {
+            ...failedResponse({ code: 'server_error', message: 'Provider could not generate a response.' }),
+            usage: { input_tokens: 10, output_tokens: 2, total_tokens: 12 },
+        } as OpenAI.Responses.Response;
         driver.service = {
             responses: {
                 create: vi.fn().mockResolvedValue(
@@ -135,9 +138,10 @@ describe('OpenAI Responses failed-response handling', () => {
         const stream = await driver.requestTextCompletionStream([{ role: 'user', content: 'hello' }], {
             model: 'gpt-5.6-sol',
         });
+        let failedUsage: unknown;
         const consume = async () => {
-            for await (const _chunk of stream) {
-                // Consume the provider stream.
+            for await (const chunk of stream) {
+                failedUsage = chunk.token_usage;
             }
         };
 
@@ -147,6 +151,12 @@ describe('OpenAI Responses failed-response handling', () => {
             status: 500,
             message:
                 '[OpenAI Responses API] Provider could not generate a response. (server_error) [response resp_failed_123]',
+        });
+        expect(failedUsage).toEqual({
+            prompt: 10,
+            prompt_new: 10,
+            result: 2,
+            total: 12,
         });
     });
 });

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -1324,9 +1324,7 @@ function responseErrorStatus(code: string): number {
     if (code === 'server_error') return 500;
     if (code === 'vector_store_timeout') return 408;
     if (code === 'image_file_not_found') return 404;
-    // Known policy, prompt, residency, and image-validation failures are request errors. Unknown
-    // proxy/provider codes are treated as server failures so the normal driver retry policy can
-    // recover from transient OpenAI-compatible backends.
+    // Known policy, prompt, residency, and image-validation failures are request errors.
     if (
         code === 'invalid_prompt' ||
         code === 'data_residency_mismatch' ||
@@ -1342,7 +1340,9 @@ function responseErrorStatus(code: string): number {
     ) {
         return 400;
     }
-    return 500;
+    // Unknown failed-response codes are not evidence of a transient provider failure. Treat them
+    // as non-retryable request errors so one billed failure cannot fan out into a retry storm.
+    return 400;
 }
 
 function openAIResponseFailure(response: OpenAI.Responses.Response): OpenAIResponseFailure {

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -41,6 +41,7 @@ import {
 import type OpenAI from 'openai';
 import type { AzureOpenAI } from 'openai';
 import { resolveModelListingMetadata } from '../shared/model-listing.js';
+import { createToolChoiceConfigurationError } from '../shared/tool-choice-error.js';
 import { mergeOpenAIExtraBody, type OpenAIExtraBody } from './extra_body.js';
 import { OpenAICompatibleDriverBase } from './openai_compatible.js';
 import { formatOpenAILikeMultimodalPrompt } from './openai_format.js';
@@ -77,13 +78,19 @@ function getOpenAIResponseToolChoice(
 function assertOpenAIResponseToolChoiceAvailable(
     modelOptions: OpenAIRequestOptions | undefined,
     useTools: boolean,
+    model: string,
+    provider: string,
+    operation: 'execute' | 'stream',
 ): void {
     const forced =
         typeof modelOptions?.required_tool_name === 'string' ||
         modelOptions?.tool_choice === 'required' ||
         modelOptions?.tool_choice === 'any';
     if (forced && !useTools) {
-        throw new Error('[OpenAI Responses API] A required tool choice was requested, but no tools are available.');
+        throw createToolChoiceConfigurationError(
+            '[OpenAI Responses API] A required tool choice was requested, but no tools are available.',
+            { provider, model, operation },
+        );
     }
 }
 
@@ -259,7 +266,7 @@ export class OpenAIResponsesProtocol {
         convertRoles(prompt, options.model);
 
         const model_options = options.model_options as OpenAIRequestOptions | undefined;
-        assertOpenAIResponseToolChoiceAvailable(model_options, useTools);
+        assertOpenAIResponseToolChoiceAvailable(model_options, useTools, options.model, driver.provider, 'stream');
         insert_image_detail(prompt, model_options?.image_detail ?? 'auto');
 
         let parsedSchema: JSONSchema | undefined;
@@ -350,7 +357,7 @@ export class OpenAIResponsesProtocol {
 
         const toolDefs = getToolDefinitions(options.tools);
         const useTools = Boolean(toolDefs?.length && supportsToolUse(options.model, driver.provider));
-        assertOpenAIResponseToolChoiceAvailable(model_options, useTools);
+        assertOpenAIResponseToolChoiceAvailable(model_options, useTools, options.model, driver.provider, 'execute');
 
         // Fix orphaned function_call items (can occur when agent is stopped mid-tool-execution)
         let conversation = fixOrphanedToolResults(fixOrphanedToolUse(updateConversation(options.conversation, prompt)));

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -442,6 +442,7 @@ export abstract class OpenAIResponsesDriverBase extends OpenAICompatibleDriverBa
     }
 
     extractDataFromResponse(_options: ExecutionOptions, result: OpenAI.Responses.Response): Completion {
+        assertOpenAIResponseSucceeded(result);
         const tokenInfo = mapUsage(result.usage);
 
         const tools = collectTools(result.output);
@@ -1034,6 +1035,7 @@ export function mapResponseStream(
                     event.type === 'response.incomplete' ||
                     event.type === 'response.failed'
                 ) {
+                    assertOpenAIResponseSucceeded(event.response);
                     finalResponse = event.response;
                     const finalTools = collectTools(event.response.output);
                     yield {
@@ -1288,6 +1290,54 @@ function responseFinishReason(
         return response.status;
     }
     return 'stop';
+}
+
+type OpenAIResponseFailure = Error & {
+    code: string;
+    status: number;
+};
+
+function responseErrorStatus(code: string): number {
+    if (code === 'rate_limit_exceeded') return 429;
+    if (code === 'server_error') return 500;
+    if (code === 'vector_store_timeout') return 408;
+    if (code === 'image_file_not_found') return 404;
+    // Known policy, prompt, residency, and image-validation failures are request errors. Unknown
+    // proxy/provider codes are treated as server failures so the normal driver retry policy can
+    // recover from transient OpenAI-compatible backends.
+    if (
+        code === 'invalid_prompt' ||
+        code === 'data_residency_mismatch' ||
+        code === 'bio_policy' ||
+        code.startsWith('invalid_image') ||
+        code === 'image_too_large' ||
+        code === 'image_too_small' ||
+        code === 'image_parse_error' ||
+        code === 'image_content_policy_violation' ||
+        code === 'unsupported_image_media_type' ||
+        code === 'empty_image_file' ||
+        code === 'image_file_too_large'
+    ) {
+        return 400;
+    }
+    return 500;
+}
+
+function openAIResponseFailure(response: OpenAI.Responses.Response): OpenAIResponseFailure {
+    const code = response.error?.code ?? 'response_failed';
+    const detail = response.error?.message ?? 'The provider returned a failed response without error details.';
+    const responseId = response.id ? ` [response ${response.id}]` : '';
+    const error = new Error(`[OpenAI Responses API] ${detail} (${code})${responseId}`) as OpenAIResponseFailure;
+    error.name = 'OpenAIResponseError';
+    error.code = code;
+    error.status = responseErrorStatus(code);
+    return error;
+}
+
+function assertOpenAIResponseSucceeded(response: OpenAI.Responses.Response): void {
+    if (response.status === 'failed') {
+        throw openAIResponseFailure(response);
+    }
 }
 
 /**

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -74,6 +74,19 @@ function getOpenAIResponseToolChoice(
     return modelOptions?.tool_choice === 'any' ? 'required' : modelOptions?.tool_choice;
 }
 
+function assertOpenAIResponseToolChoiceAvailable(
+    modelOptions: OpenAIRequestOptions | undefined,
+    useTools: boolean,
+): void {
+    const forced =
+        typeof modelOptions?.required_tool_name === 'string' ||
+        modelOptions?.tool_choice === 'required' ||
+        modelOptions?.tool_choice === 'any';
+    if (forced && !useTools) {
+        throw new Error('[OpenAI Responses API] A required tool choice was requested, but no tools are available.');
+    }
+}
+
 function asOpenAIResponseServiceTier(serviceTier?: string): OpenAIResponseServiceTier {
     // The public option deliberately accepts future provider values that may predate the installed SDK union.
     return serviceTier as OpenAIResponseServiceTier;
@@ -235,7 +248,7 @@ export class OpenAIResponsesProtocol {
         let conversation = fixOrphanedToolResults(fixOrphanedToolUse(updateConversation(options.conversation, prompt)));
 
         const toolDefs = getToolDefinitions(options.tools);
-        const useTools: boolean = toolDefs ? supportsToolUse(options.model, driver.provider, true) : false;
+        const useTools = Boolean(toolDefs?.length && supportsToolUse(options.model, driver.provider, true));
 
         // When no tools are provided but conversation contains function_call/function_call_output
         // items (e.g. checkpoint summary calls), convert them to text to avoid API errors
@@ -246,6 +259,7 @@ export class OpenAIResponsesProtocol {
         convertRoles(prompt, options.model);
 
         const model_options = options.model_options as OpenAIRequestOptions | undefined;
+        assertOpenAIResponseToolChoiceAvailable(model_options, useTools);
         insert_image_detail(prompt, model_options?.image_detail ?? 'auto');
 
         let parsedSchema: JSONSchema | undefined;
@@ -335,7 +349,8 @@ export class OpenAIResponsesProtocol {
         insert_image_detail(prompt, model_options?.image_detail ?? 'auto');
 
         const toolDefs = getToolDefinitions(options.tools);
-        const useTools: boolean = toolDefs ? supportsToolUse(options.model, driver.provider) : false;
+        const useTools = Boolean(toolDefs?.length && supportsToolUse(options.model, driver.provider));
+        assertOpenAIResponseToolChoiceAvailable(model_options, useTools);
 
         // Fix orphaned function_call items (can occur when agent is stopped mid-tool-execution)
         let conversation = fixOrphanedToolResults(fixOrphanedToolUse(updateConversation(options.conversation, prompt)));
@@ -1050,7 +1065,6 @@ export function mapResponseStream(
                     event.type === 'response.incomplete' ||
                     event.type === 'response.failed'
                 ) {
-                    assertOpenAIResponseSucceeded(event.response);
                     finalResponse = event.response;
                     const finalTools = collectTools(event.response.output);
                     yield {
@@ -1059,6 +1073,9 @@ export function mapResponseStream(
                         token_usage: mapUsage(event.response.usage),
                         service_tier: event.response.service_tier ?? undefined,
                     } satisfies CompletionChunkObject;
+                    // Preserve provider usage even when the terminal response is failed/incomplete;
+                    // the next iterator step surfaces the provider error to the caller.
+                    assertOpenAIResponseSucceeded(event.response);
                 }
             }
         },

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -59,7 +59,18 @@ type OpenAIRequestOptions = Partial<TextFallbackOptions> & {
     prompt_cache_retention?: 'in_memory' | '24h';
     service_tier?: string;
     extra_body?: OpenAIExtraBody;
+    /** Internal execution hint supplied after public model-option validation. */
+    required_tool_name?: string;
 };
+
+function getOpenAIResponseToolChoice(
+    modelOptions: OpenAIRequestOptions | undefined,
+): OpenAI.Responses.ResponseCreateParams['tool_choice'] {
+    if (modelOptions?.required_tool_name) {
+        return { type: 'function', name: modelOptions.required_tool_name };
+    }
+    return modelOptions?.tool_choice === 'any' ? 'required' : modelOptions?.tool_choice;
+}
 
 function asOpenAIResponseServiceTier(serviceTier?: string): OpenAIResponseServiceTier {
     // The public option deliberately accepts future provider values that may predate the installed SDK union.
@@ -263,7 +274,7 @@ export class OpenAIResponsesProtocol {
             driver.getResponsesRequestModel(options.model),
             promptCacheKey,
         );
-        const toolChoice = model_options?.tool_choice === 'any' ? 'required' : model_options?.tool_choice;
+        const toolChoice = getOpenAIResponseToolChoice(model_options);
         const request = mergeOpenAIExtraBody<OpenAI.Responses.ResponseCreateParamsStreaming>(
             {
                 stream: true,
@@ -359,7 +370,7 @@ export class OpenAIResponsesProtocol {
             driver.getResponsesRequestModel(options.model),
             promptCacheKey,
         );
-        const toolChoice = model_options?.tool_choice === 'any' ? 'required' : model_options?.tool_choice;
+        const toolChoice = getOpenAIResponseToolChoice(model_options);
         const request = mergeOpenAIExtraBody<OpenAI.Responses.ResponseCreateParamsNonStreaming>(
             {
                 stream: false,

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -1104,6 +1104,13 @@ function supportsSchema(model: string, provider: Providers): boolean {
     if (realtimeModel) {
         return false;
     }
+    // OpenRouter's OpenAI-compatible Responses surface advertises native structured output for
+    // GLM 5.3, but the model returns unconstrained prose and downstream validation fails. Keep
+    // this generation on the existing prompt-schema fallback; later GLM generations remain
+    // eligible for native support unless runtime evidence says otherwise.
+    if (provider === Providers.openai_compatible && /^z-ai\/glm-5\.3(?:$|[-/:])/.test(model)) {
+        return false;
+    }
     return supportsToolUse(model, provider);
 }
 

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -61,6 +61,8 @@ type OpenAIRequestOptions = Partial<TextFallbackOptions> & {
     extra_body?: OpenAIExtraBody;
     /** Internal execution hint supplied after public model-option validation. */
     required_tool_name?: string;
+    /** Internal execution hint used with a required named tool. */
+    parallel_tool_calls?: boolean;
 };
 
 function getOpenAIResponseToolChoice(
@@ -291,6 +293,7 @@ export class OpenAIResponsesProtocol {
                 service_tier: asOpenAIResponseServiceTier(model_options?.service_tier),
                 tools: useTools ? toolDefs : undefined,
                 tool_choice: useTools ? toolChoice : undefined,
+                parallel_tool_calls: useTools ? model_options?.parallel_tool_calls : undefined,
                 text: buildResponseTextConfig(
                     parsedSchema,
                     strictMode,
@@ -387,6 +390,7 @@ export class OpenAIResponsesProtocol {
                 service_tier: asOpenAIResponseServiceTier(model_options?.service_tier),
                 tools: useTools ? toolDefs : undefined,
                 tool_choice: useTools ? toolChoice : undefined,
+                parallel_tool_calls: useTools ? model_options?.parallel_tool_calls : undefined,
                 text: buildResponseTextConfig(
                     parsedSchema,
                     strictMode,

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -261,6 +261,7 @@ export class OpenAIResponsesProtocol {
             driver.getResponsesRequestModel(options.model),
             promptCacheKey,
         );
+        const toolChoice = model_options?.tool_choice === 'any' ? 'required' : model_options?.tool_choice;
         const request: OpenAI.Responses.ResponseCreateParamsStreaming = {
             stream: true,
             model: driver.getResponsesRequestModel(options.model),
@@ -275,6 +276,7 @@ export class OpenAIResponsesProtocol {
             max_output_tokens: model_options?.max_tokens,
             service_tier: asOpenAIResponseServiceTier(model_options?.service_tier),
             tools: useTools ? toolDefs : undefined,
+            tool_choice: useTools ? toolChoice : undefined,
             text: buildResponseTextConfig(
                 parsedSchema,
                 strictMode,
@@ -352,6 +354,7 @@ export class OpenAIResponsesProtocol {
             driver.getResponsesRequestModel(options.model),
             promptCacheKey,
         );
+        const toolChoice = model_options?.tool_choice === 'any' ? 'required' : model_options?.tool_choice;
         const request = {
             stream: false,
             model: driver.getResponsesRequestModel(options.model),
@@ -366,6 +369,7 @@ export class OpenAIResponsesProtocol {
             max_output_tokens: model_options?.max_tokens,
             service_tier: asOpenAIResponseServiceTier(model_options?.service_tier),
             tools: useTools ? toolDefs : undefined,
+            tool_choice: useTools ? toolChoice : undefined,
             text: buildResponseTextConfig(
                 parsedSchema,
                 strictMode,

--- a/drivers/src/openai/openai_chat_completions.test.ts
+++ b/drivers/src/openai/openai_chat_completions.test.ts
@@ -1161,6 +1161,58 @@ describe('OpenAIChatCompletionsProtocol', () => {
         expect(chunks[chunks.length - 1].finish_reason).toBe('tool_use');
     });
 
+    it('keeps empty argument deltas as strings and preserves a length stop', async () => {
+        const model = new TestOpenAIChatCompletionsProtocol(
+            undefined,
+            createSSEStream([
+                {
+                    type: 'event',
+                    data: JSON.stringify({
+                        id: 'chatcmpl-1',
+                        object: 'chat.completion.chunk',
+                        created: 1,
+                        model: 'test/model',
+                        choices: [
+                            {
+                                index: 0,
+                                delta: {
+                                    tool_calls: [
+                                        {
+                                            index: 0,
+                                            id: 'call_real_id',
+                                            type: 'function',
+                                            function: { name: 'write_artifact', arguments: '{"name"' },
+                                        },
+                                    ],
+                                },
+                            },
+                        ],
+                    }),
+                },
+                {
+                    type: 'event',
+                    data: JSON.stringify({
+                        id: 'chatcmpl-1',
+                        object: 'chat.completion.chunk',
+                        created: 1,
+                        model: 'test/model',
+                        choices: [
+                            {
+                                index: 0,
+                                delta: { tool_calls: [{ index: 0, function: { arguments: '' } }] },
+                                finish_reason: 'length',
+                            },
+                        ],
+                    }),
+                },
+            ]),
+        );
+
+        const chunks = await collectChunks(await model.requestTextCompletionStream(undefined, prompt, options));
+        expect(chunks.flatMap((chunk) => chunk.tool_use ?? []).map((tool) => tool.tool_input)).toEqual(['{"name"', '']);
+        expect(chunks.at(-1)?.finish_reason).toBe('length');
+    });
+
     it('normalizes tool schemas and structured-output schemas for Chat Completions payloads', async () => {
         const model = new TestOpenAIChatCompletionsProtocol({
             id: 'chatcmpl-1',

--- a/drivers/src/openai/openai_chat_completions.test.ts
+++ b/drivers/src/openai/openai_chat_completions.test.ts
@@ -1095,7 +1095,12 @@ describe('OpenAIChatCompletionsProtocol', () => {
                 tools: [],
                 model_options: { _option_id: 'text-fallback', tool_choice: 'required' },
             }),
-        ).rejects.toThrow('required tool choice was requested, but no tools are available');
+        ).rejects.toMatchObject({
+            name: 'ToolChoiceConfigurationError',
+            retryable: false,
+            code: 400,
+            message: expect.stringContaining('required tool choice was requested, but no tools are available'),
+        });
         expect(model.payloads).toHaveLength(0);
     });
 

--- a/drivers/src/openai/openai_chat_completions.test.ts
+++ b/drivers/src/openai/openai_chat_completions.test.ts
@@ -1080,6 +1080,25 @@ describe('OpenAIChatCompletionsProtocol', () => {
         ]);
     });
 
+    it('rejects a required tool choice when no tools are available', async () => {
+        const model = new TestOpenAIChatCompletionsProtocol({
+            id: 'chatcmpl-1',
+            object: 'chat.completion',
+            created: 1,
+            model: 'test/model',
+            choices: [],
+        });
+
+        await expect(
+            model.requestTextCompletion(undefined, prompt, {
+                ...options,
+                tools: [],
+                model_options: { _option_id: 'text-fallback', tool_choice: 'required' },
+            }),
+        ).rejects.toThrow('required tool choice was requested, but no tools are available');
+        expect(model.payloads).toHaveLength(0);
+    });
+
     it('throws when a non-streaming response has no content or tool calls', async () => {
         const model = new TestOpenAIChatCompletionsProtocol({
             id: 'chatcmpl-1',

--- a/drivers/src/openai/openai_chat_completions.test.ts
+++ b/drivers/src/openai/openai_chat_completions.test.ts
@@ -144,6 +144,45 @@ const options: ExecutionOptions = {
 };
 
 describe('OpenAIChatCompletionsProtocol', () => {
+    it('preserves compatible-provider prompt cache usage', async () => {
+        const model = new TestOpenAIChatCompletionsProtocol({
+            id: 'chatcmpl-cache',
+            object: 'chat.completion',
+            created: 1,
+            model: 'compatible-model',
+            choices: [
+                {
+                    index: 0,
+                    message: { role: 'assistant', content: 'ok' },
+                    finish_reason: 'stop',
+                    logprobs: null,
+                },
+            ],
+            usage: {
+                prompt_tokens: 1_000,
+                completion_tokens: 20,
+                total_tokens: 1_020,
+                prompt_tokens_details: { cached_tokens: 800, audio_tokens: 0 },
+                completion_tokens_details: {
+                    accepted_prediction_tokens: 0,
+                    audio_tokens: 0,
+                    reasoning_tokens: 0,
+                    rejected_prediction_tokens: 0,
+                },
+            },
+        });
+
+        const completion = await model.requestTextCompletion(undefined, prompt, options);
+
+        expect(completion.token_usage).toMatchObject({
+            prompt: 1_000,
+            prompt_cached: 800,
+            prompt_new: 200,
+            result: 20,
+            total: 1_020,
+        });
+    });
+
     it('preserves compatible reasoning fields at the OpenAI SDK transport boundary', async () => {
         const response = {
             id: 'chatcmpl-1',

--- a/drivers/src/openai/openai_chat_completions.test.ts
+++ b/drivers/src/openai/openai_chat_completions.test.ts
@@ -326,6 +326,35 @@ describe('OpenAIChatCompletionsProtocol', () => {
         expect(model.payloads[0].tool_choice).toBe(expected);
     });
 
+    it('forces one named tool without changing the visible tool definitions', async () => {
+        const model = new TestOpenAIChatCompletionsProtocol({
+            id: 'chatcmpl-1',
+            object: 'chat.completion',
+            created: 1,
+            model: 'test/model',
+            choices: [{ index: 0, message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' }],
+        });
+
+        await model.requestTextCompletion(undefined, prompt, {
+            ...options,
+            model_options: {
+                _option_id: 'text-fallback',
+                tool_choice: 'required',
+                required_tool_name: 'write_artifact',
+            } as ExecutionOptions['model_options'] & { required_tool_name: string },
+            tools: [
+                { name: 'read_artifact', description: 'Read', input_schema: { type: 'object' } },
+                { name: 'write_artifact', description: 'Write', input_schema: { type: 'object' } },
+            ],
+        });
+
+        expect(model.payloads[0].tools).toHaveLength(2);
+        expect(model.payloads[0].tool_choice).toEqual({
+            type: 'function',
+            function: { name: 'write_artifact' },
+        });
+    });
+
     it('reads text from non-streaming content arrays', async () => {
         const model = new TestOpenAIChatCompletionsProtocol({
             id: 'chatcmpl-1',

--- a/drivers/src/openai/openai_chat_completions.test.ts
+++ b/drivers/src/openai/openai_chat_completions.test.ts
@@ -290,6 +290,34 @@ describe('OpenAIChatCompletionsProtocol', () => {
         expect(model.payloads[0].tool_choice).toBeUndefined();
     });
 
+    it.each([
+        ['required', 'required'],
+        ['any', 'required'],
+    ] as const)('forwards explicit %s tool choice as %s', async (configured, expected) => {
+        const model = new TestOpenAIChatCompletionsProtocol({
+            id: 'chatcmpl-1',
+            object: 'chat.completion',
+            created: 1,
+            model: 'test/model',
+            choices: [
+                {
+                    index: 0,
+                    message: { role: 'assistant', content: 'ok' },
+                    finish_reason: 'stop',
+                    logprobs: null,
+                },
+            ],
+        });
+
+        await model.requestTextCompletion(undefined, prompt, {
+            ...options,
+            model_options: { _option_id: 'text-fallback', tool_choice: configured },
+            tools: [{ name: 'think', description: 'Think', input_schema: { type: 'object' } }],
+        });
+
+        expect(model.payloads[0].tool_choice).toBe(expected);
+    });
+
     it('reads text from non-streaming content arrays', async () => {
         const model = new TestOpenAIChatCompletionsProtocol({
             id: 'chatcmpl-1',

--- a/drivers/src/openai/openai_chat_completions.test.ts
+++ b/drivers/src/openai/openai_chat_completions.test.ts
@@ -341,7 +341,8 @@ describe('OpenAIChatCompletionsProtocol', () => {
                 _option_id: 'text-fallback',
                 tool_choice: 'required',
                 required_tool_name: 'write_artifact',
-            } as ExecutionOptions['model_options'] & { required_tool_name: string },
+                parallel_tool_calls: false,
+            } as ExecutionOptions['model_options'] & { required_tool_name: string; parallel_tool_calls: false },
             tools: [
                 { name: 'read_artifact', description: 'Read', input_schema: { type: 'object' } },
                 { name: 'write_artifact', description: 'Write', input_schema: { type: 'object' } },
@@ -353,6 +354,7 @@ describe('OpenAIChatCompletionsProtocol', () => {
             type: 'function',
             function: { name: 'write_artifact' },
         });
+        expect(model.payloads[0].parallel_tool_calls).toBe(false);
     });
 
     it('reads text from non-streaming content arrays', async () => {

--- a/drivers/src/openai/openai_chat_completions.ts
+++ b/drivers/src/openai/openai_chat_completions.ts
@@ -1163,6 +1163,8 @@ export abstract class OpenAIChatCompletionsProtocol<DriverT> {
             seed?: number;
             service_tier?: string;
             tool_choice?: 'auto' | 'none' | 'any' | 'required';
+            /** Internal execution hint supplied after public model-option validation. */
+            required_tool_name?: string;
         };
         const payload: OpenAIChatCompletionsPayload = {
             model: this.getModelName(options),
@@ -1190,7 +1192,11 @@ export abstract class OpenAIChatCompletionsProtocol<DriverT> {
         const toolsPayload = convertToolsToOpenAIChatCompletionsFormat(options.tools, this.options.toolSchemaMode);
         if (toolsPayload && toolsPayload.length > 0) {
             payload.tools = toolsPayload;
-            payload.tool_choice = modelOptions?.tool_choice === 'any' ? 'required' : modelOptions?.tool_choice;
+            payload.tool_choice = modelOptions?.required_tool_name
+                ? { type: 'function', function: { name: modelOptions.required_tool_name } }
+                : modelOptions?.tool_choice === 'any'
+                  ? 'required'
+                  : modelOptions?.tool_choice;
         }
 
         if (options.result_schema && this.options.resultSchemaMode !== 'prompt') {

--- a/drivers/src/openai/openai_chat_completions.ts
+++ b/drivers/src/openai/openai_chat_completions.ts
@@ -1161,6 +1161,7 @@ export abstract class OpenAIChatCompletionsProtocol<DriverT> {
             reasoning_effort?: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
             seed?: number;
             service_tier?: string;
+            tool_choice?: 'auto' | 'none' | 'any' | 'required';
         };
         const payload: OpenAIChatCompletionsPayload = {
             model: this.getModelName(options),
@@ -1187,6 +1188,7 @@ export abstract class OpenAIChatCompletionsProtocol<DriverT> {
         const toolsPayload = convertToolsToOpenAIChatCompletionsFormat(options.tools, this.options.toolSchemaMode);
         if (toolsPayload && toolsPayload.length > 0) {
             payload.tools = toolsPayload;
+            payload.tool_choice = modelOptions?.tool_choice === 'any' ? 'required' : modelOptions?.tool_choice;
         }
 
         if (options.result_schema && this.options.resultSchemaMode !== 'prompt') {

--- a/drivers/src/openai/openai_chat_completions.ts
+++ b/drivers/src/openai/openai_chat_completions.ts
@@ -1201,6 +1201,15 @@ export abstract class OpenAIChatCompletionsProtocol<DriverT> {
         }
 
         const toolsPayload = convertToolsToOpenAIChatCompletionsFormat(options.tools, this.options.toolSchemaMode);
+        const forcedToolChoice =
+            typeof modelOptions?.required_tool_name === 'string' ||
+            modelOptions?.tool_choice === 'required' ||
+            modelOptions?.tool_choice === 'any';
+        if (forcedToolChoice && (!toolsPayload || toolsPayload.length === 0)) {
+            throw new Error(
+                '[OpenAI Chat Completions API] A required tool choice was requested, but no tools are available.',
+            );
+        }
         if (toolsPayload && toolsPayload.length > 0) {
             payload.tools = toolsPayload;
             payload.tool_choice = modelOptions?.required_tool_name

--- a/drivers/src/openai/openai_chat_completions.ts
+++ b/drivers/src/openai/openai_chat_completions.ts
@@ -367,10 +367,13 @@ function mapOpenAIChatCompletionsUsage(usage?: OpenAIChatCompletionsUsage | null
     if (!usage) {
         return undefined;
     }
+    const cachedTokens = usage.prompt_tokens_details?.cached_tokens;
     return {
         prompt: usage.prompt_tokens,
         result: usage.completion_tokens,
         total: usage.total_tokens,
+        prompt_cached: cachedTokens ?? undefined,
+        prompt_new: Math.max(0, usage.prompt_tokens - (cachedTokens ?? 0)),
     };
 }
 

--- a/drivers/src/openai/openai_chat_completions.ts
+++ b/drivers/src/openai/openai_chat_completions.ts
@@ -1239,6 +1239,7 @@ export interface OpenAIChatCompletionsDriverOptions extends DriverOptions {
     defaultMaxTokens?: number;
     extraBody?: Record<string, unknown>;
     resultSchemaMode?: OpenAIChatCompletionsProtocolOptions['resultSchemaMode'];
+    includeResultSchemaInPrompt?: OpenAIChatCompletionsProtocolOptions['includeResultSchemaInPrompt'];
     toolSchemaMode?: OpenAIChatCompletionsProtocolOptions['toolSchemaMode'];
 }
 
@@ -1429,6 +1430,7 @@ export abstract class OpenAIChatCompletionsDriverBase<
             defaultMaxTokens: options.defaultMaxTokens,
             extraBody: options.extraBody,
             resultSchemaMode: options.resultSchemaMode,
+            includeResultSchemaInPrompt: options.includeResultSchemaInPrompt,
             toolSchemaMode: options.toolSchemaMode,
         });
     }

--- a/drivers/src/openai/openai_chat_completions.ts
+++ b/drivers/src/openai/openai_chat_completions.ts
@@ -164,6 +164,8 @@ export interface OpenAIChatCompletionsProtocolOptions {
     resultSchemaMode?: 'response_format' | 'prompt';
     /** Supplement native structured output with prompt alignment for providers with unreliable enforcement. */
     includeResultSchemaInPrompt?: boolean;
+    /** Model-specific form of the prompt alignment guard for mixed-model providers. */
+    includeResultSchemaInPromptForModel?: (model: string) => boolean;
     /**
      * OpenAI supports strict function schemas. Some OpenAI-compatible providers reject
      * or mis-handle those OpenAI-specific fields, so adapters can request a looser
@@ -889,7 +891,9 @@ export abstract class OpenAIChatCompletionsProtocol<DriverT> {
             ? `IMPORTANT: only answer using JSON, and respecting the schema included below, between the <response_schema> tags. <response_schema>${JSON.stringify(_options.result_schema)}</response_schema>`
             : undefined;
         if (
-            (this.options.resultSchemaMode === 'prompt' || this.options.includeResultSchemaInPrompt) &&
+            (this.options.resultSchemaMode === 'prompt' ||
+                this.options.includeResultSchemaInPrompt ||
+                this.options.includeResultSchemaInPromptForModel?.(_options.model)) &&
             resultSchemaInstruction
         ) {
             messages.push({
@@ -1242,6 +1246,7 @@ export interface OpenAIChatCompletionsDriverOptions extends DriverOptions {
     extraBody?: Record<string, unknown>;
     resultSchemaMode?: OpenAIChatCompletionsProtocolOptions['resultSchemaMode'];
     includeResultSchemaInPrompt?: OpenAIChatCompletionsProtocolOptions['includeResultSchemaInPrompt'];
+    includeResultSchemaInPromptForModel?: OpenAIChatCompletionsProtocolOptions['includeResultSchemaInPromptForModel'];
     toolSchemaMode?: OpenAIChatCompletionsProtocolOptions['toolSchemaMode'];
 }
 
@@ -1433,6 +1438,7 @@ export abstract class OpenAIChatCompletionsDriverBase<
             extraBody: options.extraBody,
             resultSchemaMode: options.resultSchemaMode,
             includeResultSchemaInPrompt: options.includeResultSchemaInPrompt,
+            includeResultSchemaInPromptForModel: options.includeResultSchemaInPromptForModel,
             toolSchemaMode: options.toolSchemaMode,
         });
     }

--- a/drivers/src/openai/openai_chat_completions.ts
+++ b/drivers/src/openai/openai_chat_completions.ts
@@ -381,6 +381,9 @@ function normalizeOpenAIChatCompletionsFinishReason(
     reason: string | null | undefined,
     hasToolUse: boolean = false,
 ): string | undefined {
+    // A provider may include a partial tool-call delta on the token-limit chunk. Preserve
+    // truncation so core drops the incomplete call instead of classifying it as malformed JSON.
+    if (reason === 'length') return 'length';
     if (hasToolUse || reason === 'tool_calls' || reason === 'function_call') {
         return 'tool_use';
     }
@@ -1111,10 +1114,9 @@ export abstract class OpenAIChatCompletionsProtocol<DriverT> {
                     const toolUse: StreamingOpenAIToolUse = {
                         id: `tool_${index}`,
                         tool_name: tc.function?.name ?? '',
-                        tool_input:
-                            typeof tc.function?.arguments === 'string' && tc.function.arguments.length > 0
-                                ? tc.function.arguments
-                                : {},
+                        // Empty deltas are zero-byte string fragments, not parsed empty objects.
+                        // Keeping one representation prevents a placeholder from replacing prior JSON bytes.
+                        tool_input: typeof tc.function?.arguments === 'string' ? tc.function.arguments : '',
                     };
                     if (tc.id) {
                         toolUse._actual_id = tc.id;

--- a/drivers/src/openai/openai_chat_completions.ts
+++ b/drivers/src/openai/openai_chat_completions.ts
@@ -34,6 +34,7 @@ import {
 import { transformSSEStream } from '@llumiverse/core/async';
 import OpenAI from 'openai';
 import { resolveModelListingMetadata } from '../shared/model-listing.js';
+import { createToolChoiceConfigurationError } from '../shared/tool-choice-error.js';
 import { getOpenAIExtraBody, mergeOpenAIExtraBody } from './extra_body.js';
 import { OpenAICompatibleDriverBase } from './openai_compatible.js';
 import { formatOpenAISchema, limitedSchemaFormat } from './schema.js';
@@ -862,6 +863,13 @@ function finalizeOpenAIChatCompletionsConversation(
     return processedConversation;
 }
 
+function getOpenAIChatDriverProvider(driver: unknown): string {
+    if (typeof driver !== 'object' || driver === null || !('provider' in driver)) {
+        return Providers.openai_compatible;
+    }
+    return typeof driver.provider === 'string' ? driver.provider : Providers.openai_compatible;
+}
+
 export abstract class OpenAIChatCompletionsProtocol<DriverT> {
     protected readonly options: OpenAIChatCompletionsProtocolOptions;
 
@@ -1006,7 +1014,7 @@ export abstract class OpenAIChatCompletionsProtocol<DriverT> {
         conversation = prepareOpenAIChatCompletionsConversation(conversation, options);
         const includeThoughts =
             (options.model_options as TextFallbackOptions & { include_thoughts?: boolean })?.include_thoughts !== false;
-        const payload = this.buildPayload(conversation, options, false);
+        const payload = this.buildPayload(conversation, options, false, getOpenAIChatDriverProvider(driver));
         const result = await this.postChatCompletion(driver, payload, options, signal);
 
         const choice = result?.choices?.[0];
@@ -1065,7 +1073,7 @@ export abstract class OpenAIChatCompletionsProtocol<DriverT> {
         conversation = prepareOpenAIChatCompletionsConversation(conversation, options);
         const includeThoughts =
             (options.model_options as TextFallbackOptions & { include_thoughts?: boolean })?.include_thoughts !== false;
-        const payload = this.buildPayload(conversation, options, true);
+        const payload = this.buildPayload(conversation, options, true, getOpenAIChatDriverProvider(driver));
         const responseStream = await this.postChatCompletionStream(driver, payload, options, signal);
 
         const projector = new OpenAIThinkStreamProjector();
@@ -1165,6 +1173,7 @@ export abstract class OpenAIChatCompletionsProtocol<DriverT> {
         conversation: OpenAIChatCompletionsPrompt,
         options: ExecutionOptions,
         stream: boolean,
+        provider: string = Providers.openai_compatible,
     ): OpenAIChatCompletionsPayload {
         const modelOptions = options.model_options as TextFallbackOptions & {
             effort?: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
@@ -1206,8 +1215,9 @@ export abstract class OpenAIChatCompletionsProtocol<DriverT> {
             modelOptions?.tool_choice === 'required' ||
             modelOptions?.tool_choice === 'any';
         if (forcedToolChoice && (!toolsPayload || toolsPayload.length === 0)) {
-            throw new Error(
+            throw createToolChoiceConfigurationError(
                 '[OpenAI Chat Completions API] A required tool choice was requested, but no tools are available.',
+                { provider, model: options.model, operation: stream ? 'stream' : 'execute' },
             );
         }
         if (toolsPayload && toolsPayload.length > 0) {

--- a/drivers/src/openai/openai_chat_completions.ts
+++ b/drivers/src/openai/openai_chat_completions.ts
@@ -1165,6 +1165,8 @@ export abstract class OpenAIChatCompletionsProtocol<DriverT> {
             tool_choice?: 'auto' | 'none' | 'any' | 'required';
             /** Internal execution hint supplied after public model-option validation. */
             required_tool_name?: string;
+            /** Internal execution hint used with a required named tool. */
+            parallel_tool_calls?: boolean;
         };
         const payload: OpenAIChatCompletionsPayload = {
             model: this.getModelName(options),
@@ -1197,6 +1199,7 @@ export abstract class OpenAIChatCompletionsProtocol<DriverT> {
                 : modelOptions?.tool_choice === 'any'
                   ? 'required'
                   : modelOptions?.tool_choice;
+            payload.parallel_tool_calls = modelOptions?.parallel_tool_calls;
         }
 
         if (options.result_schema && this.options.resultSchemaMode !== 'prompt') {

--- a/drivers/src/openai/responses-reasoning.test.ts
+++ b/drivers/src/openai/responses-reasoning.test.ts
@@ -1,4 +1,4 @@
-import { Providers } from '@llumiverse/core';
+import { PromptRole, Providers } from '@llumiverse/core';
 import type OpenAI from 'openai';
 import { describe, expect, it, vi } from 'vitest';
 import { OpenAIResponsesDriverBase } from './index.js';
@@ -56,6 +56,35 @@ function response() {
 }
 
 describe('OpenAI Responses reasoning', () => {
+    it('uses prompt-schema fallback for GLM 5.3 on OpenAI-compatible Responses', async () => {
+        const create = vi.fn(async () => ({
+            ...response(),
+            model: 'z-ai/glm-5.3',
+            output: [
+                {
+                    ...messageItem,
+                    content: [{ type: 'output_text', text: '{"value":"ok"}', annotations: [], logprobs: [] }],
+                },
+            ],
+        }));
+        const driver = new TestResponsesDriver(create, Providers.openai_compatible);
+        const options = {
+            model: 'z-ai/glm-5.3',
+            result_schema: {
+                type: 'object' as const,
+                properties: { value: { type: 'string' as const } },
+                required: ['value'],
+                additionalProperties: false,
+            },
+        };
+        const prompt = await driver.createPrompt([{ role: PromptRole.user, content: 'Return the value.' }], options);
+
+        await driver.requestTextCompletion(prompt, options);
+
+        expect(JSON.stringify(prompt)).toContain('<response_schema>');
+        expect(create).toHaveBeenCalledWith(expect.not.objectContaining({ text: expect.anything() }));
+    });
+
     it.each([
         ['required', 'required'],
         ['any', 'required'],

--- a/drivers/src/openai/responses-reasoning.test.ts
+++ b/drivers/src/openai/responses-reasoning.test.ts
@@ -134,6 +134,20 @@ describe('OpenAI Responses reasoning', () => {
         );
     });
 
+    it('rejects a required tool choice when no tools are available', async () => {
+        const create = vi.fn(async (_request: unknown) => response());
+        const driver = new TestResponsesDriver(create);
+
+        await expect(
+            driver.requestTextCompletion([{ type: 'message', role: 'user', content: 'question' }], {
+                model: 'gpt-5.6-sol',
+                model_options: { _option_id: 'openai-thinking', tool_choice: 'required' },
+                tools: [],
+            }),
+        ).rejects.toThrow('required tool choice was requested, but no tools are available');
+        expect(create).not.toHaveBeenCalled();
+    });
+
     it('returns the processing tier reported by OpenAI', async () => {
         const driver = new TestResponsesDriver(vi.fn(async () => response()));
 

--- a/drivers/src/openai/responses-reasoning.test.ts
+++ b/drivers/src/openai/responses-reasoning.test.ts
@@ -101,6 +101,36 @@ describe('OpenAI Responses reasoning', () => {
         expect(create).toHaveBeenCalledWith(expect.objectContaining({ tool_choice: expected }));
     });
 
+    it('forces one named tool without changing the visible tool definitions', async () => {
+        const create = vi.fn(async (_request: unknown) => response());
+        const driver = new TestResponsesDriver(create);
+
+        await driver.requestTextCompletion([{ type: 'message', role: 'user', content: 'question' }], {
+            model: 'gpt-5.6-sol',
+            model_options: {
+                _option_id: 'openai-thinking',
+                tool_choice: 'required',
+                required_tool_name: 'write_artifact',
+            } as Parameters<typeof driver.requestTextCompletion>[1]['model_options'] & {
+                required_tool_name: string;
+            },
+            tools: [
+                { name: 'read_artifact', description: 'Read', input_schema: { type: 'object' } },
+                { name: 'write_artifact', description: 'Write', input_schema: { type: 'object' } },
+            ],
+        });
+
+        expect(create).toHaveBeenCalledWith(
+            expect.objectContaining({
+                tools: expect.arrayContaining([
+                    expect.objectContaining({ name: 'read_artifact' }),
+                    expect.objectContaining({ name: 'write_artifact' }),
+                ]),
+                tool_choice: { type: 'function', name: 'write_artifact' },
+            }),
+        );
+    });
+
     it('returns the processing tier reported by OpenAI', async () => {
         const driver = new TestResponsesDriver(vi.fn(async () => response()));
 

--- a/drivers/src/openai/responses-reasoning.test.ts
+++ b/drivers/src/openai/responses-reasoning.test.ts
@@ -56,6 +56,22 @@ function response() {
 }
 
 describe('OpenAI Responses reasoning', () => {
+    it.each([
+        ['required', 'required'],
+        ['any', 'required'],
+    ] as const)('forwards explicit %s tool choice as %s', async (configured, expected) => {
+        const create = vi.fn(async (_request: unknown) => response());
+        const driver = new TestResponsesDriver(create);
+
+        await driver.requestTextCompletion([{ type: 'message', role: 'user', content: 'question' }], {
+            model: 'gpt-5.6-sol',
+            model_options: { _option_id: 'openai-thinking', tool_choice: configured },
+            tools: [{ name: 'think', description: 'Think', input_schema: { type: 'object' } }],
+        });
+
+        expect(create).toHaveBeenCalledWith(expect.objectContaining({ tool_choice: expected }));
+    });
+
     it('returns the processing tier reported by OpenAI', async () => {
         const driver = new TestResponsesDriver(vi.fn(async () => response()));
 

--- a/drivers/src/openai/responses-reasoning.test.ts
+++ b/drivers/src/openai/responses-reasoning.test.ts
@@ -111,8 +111,10 @@ describe('OpenAI Responses reasoning', () => {
                 _option_id: 'openai-thinking',
                 tool_choice: 'required',
                 required_tool_name: 'write_artifact',
+                parallel_tool_calls: false,
             } as Parameters<typeof driver.requestTextCompletion>[1]['model_options'] & {
                 required_tool_name: string;
+                parallel_tool_calls: false;
             },
             tools: [
                 { name: 'read_artifact', description: 'Read', input_schema: { type: 'object' } },
@@ -127,6 +129,7 @@ describe('OpenAI Responses reasoning', () => {
                     expect.objectContaining({ name: 'write_artifact' }),
                 ]),
                 tool_choice: { type: 'function', name: 'write_artifact' },
+                parallel_tool_calls: false,
             }),
         );
     });

--- a/drivers/src/openai/responses-reasoning.test.ts
+++ b/drivers/src/openai/responses-reasoning.test.ts
@@ -144,7 +144,12 @@ describe('OpenAI Responses reasoning', () => {
                 model_options: { _option_id: 'openai-thinking', tool_choice: 'required' },
                 tools: [],
             }),
-        ).rejects.toThrow('required tool choice was requested, but no tools are available');
+        ).rejects.toMatchObject({
+            name: 'ToolChoiceConfigurationError',
+            retryable: false,
+            code: 400,
+            message: expect.stringContaining('required tool choice was requested, but no tools are available'),
+        });
         expect(create).not.toHaveBeenCalled();
     });
 

--- a/drivers/src/openrouter/index.test.ts
+++ b/drivers/src/openrouter/index.test.ts
@@ -12,6 +12,20 @@ describe('OpenRouterDriver native SDK transport', () => {
         expect(() => new OpenRouterDriver({ apiKey: '' })).toThrow('apiKey is required');
     });
 
+    it('supplements native structured output only for GLM 5.3', async () => {
+        const driver = new OpenRouterDriver({ apiKey: 'test-key' });
+        const resultSchema = { type: 'object' as const, properties: { answer: { type: 'string' as const } } };
+        const segments = [{ role: PromptRole.user, content: 'Answer.' }];
+
+        const glmPrompt = await driver.createPrompt(segments, { model: 'z-ai/glm-5.3', result_schema: resultSchema });
+        const grokPrompt = await driver.createPrompt(segments, { model: 'x-ai/grok-4.6', result_schema: resultSchema });
+
+        expect(glmPrompt.messages.some((message) => JSON.stringify(message).includes('<response_schema>'))).toBe(true);
+        expect(grokPrompt.messages.some((message) => JSON.stringify(message).includes('<response_schema>'))).toBe(
+            false,
+        );
+    });
+
     it('maps chat, structured output, tools, timeout, and the native response', async () => {
         const driver = new OpenRouterDriver({ apiKey: 'test-key' });
         const response = {

--- a/drivers/src/openrouter/index.test.ts
+++ b/drivers/src/openrouter/index.test.ts
@@ -1,4 +1,4 @@
-import { Base64DataSource, ModelType, PromptRole, Providers } from '@llumiverse/core';
+import { Base64DataSource, type ExecutionOptions, ModelType, PromptRole, Providers } from '@llumiverse/core';
 import { RequestTimeoutError } from '@openrouter/sdk/models/errors';
 import { describe, expect, it, vi } from 'vitest';
 import { OpenRouterDriver } from './index.js';
@@ -70,6 +70,12 @@ describe('OpenRouterDriver native SDK transport', () => {
                     provider_sort: 'throughput',
                     provider_order: ['google-vertex', 'amazon-bedrock'],
                     provider_allow_fallbacks: false,
+                    tool_choice: 'required',
+                    required_tool_name: 'lookup',
+                    parallel_tool_calls: false,
+                } as ExecutionOptions['model_options'] & {
+                    required_tool_name: string;
+                    parallel_tool_calls: false;
                 },
                 result_schema: {
                     type: 'object',
@@ -112,6 +118,8 @@ describe('OpenRouterDriver native SDK transport', () => {
                         function: expect.objectContaining({ name: 'lookup' }),
                     },
                 ],
+                toolChoice: { type: 'function', function: { name: 'lookup' } },
+                parallelToolCalls: false,
             },
         });
         expect(requestOptions).toEqual({ timeoutMs: 1_800_000 });

--- a/drivers/src/openrouter/index.test.ts
+++ b/drivers/src/openrouter/index.test.ts
@@ -201,7 +201,7 @@ describe('OpenRouterDriver native SDK transport', () => {
             }),
         });
         expect(stream.completion?.result).toContainEqual({ type: 'thoughts', value: 'thinking' });
-        expect(stream.completion?.token_usage).toEqual({ prompt: 2, result: 1, total: 3 });
+        expect(stream.completion?.token_usage).toEqual({ prompt: 2, prompt_new: 2, result: 1, total: 3 });
         expect(stream.completion?.tool_use).toEqual([
             { id: 'call_actual', tool_name: 'lookup', tool_input: { city: 'Paris' } },
         ]);

--- a/drivers/src/openrouter/index.test.ts
+++ b/drivers/src/openrouter/index.test.ts
@@ -185,8 +185,13 @@ describe('OpenRouterDriver native SDK transport', () => {
         const send = vi.fn(async (_request: unknown, _options?: unknown) => nativeStream);
         setService(driver, { chat: { send } });
 
-        const options = {
+        const options: ExecutionOptions = {
             model: 'openai/gpt-5.6-sol',
+            result_schema: {
+                type: 'object',
+                properties: { answer: { type: 'string' } },
+                required: ['answer'],
+            },
             tools: [{ name: 'lookup', input_schema: { type: 'object' } }],
         };
         const stream = await driver.stream([{ role: PromptRole.user, content: 'Weather?' }], options);
@@ -194,11 +199,22 @@ describe('OpenRouterDriver native SDK transport', () => {
             // Consume all native chunks so the final completion and conversation are assembled.
         }
 
-        expect(send.mock.calls[0][0]).toEqual({
-            chatRequest: expect.objectContaining({
+        expect(send.mock.calls[0][0]).toMatchObject({
+            chatRequest: {
                 stream: true,
                 streamOptions: { includeUsage: true },
-            }),
+                messages: [
+                    {
+                        role: 'system',
+                        content: expect.stringMatching(/only answer using JSON[\s\S]*<response_schema>[\s\S]*"answer"/),
+                    },
+                    { role: 'user', content: 'Weather?' },
+                ],
+                responseFormat: {
+                    type: 'json_schema',
+                    jsonSchema: expect.objectContaining({ name: 'output' }),
+                },
+            },
         });
         expect(stream.completion?.result).toContainEqual({ type: 'thoughts', value: 'thinking' });
         expect(stream.completion?.token_usage).toEqual({ prompt: 2, prompt_new: 2, result: 1, total: 3 });

--- a/drivers/src/openrouter/index.test.ts
+++ b/drivers/src/openrouter/index.test.ts
@@ -203,13 +203,7 @@ describe('OpenRouterDriver native SDK transport', () => {
             chatRequest: {
                 stream: true,
                 streamOptions: { includeUsage: true },
-                messages: [
-                    {
-                        role: 'system',
-                        content: expect.stringMatching(/only answer using JSON[\s\S]*<response_schema>[\s\S]*"answer"/),
-                    },
-                    { role: 'user', content: 'Weather?' },
-                ],
+                messages: [{ role: 'user', content: 'Weather?' }],
                 responseFormat: {
                     type: 'json_schema',
                     jsonSchema: expect.objectContaining({ name: 'output' }),

--- a/drivers/src/openrouter/index.ts
+++ b/drivers/src/openrouter/index.ts
@@ -51,7 +51,15 @@ export class OpenRouterDriver extends OpenAIChatCompletionsDriverBase<OpenRouter
     service: OpenRouter;
 
     constructor(options: OpenRouterDriverOptions) {
-        super({ ...options, resultSchemaMode: 'response_format', toolSchemaMode: 'compatible' });
+        super({
+            ...options,
+            resultSchemaMode: 'response_format',
+            // OpenRouter exposes one protocol across many model families. Some routed models accept
+            // response_format but do not enforce it, so keep the provider-native constraint and give
+            // the model the same stable schema instruction as a compatibility fallback.
+            includeResultSchemaInPrompt: true,
+            toolSchemaMode: 'compatible',
+        });
         if (!options.apiKey) {
             throw new Error('apiKey is required');
         }

--- a/drivers/src/openrouter/index.ts
+++ b/drivers/src/openrouter/index.ts
@@ -260,6 +260,8 @@ function toOpenRouterRequest(
         reasoningEffort: payload.reasoning_effort,
         serviceTier: payload.service_tier,
         tools: payload.tools?.flatMap(toOpenRouterTool),
+        toolChoice: payload.tool_choice as ChatRequest['toolChoice'],
+        parallelToolCalls: payload.parallel_tool_calls,
         responseFormat: toOpenRouterResponseFormat(payload.response_format),
         provider: toOpenRouterProviderPreferences(modelOptions),
         stream,

--- a/drivers/src/openrouter/index.ts
+++ b/drivers/src/openrouter/index.ts
@@ -54,10 +54,6 @@ export class OpenRouterDriver extends OpenAIChatCompletionsDriverBase<OpenRouter
         super({
             ...options,
             resultSchemaMode: 'response_format',
-            // OpenRouter exposes one protocol across many model families. Some routed models accept
-            // response_format but do not enforce it, so keep the provider-native constraint and give
-            // the model the same stable schema instruction as a compatibility fallback.
-            includeResultSchemaInPrompt: true,
             toolSchemaMode: 'compatible',
         });
         if (!options.apiKey) {

--- a/drivers/src/openrouter/index.ts
+++ b/drivers/src/openrouter/index.ts
@@ -54,6 +54,7 @@ export class OpenRouterDriver extends OpenAIChatCompletionsDriverBase<OpenRouter
         super({
             ...options,
             resultSchemaMode: 'response_format',
+            includeResultSchemaInPromptForModel: (model) => /(?:^|\/)glm-5\.3(?:$|[-:])/i.test(model),
             toolSchemaMode: 'compatible',
         });
         if (!options.apiKey) {

--- a/drivers/src/shared/claude-messages.test.ts
+++ b/drivers/src/shared/claude-messages.test.ts
@@ -272,6 +272,46 @@ describe('formatClaudePrompt', () => {
         expect(payload.messages[payload.messages.length - 1]?.role).toBe('user');
     });
 
+    it('maps private required-tool hints to native Claude tool choice', () => {
+        const { payload } = getClaudePayload(
+            {
+                model: 'claude-haiku-4-5',
+                tools: [{ name: 'write_artifact', input_schema: { type: 'object', properties: {} } }],
+                model_options: {
+                    _option_id: 'anthropic-claude',
+                    tool_choice: 'required',
+                    required_tool_name: 'write_artifact',
+                    parallel_tool_calls: false,
+                } as never,
+            },
+            { messages: [{ role: 'user', content: [{ type: 'text', text: 'Act now.' }] }] },
+        );
+
+        expect(payload.tool_choice).toEqual({
+            type: 'tool',
+            name: 'write_artifact',
+            disable_parallel_tool_use: true,
+        });
+    });
+
+    it('falls back to auto tool choice when Claude thinking prevents forcing', () => {
+        const { payload } = getClaudePayload(
+            {
+                model: 'claude-sonnet-4-6',
+                tools: [{ name: 'write_artifact', input_schema: { type: 'object', properties: {} } }],
+                model_options: {
+                    _option_id: 'anthropic-claude',
+                    effort: 'medium',
+                    tool_choice: 'required',
+                    required_tool_name: 'write_artifact',
+                } as never,
+            },
+            { messages: [{ role: 'user', content: [{ type: 'text', text: 'Act now.' }] }] },
+        );
+
+        expect(payload.tool_choice).toEqual({ type: 'auto' });
+    });
+
     it('preserves model-option cache controls when no routing identity is supplied', () => {
         const options: ExecutionOptions = {
             model: 'claude-sonnet-4-6',

--- a/drivers/src/shared/claude-messages.test.ts
+++ b/drivers/src/shared/claude-messages.test.ts
@@ -294,7 +294,7 @@ describe('formatClaudePrompt', () => {
         });
     });
 
-    it('falls back to auto tool choice when Claude thinking prevents forcing', () => {
+    it('disables thinking for a forced Claude tool turn without weakening tool choice', () => {
         const { payload } = getClaudePayload(
             {
                 model: 'claude-sonnet-4-6',
@@ -309,7 +309,29 @@ describe('formatClaudePrompt', () => {
             { messages: [{ role: 'user', content: [{ type: 'text', text: 'Act now.' }] }] },
         );
 
-        expect(payload.tool_choice).toEqual({ type: 'auto' });
+        expect(payload.tool_choice).toEqual({
+            type: 'tool',
+            name: 'write_artifact',
+            disable_parallel_tool_use: false,
+        });
+        expect(payload.thinking).toBeUndefined();
+        expect(payload.output_config).toBeUndefined();
+    });
+
+    it('rejects a forced Claude tool turn when no tools are available', () => {
+        expect(() =>
+            getClaudePayload(
+                {
+                    model: 'claude-sonnet-4-6',
+                    model_options: {
+                        _option_id: 'anthropic-claude',
+                        tool_choice: 'required',
+                        required_tool_name: 'write_artifact',
+                    } as never,
+                },
+                { messages: [{ role: 'user', content: [{ type: 'text', text: 'Act now.' }] }] },
+            ),
+        ).toThrow('requires at least one tool definition');
     });
 
     it('preserves model-option cache controls when no routing identity is supplied', () => {

--- a/drivers/src/shared/claude-messages.test.ts
+++ b/drivers/src/shared/claude-messages.test.ts
@@ -294,7 +294,7 @@ describe('formatClaudePrompt', () => {
         });
     });
 
-    it('disables thinking for a forced Claude tool turn without weakening tool choice', () => {
+    it('preserves adaptive thinking for a forced Claude tool turn', () => {
         const { payload } = getClaudePayload(
             {
                 model: 'claude-sonnet-4-6',
@@ -314,8 +314,27 @@ describe('formatClaudePrompt', () => {
             name: 'write_artifact',
             disable_parallel_tool_use: false,
         });
+        expect(payload.thinking).toEqual({ type: 'adaptive', display: 'omitted' });
+        expect(payload.output_config).toEqual({ effort: 'medium' });
+    });
+
+    it('disables only manual extended thinking for forced Anthropic-compatible tool turns', () => {
+        const { payload } = getClaudePayload(
+            {
+                model: 'claude-3-7-sonnet',
+                tools: [{ name: 'write_artifact', input_schema: { type: 'object', properties: {} } }],
+                model_options: {
+                    _option_id: 'anthropic-claude',
+                    thinking_budget_tokens: 8_000,
+                    tool_choice: 'required',
+                    required_tool_name: 'write_artifact',
+                } as never,
+            },
+            { messages: [{ role: 'user', content: [{ type: 'text', text: 'Act now.' }] }] },
+        );
+
+        expect(payload.tool_choice).toMatchObject({ type: 'tool', name: 'write_artifact' });
         expect(payload.thinking).toEqual({ type: 'disabled' });
-        expect(payload.output_config).toBeUndefined();
     });
 
     it('keeps sampling parameters suppressed for a forced future-Claude tool turn', () => {
@@ -337,10 +356,36 @@ describe('formatClaudePrompt', () => {
         );
 
         expect(payload.tool_choice).toMatchObject({ type: 'tool', name: 'write_artifact' });
-        expect(payload.thinking).toEqual({ type: 'disabled' });
+        expect(payload.thinking).toEqual({ type: 'adaptive', display: 'omitted' });
+        expect(payload.output_config).toEqual({ effort: 'medium' });
         expect(payload.temperature).toBeUndefined();
         expect(payload.top_p).toBeUndefined();
         expect(payload.top_k).toBeUndefined();
+    });
+
+    it('rejects forced tool choice for Claude Mythos adaptive-only turns', () => {
+        expect(() =>
+            getClaudePayload(
+                {
+                    model: 'claude-mythos-preview',
+                    tools: [{ name: 'write_artifact', input_schema: { type: 'object', properties: {} } }],
+                    model_options: {
+                        _option_id: 'anthropic-claude',
+                        effort: 'medium',
+                        tool_choice: 'required',
+                        required_tool_name: 'write_artifact',
+                    } as never,
+                },
+                { messages: [{ role: 'user', content: [{ type: 'text', text: 'Act now.' }] }] },
+            ),
+        ).toThrowError(
+            expect.objectContaining({
+                name: 'ToolChoiceConfigurationError',
+                retryable: false,
+                code: 400,
+                message: expect.stringContaining('required adaptive thinking'),
+            }),
+        );
     });
 
     it('rejects a forced Claude tool turn when no tools are available', () => {
@@ -356,7 +401,13 @@ describe('formatClaudePrompt', () => {
                 },
                 { messages: [{ role: 'user', content: [{ type: 'text', text: 'Act now.' }] }] },
             ),
-        ).toThrow('requires at least one tool definition');
+        ).toThrowError(
+            expect.objectContaining({
+                name: 'ToolChoiceConfigurationError',
+                retryable: false,
+                code: 400,
+            }),
+        );
     });
 
     it('preserves model-option cache controls when no routing identity is supplied', () => {

--- a/drivers/src/shared/claude-messages.test.ts
+++ b/drivers/src/shared/claude-messages.test.ts
@@ -314,8 +314,33 @@ describe('formatClaudePrompt', () => {
             name: 'write_artifact',
             disable_parallel_tool_use: false,
         });
-        expect(payload.thinking).toBeUndefined();
+        expect(payload.thinking).toEqual({ type: 'disabled' });
         expect(payload.output_config).toBeUndefined();
+    });
+
+    it('keeps sampling parameters suppressed for a forced future-Claude tool turn', () => {
+        const { payload } = getClaudePayload(
+            {
+                model: 'claude-fable-5',
+                tools: [{ name: 'write_artifact', input_schema: { type: 'object', properties: {} } }],
+                model_options: {
+                    _option_id: 'anthropic-claude',
+                    effort: 'medium',
+                    temperature: 0.4,
+                    top_p: 0.8,
+                    top_k: 20,
+                    tool_choice: 'required',
+                    required_tool_name: 'write_artifact',
+                } as never,
+            },
+            { messages: [{ role: 'user', content: [{ type: 'text', text: 'Act now.' }] }] },
+        );
+
+        expect(payload.tool_choice).toMatchObject({ type: 'tool', name: 'write_artifact' });
+        expect(payload.thinking).toEqual({ type: 'disabled' });
+        expect(payload.temperature).toBeUndefined();
+        expect(payload.top_p).toBeUndefined();
+        expect(payload.top_k).toBeUndefined();
     });
 
     it('rejects a forced Claude tool turn when no tools are available', () => {

--- a/drivers/src/shared/claude-messages.test.ts
+++ b/drivers/src/shared/claude-messages.test.ts
@@ -363,7 +363,7 @@ describe('formatClaudePrompt', () => {
         expect(payload.top_k).toBeUndefined();
     });
 
-    it('rejects forced tool choice for Claude Mythos adaptive-only turns', () => {
+    it('rejects forced tool choice for Claude Mythos preview turns', () => {
         expect(() =>
             getClaudePayload(
                 {
@@ -383,9 +383,29 @@ describe('formatClaudePrompt', () => {
                 name: 'ToolChoiceConfigurationError',
                 retryable: false,
                 code: 400,
-                message: expect.stringContaining('required adaptive thinking'),
+                message: expect.stringContaining('does not support forced tool choice'),
             }),
         );
+    });
+
+    it('preserves adaptive thinking and forced tool choice for released Claude Mythos turns', () => {
+        const { payload } = getClaudePayload(
+            {
+                model: 'claude-mythos-5',
+                tools: [{ name: 'write_artifact', input_schema: { type: 'object', properties: {} } }],
+                model_options: {
+                    _option_id: 'anthropic-claude',
+                    effort: 'medium',
+                    tool_choice: 'required',
+                    required_tool_name: 'write_artifact',
+                } as never,
+            },
+            { messages: [{ role: 'user', content: [{ type: 'text', text: 'Act now.' }] }] },
+        );
+
+        expect(payload.tool_choice).toMatchObject({ type: 'tool', name: 'write_artifact' });
+        expect(payload.thinking).toEqual({ type: 'adaptive', display: 'omitted' });
+        expect(payload.output_config).toEqual({ effort: 'medium' });
     });
 
     it('rejects a forced Claude tool turn when no tools are available', () => {

--- a/drivers/src/shared/claude-messages.ts
+++ b/drivers/src/shared/claude-messages.ts
@@ -58,7 +58,6 @@ import {
     type Logger,
     PromptRole,
     type PromptSegment,
-    parseClaudeVersion,
     readStreamAsBase64,
     readStreamAsString,
     type StatelessExecutionOptions,
@@ -880,9 +879,9 @@ export function getClaudePayload(
             operation,
         });
     }
-    if (forcedToolChoice && parseClaudeVersion(modelName)?.variant === 'mythos') {
+    if (forcedToolChoice && modelName.toLowerCase().includes('claude-mythos-preview')) {
         throw createToolChoiceConfigurationError(
-            `Claude model ${modelName} cannot combine required adaptive thinking with forced tool choice.`,
+            `Claude preview model ${modelName} does not support forced tool choice.`,
             { provider, model: modelName, operation },
         );
     }

--- a/drivers/src/shared/claude-messages.ts
+++ b/drivers/src/shared/claude-messages.ts
@@ -877,7 +877,6 @@ export function getClaudePayload(
     // constrained action turn must preserve the tool contract, so disable
     // thinking for that one call instead of silently weakening the contract.
     const disableThinkingForForcedTool = forcedToolChoice !== undefined && thinkingEnabled;
-    const effectiveSamplingRestriction = disableThinkingForForcedTool ? false : hasSamplingRestriction;
     const toolChoice = !hasTools
         ? undefined
         : forcedToolChoice
@@ -893,17 +892,17 @@ export function getClaudePayload(
         system: sanitizedSystem,
         tools: sanitizedTools,
         tool_choice: toolChoice,
-        temperature: effectiveSamplingRestriction ? undefined : model_options?.temperature,
+        temperature: hasSamplingRestriction ? undefined : model_options?.temperature,
         model: modelName,
         max_tokens: claudeMaxTokens(options),
-        top_p: effectiveSamplingRestriction
+        top_p: hasSamplingRestriction
             ? undefined
             : model_options?.temperature != null
               ? undefined
               : model_options?.top_p,
-        top_k: effectiveSamplingRestriction ? undefined : model_options?.top_k,
+        top_k: hasSamplingRestriction ? undefined : model_options?.top_k,
         stop_sequences: model_options?.stop_sequence,
-        thinking: disableThinkingForForcedTool ? undefined : thinking,
+        thinking: disableThinkingForForcedTool ? { type: 'disabled' } : thinking,
         stream: true,
         ...(!disableThinkingForForcedTool && outputConfig && { output_config: outputConfig }),
     };

--- a/drivers/src/shared/claude-messages.ts
+++ b/drivers/src/shared/claude-messages.ts
@@ -869,37 +869,43 @@ export function getClaudePayload(
         : model_options?.tool_choice === 'required' || model_options?.tool_choice === 'any'
           ? ({ type: 'any' } as const)
           : undefined;
+    if (forcedToolChoice && !hasTools) {
+        throw new Error('A forced Claude tool turn requires at least one tool definition.');
+    }
     const thinkingEnabled = thinking !== undefined && thinking.type !== 'disabled';
+    // Anthropic rejects forced tool choice together with extended thinking. A
+    // constrained action turn must preserve the tool contract, so disable
+    // thinking for that one call instead of silently weakening the contract.
+    const disableThinkingForForcedTool = forcedToolChoice !== undefined && thinkingEnabled;
+    const effectiveSamplingRestriction = disableThinkingForForcedTool ? false : hasSamplingRestriction;
     const toolChoice = !hasTools
         ? undefined
-        : forcedToolChoice && thinkingEnabled
-          ? ({ type: 'auto' } as const)
-          : forcedToolChoice
-            ? { ...forcedToolChoice, disable_parallel_tool_use: model_options?.parallel_tool_calls === false }
-            : model_options?.tool_choice === 'none'
-              ? ({ type: 'none' } as const)
-              : model_options?.tool_choice === 'auto'
-                ? ({ type: 'auto' } as const)
-                : undefined;
+        : forcedToolChoice
+          ? { ...forcedToolChoice, disable_parallel_tool_use: model_options?.parallel_tool_calls === false }
+          : model_options?.tool_choice === 'none'
+            ? ({ type: 'none' } as const)
+            : model_options?.tool_choice === 'auto'
+              ? ({ type: 'auto' } as const)
+              : undefined;
 
     const payload: MessageCreateParamsBase = {
         messages: sanitizedMessages,
         system: sanitizedSystem,
         tools: sanitizedTools,
         tool_choice: toolChoice,
-        temperature: hasSamplingRestriction ? undefined : model_options?.temperature,
+        temperature: effectiveSamplingRestriction ? undefined : model_options?.temperature,
         model: modelName,
         max_tokens: claudeMaxTokens(options),
-        top_p: hasSamplingRestriction
+        top_p: effectiveSamplingRestriction
             ? undefined
             : model_options?.temperature != null
               ? undefined
               : model_options?.top_p,
-        top_k: hasSamplingRestriction ? undefined : model_options?.top_k,
+        top_k: effectiveSamplingRestriction ? undefined : model_options?.top_k,
         stop_sequences: model_options?.stop_sequence,
-        thinking,
+        thinking: disableThinkingForForcedTool ? undefined : thinking,
         stream: true,
-        ...(outputConfig && { output_config: outputConfig }),
+        ...(!disableThinkingForForcedTool && outputConfig && { output_config: outputConfig }),
     };
 
     return { payload, requestOptions };

--- a/drivers/src/shared/claude-messages.ts
+++ b/drivers/src/shared/claude-messages.ts
@@ -58,6 +58,7 @@ import {
     type Logger,
     PromptRole,
     type PromptSegment,
+    parseClaudeVersion,
     readStreamAsBase64,
     readStreamAsString,
     type StatelessExecutionOptions,
@@ -70,6 +71,7 @@ import { asyncMap } from '@llumiverse/core/async';
 import { claudeFinishReason, logClaudeTruncation } from './claude-stop-reason.js';
 import { resolveClaudeThinking } from './claude-thinking.js';
 import { truncateBinaryForDebug } from './debug-prompt.js';
+import { createToolChoiceConfigurationError } from './tool-choice-error.js';
 
 // ============================================================================
 // Types
@@ -745,6 +747,8 @@ function stripClaudeCacheControlFromTools(
 export function getClaudePayload(
     options: ExecutionOptions,
     prompt: ClaudePrompt,
+    provider = 'anthropic',
+    operation: 'execute' | 'stream' = 'stream',
 ): { payload: MessageCreateParamsBase; requestOptions: RequestOptions | undefined } {
     const modelName = options.model;
     const model_options = options.model_options as ClaudeBaseOptions | undefined;
@@ -870,13 +874,19 @@ export function getClaudePayload(
           ? ({ type: 'any' } as const)
           : undefined;
     if (forcedToolChoice && !hasTools) {
-        throw new Error('A forced Claude tool turn requires at least one tool definition.');
+        throw createToolChoiceConfigurationError('A forced Claude tool turn requires at least one tool definition.', {
+            provider,
+            model: modelName,
+            operation,
+        });
     }
-    const thinkingEnabled = thinking !== undefined && thinking.type !== 'disabled';
-    // Anthropic rejects forced tool choice together with extended thinking. A
-    // constrained action turn must preserve the tool contract, so disable
-    // thinking for that one call instead of silently weakening the contract.
-    const disableThinkingForForcedTool = forcedToolChoice !== undefined && thinkingEnabled;
+    if (forcedToolChoice && parseClaudeVersion(modelName)?.variant === 'mythos') {
+        throw createToolChoiceConfigurationError(
+            `Claude model ${modelName} cannot combine required adaptive thinking with forced tool choice.`,
+            { provider, model: modelName, operation },
+        );
+    }
+    const disableManualThinkingForForcedTool = forcedToolChoice !== undefined && thinking?.type === 'enabled';
     const toolChoice = !hasTools
         ? undefined
         : forcedToolChoice
@@ -902,9 +912,9 @@ export function getClaudePayload(
               : model_options?.top_p,
         top_k: hasSamplingRestriction ? undefined : model_options?.top_k,
         stop_sequences: model_options?.stop_sequence,
-        thinking: disableThinkingForForcedTool ? { type: 'disabled' } : thinking,
+        thinking: disableManualThinkingForForcedTool ? { type: 'disabled' } : thinking,
         stream: true,
-        ...(!disableThinkingForForcedTool && outputConfig && { output_config: outputConfig }),
+        ...(!disableManualThinkingForForcedTool && outputConfig && { output_config: outputConfig }),
     };
 
     return { payload, requestOptions };
@@ -1085,7 +1095,7 @@ export async function executeClaudeCompletion(
 
     const conversation = updateClaudeConversation(options.conversation as ClaudePrompt | undefined, prompt);
 
-    const { payload, requestOptions } = getClaudePayload(options, conversation);
+    const { payload, requestOptions } = getClaudePayload(options, conversation, provider, 'execute');
 
     const responseStream = await streamClaudeMessages(
         client,
@@ -1125,7 +1135,7 @@ export async function streamClaudeCompletion(
     const model_options = options.model_options as ClaudeBaseOptions | undefined;
     const conversation = updateClaudeConversation(options.conversation as ClaudePrompt | undefined, prompt);
 
-    const { payload, requestOptions } = getClaudePayload(options, conversation);
+    const { payload, requestOptions } = getClaudePayload(options, conversation, provider, 'stream');
     const streamingPayload: MessageStreamParams = { ...payload, stream: true };
 
     const response_stream = await streamClaudeMessages(

--- a/drivers/src/shared/claude-messages.ts
+++ b/drivers/src/shared/claude-messages.ts
@@ -204,6 +204,11 @@ export interface ClaudeBaseOptions {
     include_thoughts?: boolean;
     cache_enabled?: boolean;
     cache_ttl?: string;
+    tool_choice?: 'auto' | 'none' | 'any' | 'required';
+    /** Internal execution hint supplied after public model-option validation. */
+    required_tool_name?: string;
+    /** Internal execution hint used with a required named tool. */
+    parallel_tool_calls?: boolean;
 }
 
 interface RequestOptions {
@@ -859,11 +864,29 @@ export function getClaudePayload(
         modelName,
         model_options as Parameters<typeof resolveClaudeThinking>[1],
     );
+    const forcedToolChoice = model_options?.required_tool_name
+        ? ({ type: 'tool', name: model_options.required_tool_name } as const)
+        : model_options?.tool_choice === 'required' || model_options?.tool_choice === 'any'
+          ? ({ type: 'any' } as const)
+          : undefined;
+    const thinkingEnabled = thinking !== undefined && thinking.type !== 'disabled';
+    const toolChoice = !hasTools
+        ? undefined
+        : forcedToolChoice && thinkingEnabled
+          ? ({ type: 'auto' } as const)
+          : forcedToolChoice
+            ? { ...forcedToolChoice, disable_parallel_tool_use: model_options?.parallel_tool_calls === false }
+            : model_options?.tool_choice === 'none'
+              ? ({ type: 'none' } as const)
+              : model_options?.tool_choice === 'auto'
+                ? ({ type: 'auto' } as const)
+                : undefined;
 
     const payload: MessageCreateParamsBase = {
         messages: sanitizedMessages,
         system: sanitizedSystem,
         tools: sanitizedTools,
+        tool_choice: toolChoice,
         temperature: hasSamplingRestriction ? undefined : model_options?.temperature,
         model: modelName,
         max_tokens: claudeMaxTokens(options),

--- a/drivers/src/shared/tool-choice-error.ts
+++ b/drivers/src/shared/tool-choice-error.ts
@@ -1,0 +1,7 @@
+import { LlumiverseError, type LlumiverseErrorContext } from '@llumiverse/core';
+
+export function createToolChoiceConfigurationError(message: string, context: LlumiverseErrorContext): LlumiverseError {
+    const cause = new Error(message);
+    cause.name = 'ToolChoiceConfigurationError';
+    return new LlumiverseError(message, false, context, cause, 400, cause.name);
+}

--- a/drivers/src/vertexai/models/gemini-orphaned-tool-result.test.ts
+++ b/drivers/src/vertexai/models/gemini-orphaned-tool-result.test.ts
@@ -132,6 +132,35 @@ describe('getGeminiPayload - orphaned tool results', () => {
         expect(payload.config?.toolConfig?.functionCallingConfig?.mode).toBe('NONE');
     });
 
+    test('rejects a required tool choice when no tools are available', () => {
+        let thrown: unknown;
+        try {
+            getGeminiPayload(
+                {
+                    model: 'gemini-2.5-flash',
+                    tools: [],
+                    model_options: { _option_id: 'vertexai-gemini', tool_choice: 'required' },
+                } as unknown as ExecutionOptions,
+                { contents: [{ role: 'user', parts: [{ text: 'Act now.' }] }] },
+                'stream',
+            );
+        } catch (error: unknown) {
+            thrown = error;
+        }
+
+        expect(thrown).toMatchObject({
+            name: 'ToolChoiceConfigurationError',
+            retryable: false,
+            code: 400,
+            context: {
+                provider: 'vertexai',
+                model: 'gemini-2.5-flash',
+                operation: 'stream',
+            },
+            message: expect.stringContaining('required tool choice was requested, but no tools are available'),
+        });
+    });
+
     test('recombines split parallel functionResponses into one user turn matching the call turn', () => {
         // Gemini rejects a function-call turn whose responses are split across consecutive user
         // contents: "Please ensure that the number of function response parts is equal to the

--- a/drivers/src/vertexai/models/gemini-orphaned-tool-result.test.ts
+++ b/drivers/src/vertexai/models/gemini-orphaned-tool-result.test.ts
@@ -101,6 +101,37 @@ describe('fixOrphanedToolResults - Gemini', () => {
 });
 
 describe('getGeminiPayload - orphaned tool results', () => {
+    test('maps the private required-tool hint to Gemini ANY mode and an allowed function', () => {
+        const payload = getGeminiPayload(
+            {
+                ...OPTIONS_WITH_TOOLS,
+                model_options: {
+                    _option_id: 'vertexai-gemini',
+                    tool_choice: 'required',
+                    required_tool_name: 'a',
+                },
+            } as unknown as ExecutionOptions,
+            { contents: [{ role: 'user', parts: [{ text: 'Act now.' }] }] },
+        );
+
+        expect(payload.config?.toolConfig?.functionCallingConfig).toMatchObject({
+            mode: 'ANY',
+            allowedFunctionNames: ['a'],
+        });
+    });
+
+    test('maps the private no-tool hint to Gemini NONE mode', () => {
+        const payload = getGeminiPayload(
+            {
+                ...OPTIONS_WITH_TOOLS,
+                model_options: { _option_id: 'vertexai-gemini', tool_choice: 'none' },
+            } as unknown as ExecutionOptions,
+            { contents: [{ role: 'user', parts: [{ text: 'Return the receipt.' }] }] },
+        );
+
+        expect(payload.config?.toolConfig?.functionCallingConfig?.mode).toBe('NONE');
+    });
+
     test('recombines split parallel functionResponses into one user turn matching the call turn', () => {
         // Gemini rejects a function-call turn whose responses are split across consecutive user
         // contents: "Please ensure that the number of function response parts is equal to the

--- a/drivers/src/vertexai/models/gemini.ts
+++ b/drivers/src/vertexai/models/gemini.ts
@@ -49,6 +49,7 @@ import {
 } from '@llumiverse/core';
 import { asyncMap } from '@llumiverse/core/async';
 import { truncateBinaryForDebug } from '../../shared/debug-prompt.js';
+import { createToolChoiceConfigurationError } from '../../shared/tool-choice-error.js';
 import type { GenerateContentPrompt, VertexAIDriver } from '../index.js';
 import type { ModelDefinition } from '../models.js';
 import { generateWithGeminiContextCache } from './gemini-context-cache.js';
@@ -227,7 +228,11 @@ function getProminentPeopleOption(
     }
 }
 
-export function getGeminiPayload(options: ExecutionOptions, prompt: GenerateContentPrompt): GenerateContentParameters {
+export function getGeminiPayload(
+    options: ExecutionOptions,
+    prompt: GenerateContentPrompt,
+    operation: LlumiverseErrorContext['operation'] = 'execute',
+): GenerateContentParameters {
     const model_options = options.model_options as
         | (VertexAIGeminiOptions & {
               tool_choice?: 'auto' | 'none' | 'any' | 'required';
@@ -235,6 +240,16 @@ export function getGeminiPayload(options: ExecutionOptions, prompt: GenerateCont
           })
         | undefined;
     const tools = getToolDefinitions(options.tools);
+    const forcedToolRequested =
+        model_options?.required_tool_name !== undefined ||
+        model_options?.tool_choice === 'required' ||
+        model_options?.tool_choice === 'any';
+    if (forcedToolRequested && !tools) {
+        throw createToolChoiceConfigurationError(
+            '[Vertex AI Gemini] A required tool choice was requested, but no tools are available.',
+            { provider: 'vertexai', model: options.model, operation },
+        );
+    }
 
     // When no tools are provided but conversation contains functionCall/functionResponse parts
     // (e.g. checkpoint summary calls), convert them to text to avoid API errors.
@@ -809,7 +824,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
             options.httpTimeout,
         );
 
-        const payload = getGeminiPayload(options, prompt);
+        const payload = getGeminiPayload(options, prompt, 'execute');
         if (signal) payload.config = { ...payload.config, abortSignal: signal };
         // Routes through an explicit Vertex context cache when this execution carries a
         // prompt_cache_key; sends `payload` untouched otherwise, and on any cache failure.
@@ -924,7 +939,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
             options.httpTimeout,
         );
 
-        const payload = getGeminiPayload(options, prompt);
+        const payload = getGeminiPayload(options, prompt, 'stream');
         payload.config = { ...payload.config, abortSignal: signal };
         const cacheExecution = await generateWithGeminiContextCache(
             driver,

--- a/drivers/src/vertexai/models/gemini.ts
+++ b/drivers/src/vertexai/models/gemini.ts
@@ -228,7 +228,12 @@ function getProminentPeopleOption(
 }
 
 export function getGeminiPayload(options: ExecutionOptions, prompt: GenerateContentPrompt): GenerateContentParameters {
-    const model_options = options.model_options as VertexAIGeminiOptions | undefined;
+    const model_options = options.model_options as
+        | (VertexAIGeminiOptions & {
+              tool_choice?: 'auto' | 'none' | 'any' | 'required';
+              required_tool_name?: string;
+          })
+        | undefined;
     const tools = getToolDefinitions(options.tools);
 
     // When no tools are provided but conversation contains functionCall/functionResponse parts
@@ -278,7 +283,15 @@ export function getGeminiPayload(options: ExecutionOptions, prompt: GenerateCont
         toolConfig: tools
             ? {
                   functionCallingConfig: {
-                      mode: FunctionCallingConfigMode.AUTO,
+                      mode:
+                          model_options?.tool_choice === 'none'
+                              ? FunctionCallingConfigMode.NONE
+                              : model_options?.tool_choice === 'required' || model_options?.tool_choice === 'any'
+                                ? FunctionCallingConfigMode.ANY
+                                : FunctionCallingConfigMode.AUTO,
+                      ...(model_options?.required_tool_name
+                          ? { allowedFunctionNames: [model_options.required_tool_name] }
+                          : {}),
                   },
               }
             : undefined,


### PR DESCRIPTION
## Summary

Lets an agent runtime **require a specific tool call on a model turn** and tell apart three outcomes that previously all looked like "the model didn't do what we asked": the model ignored the contract, the provider streamed a tool call it could not finish, or the request itself was invalid for that provider/model.

### Required and named tool choice across drivers

- `ModelOptions.tool_choice` accepts `auto | none | any | required`, and the private `required_tool_name` option pins a single tool. Mapped per provider: Anthropic / Vertex Claude `tool_choice: {type: 'tool' | 'any'}` with `disable_parallel_tool_use`; Bedrock Converse `toolChoice`; Gemini `functionCallingConfig` mode + `allowedFunctionNames`; OpenAI Chat Completions and Responses; Azure Foundry (`extra-parameters: pass-through`, `parallel_tool_calls`); Mistral; OpenRouter (`toolChoice`, `parallelToolCalls`).
- Claude adaptive-thinking models keep `thinking: adaptive` and `output_config.effort` on forced turns (the Messages API allows forced `tool_choice` with adaptive thinking); only manual budgeted thinking is disabled for the turn. On Bedrock, which needs thinking disabled for a forced choice, models that cannot disable thinking (Fable / Mythos) degrade the hint to automatic selection so the caller's own required-tool validation decides — nothing is sent that the provider would reject. `claude-mythos-preview` rejects forced choice explicitly.
- Forced choice with no tools, or on a Bedrock family that cannot enforce it, throws a typed non-retryable `ToolChoiceConfigurationError` (`LlumiverseError`, status 400) in every driver instead of an untyped `Error`.

### Recoverable failures are distinguishable

- `CompletionStream` surfaces malformed streamed tool arguments as `MalformedStreamingToolArgumentsError` (`retryable: false`) rather than a JSON parse error, and when a transport reports final usage right before a terminal error it keeps a partial completion so the failed call's tokens can still be metered.
- OpenAI Responses failures are surfaced as typed errors with the usage emitted before the throw; cached-prompt usage (`prompt_cached`, `prompt_cache_write`, `prompt_new`) is reported consistently.
- Sampling parameters remain suppressed on models that reject them (Claude 4.7+ / 5.x), including on forced turns.

### Other

- OpenRouter: GLM 5.3 structured output falls back to a prompt-embedded schema (`includeResultSchemaInPromptForModel`).

## Test Plan

Run on `38aa2d2`:

- [x] `pnpm test` from `core/` — 12 files, 187 tests
- [x] `pnpm lint` from `drivers/`
- [x] `pnpm typecheck:test` from `drivers/`
- [x] `pnpm test` from `drivers/` — 59 files, 672 passed, 19 skipped

