### PR TITLE
chore(deps): update fast-uri security floor

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ overrides:
   '@types/node': ^24.13.3
   vite: ^8.0.16
   brace-expansion@>=3.0.0 <5.0.8: 5.0.9
-  fast-uri@>=3.0.0 <3.1.4: 3.1.5
+  fast-uri@>=3.0.0 <3.1.6: 3.1.6
   nanoid@<3.3.17: 3.3.18
   postcss@<8.5.18: ^8.5.18
   protobufjs@<=7.6.4: 7.6.5
@@ -1312,8 +1312,8 @@ packages:
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fast-xml-builder@1.2.0:
     resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
@@ -3141,7 +3141,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -3261,7 +3261,7 @@ snapshots:
 
   fast-sha256@1.3.0: {}
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fast-xml-builder@1.2.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,7 +38,9 @@ overrides:
   # Dependabot alerts #77/#78: Vite dev-server Windows path disclosure issues.
   vite: ^8.0.16
   "brace-expansion@>=3.0.0 <5.0.8": 5.0.9
-  "fast-uri@>=3.0.0 <3.1.4": 3.1.5
+  # GHSA-7p8r-x3mc-p8w7, GHSA-5jgf-p345-68v8, GHSA-f65p-4m7j-42xc,
+  # GHSA-fph4-wmhf-6fwf, and GHSA-jqff-g426-hqxp (host-confusion and SSRF flaws).
+  "fast-uri@>=3.0.0 <3.1.6": 3.1.6
   # GHSA-2v37-7h3g-55p8: zero-sized custom generators can loop indefinitely.
   "nanoid@<3.3.17": 3.3.18
   # GHSA path traversal in sourceMappingURL auto-loading. Reached via vitest > vite > postcss.


### PR DESCRIPTION
## Summary

- update the transitive `fast-uri` security floor from 3.1.5 to 3.1.6
- resolve AJV consumers to the patched release for the latest host-confusion and SSRF advisories

## Test Plan

- [x] `pnpm audit` — no known vulnerabilities
- [x] `pnpm lint`
- [x] `pnpm build` — 4/4 tasks successful
- [x] `pnpm test` — 1,104 passed, 19 skipped