### PR TITLE
feat(vertexai): support Gemini Omni Flash 1.1

### DIFF
--- a/common/src/capability.test.ts
+++ b/common/src/capability.test.ts
@@ -70,14 +70,17 @@ describe('xAI Grok tool capabilities', () => {
 });
 
 describe('Gemini Omni video capabilities', () => {
-    it('exposes only text/image input and video output', () => {
-        expect(getModelCapabilities('gemini-omni-flash-preview', Providers.vertexai)).toEqual({
-            input: { text: true, image: true, video: false, audio: false, embed: false },
-            output: { text: false, image: false, video: true, audio: false, embed: false },
-            tool_support: false,
-            tool_support_streaming: false,
-        });
-    });
+    it.each(['gemini-omni-flash-preview', 'gemini-omni-1.1-flash-preview'])(
+        'exposes the executable media capabilities for %s',
+        (model) => {
+            expect(getModelCapabilities(model, Providers.vertexai)).toEqual({
+                input: { text: true, image: true, video: true, audio: false, embed: false },
+                output: { text: true, image: false, video: true, audio: false, embed: false },
+                tool_support: false,
+                tool_support_streaming: false,
+            });
+        },
+    );
 });
 
 describe('supportsToolUse streaming default', () => {

--- a/common/src/capability.ts
+++ b/common/src/capability.ts
@@ -10,10 +10,13 @@ export function getModelCapabilities(model: string, provider: Providers): ModelC
         }
     }
     const modelName = model.split('/').pop()?.toLowerCase();
-    if (provider === 'vertexai' && modelName === 'gemini-omni-flash-preview') {
+    if (
+        provider === 'vertexai' &&
+        (modelName === 'gemini-omni-flash-preview' || modelName === 'gemini-omni-1.1-flash-preview')
+    ) {
         return {
-            input: { text: true, image: true, video: false, audio: false, embed: false },
-            output: { text: false, image: false, video: true, audio: false, embed: false },
+            input: { text: true, image: true, video: true, audio: false, embed: false },
+            output: { text: true, image: false, video: true, audio: false, embed: false },
             tool_support: false,
             tool_support_streaming: false,
         };

--- a/common/src/options/vertexai.test.ts
+++ b/common/src/options/vertexai.test.ts
@@ -4,6 +4,34 @@ import { Providers } from '../types.js';
 import { getMaxTokensLimitVertexAi, getVertexAiOptions, isFlexSupportedGeminiModel } from './vertexai.js';
 
 describe('Vertex AI MaaS metadata', () => {
+    it('exposes model-specific Gemini Omni tasks and resolutions', () => {
+        const omni10 = getVertexAiOptions('gemini-omni-flash-preview');
+        const omni11 = getVertexAiOptions('locations/global/publishers/google/models/gemini-omni-1.1-flash-preview');
+
+        expect(omni10.options.find((option) => option.name === 'task')).toMatchObject({
+            enum: {
+                'Text to video': 'text_to_video',
+                'Image to video': 'image_to_video',
+                'References to video': 'reference_to_video',
+                'Edit video': 'edit',
+            },
+        });
+        expect(omni10.options.find((option) => option.name === 'resolution')).toMatchObject({
+            enum: { '720p': '720p' },
+        });
+        expect(omni11.options.find((option) => option.name === 'task')).toMatchObject({
+            enum: { 'Extend video': 'extend' },
+        });
+        expect(omni11.options.find((option) => option.name === 'resolution')).toMatchObject({
+            enum: {
+                '360p': '360p',
+                '720p': '720p',
+                '1080p': '1080p',
+                '4K': '4k',
+            },
+        });
+    });
+
     it.each(['gemini-3.5-flash', 'gemini-3.5-flash-lite', 'gemini-3.6-flash', 'gemini-3.7-flash', 'gemini-4.0-flash'])(
         'supports current Gemini Flash Flex inference for %s',
         (model) => {

--- a/common/src/options/vertexai.ts
+++ b/common/src/options/vertexai.ts
@@ -101,7 +101,9 @@ export function isFlexSupportedGeminiModel(model: string): boolean {
 }
 
 export function getVertexAiOptions(model: string, option?: ModelOptions): ModelOptionsInfo {
-    if (model.split('/').pop() === 'gemini-omni-flash-preview') {
+    const modelName = model.split('/').pop();
+    if (modelName === 'gemini-omni-flash-preview' || modelName === 'gemini-omni-1.1-flash-preview') {
+        const isOmni11 = modelName === 'gemini-omni-1.1-flash-preview';
         return {
             _option_id: 'vertexai-gemini-omni-video',
             options: [
@@ -111,9 +113,11 @@ export function getVertexAiOptions(model: string, option?: ModelOptions): ModelO
                     enum: {
                         'Text to video': 'text_to_video',
                         'Image to video': 'image_to_video',
-                        'Reference images to video': 'reference_to_video',
+                        'References to video': 'reference_to_video',
+                        'Edit video': 'edit',
+                        ...(isOmni11 ? { 'Extend video': 'extend' } : {}),
                     },
-                    description: 'Video generation task. Image inputs require an explicit image task.',
+                    description: 'Video generation task. Media inputs require an explicit task.',
                 },
                 {
                     name: 'aspect_ratio',
@@ -129,6 +133,14 @@ export function getVertexAiOptions(model: string, option?: ModelOptions): ModelO
                     default: 5,
                     integer: true,
                     description: 'Duration of the generated video in seconds.',
+                },
+                {
+                    name: 'resolution',
+                    type: OptionType.enum,
+                    enum: isOmni11
+                        ? { '360p': '360p', '720p': '720p', '1080p': '1080p', '4K': '4k' }
+                        : { '720p': '720p' },
+                    description: 'Resolution of the generated video.',
                 },
             ],
         };

--- a/common/src/schemas/model-options.test.ts
+++ b/common/src/schemas/model-options.test.ts
@@ -29,6 +29,7 @@ describe('ModelOptionsSchema', () => {
                 task: 'reference_to_video',
                 aspect_ratio: '16:9',
                 duration_seconds: 3,
+                resolution: '4k',
             }).success,
         ).toBe(true);
         expect(
@@ -39,6 +40,12 @@ describe('ModelOptionsSchema', () => {
         ).toBe(false);
         expect(
             ModelOptionsSchema.safeParse({ _option_id: 'vertexai-gemini-omni-video', duration_seconds: 5.5 }).success,
+        ).toBe(false);
+        expect(ModelOptionsSchema.safeParse({ _option_id: 'vertexai-gemini-omni-video', task: 'edit' }).success).toBe(
+            true,
+        );
+        expect(
+            ModelOptionsSchema.safeParse({ _option_id: 'vertexai-gemini-omni-video', resolution: '1440p' }).success,
         ).toBe(false);
         expect(ModelOptionsSchema.safeParse({ _option_id: 'vertexai-gemini-omni-video', unknown: true }).success).toBe(
             false,

--- a/common/src/schemas/model-options.ts
+++ b/common/src/schemas/model-options.ts
@@ -464,9 +464,10 @@ export const VertexAIGeminiOptionsSchema = z
 export const VertexAIGeminiOmniVideoOptionsSchema = z
     .strictObject({
         _option_id: z.literal('vertexai-gemini-omni-video'),
-        task: z.enum(['text_to_video', 'image_to_video', 'reference_to_video']).optional(),
+        task: z.enum(['text_to_video', 'image_to_video', 'reference_to_video', 'edit', 'extend']).optional(),
         aspect_ratio: z.enum(['16:9', '9:16']).optional(),
         duration_seconds: z.number().int().min(3).max(10).optional(),
+        resolution: z.enum(['360p', '720p', '1080p', '4k']).optional(),
     })
     .meta({ id: 'VertexAIGeminiOmniVideoOptions' });
 

--- a/drivers/package.json
+++ b/drivers/package.json
@@ -129,7 +129,7 @@
         "@azure/identity": "^4.13.1",
         "@azure/openai": "^2.0.0",
         "@google-cloud/aiplatform": "^7.0.0",
-        "@google/genai": "^2.17.0",
+        "@google/genai": "^2.21.0",
         "@huggingface/inference": "^4.13.25",
         "@llumiverse/common": "workspace:*",
         "@llumiverse/core": "workspace:*",

--- a/drivers/src/vertexai/index.test.ts
+++ b/drivers/src/vertexai/index.test.ts
@@ -27,6 +27,7 @@ class TestVertexAIDriver extends VertexAIDriver {
                         [
                             { name: 'publishers/google/models/gemini-4-future' },
                             { name: 'publishers/google/models/gemini-omni-flash-preview' },
+                            { name: 'publishers/google/models/gemini-omni-1.1-flash-preview' },
                             { name: 'publishers/google/models/gemini-live-future' },
                             { name: 'publishers/google/models/gemini-4-tts' },
                         ],
@@ -57,9 +58,13 @@ describe('VertexAIDriver listModels', () => {
 
     it('lists Gemini Omni only with its global location id', async () => {
         const models = await new TestVertexAIDriver().listModels();
-        const omniModels = models.filter((model) => model.id.includes('gemini-omni-flash-preview'));
+        const omniModels = models.filter((model) => model.id.includes('gemini-omni'));
 
         expect(omniModels).toEqual([
+            expect.objectContaining({
+                id: 'locations/global/publishers/google/models/gemini-omni-1.1-flash-preview',
+                name: 'Global gemini-omni-1.1-flash-preview',
+            }),
             expect.objectContaining({
                 id: 'locations/global/publishers/google/models/gemini-omni-flash-preview',
                 name: 'Global gemini-omni-flash-preview',

--- a/drivers/src/vertexai/index.ts
+++ b/drivers/src/vertexai/index.ts
@@ -41,7 +41,7 @@ import {
     GeminiContextCacheManager,
 } from './models/gemini-context-cache.js';
 import { formatImagenDebugPrompt, ImagenModelDefinition, type ImagenPrompt } from './models/imagen.js';
-import { GEMINI_OMNI_VIDEO_MODEL, type OmniVideoPrompt } from './models/omni-video.js';
+import { GEMINI_OMNI_VIDEO_MODELS, isGeminiOmniVideoModel, type OmniVideoPrompt } from './models/omni-video.js';
 import { getModelDefinition, trimModelName } from './models.js';
 import { getListedVertexOpenMaaSModels } from './open-maas-models.js';
 
@@ -432,7 +432,7 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
         if ('messages' in prompt) {
             return prompt;
         }
-        if ('text' in prompt && 'images' in prompt) {
+        if ('text' in prompt && 'media' in prompt) {
             return prompt;
         }
         return formatImagenDebugPrompt(prompt);
@@ -733,7 +733,7 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
                 ],
                 /** Additional models not in the listings, but we want to include.
                  * TODO: Remove once available in listing API. */
-                additional: ['imagen-3.0-fast-generate-001', 'gemini-omni-flash-preview'],
+                additional: ['imagen-3.0-fast-generate-001', ...GEMINI_OMNI_VIDEO_MODELS],
             },
             anthropic: {
                 families: ['claude'],
@@ -981,12 +981,13 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
 }
 
 function isGlobalOnlyPublisherModel(publisher: string, modelId: string): boolean {
-    return publisher === 'xai' || (publisher === 'google' && modelId.endsWith(`/models/${GEMINI_OMNI_VIDEO_MODEL}`));
+    const modelName = modelId.split('/').pop() ?? modelId;
+    return publisher === 'xai' || (publisher === 'google' && isGeminiOmniVideoModel(modelName));
 }
 
 function isExecutableGoogleModel(model: Model): boolean {
     const modelName = (model.name ?? '').toLowerCase();
-    if (modelName.endsWith('/gemini-omni-flash-preview') || modelName === 'gemini-omni-flash-preview') return true;
+    if (isGeminiOmniVideoModel(modelName.split('/').pop() ?? modelName)) return true;
     // Intentional execution-path allow-list: Vertex uses separate methods for embeddings, Live/TTS, music and video.
     // This driver currently implements generateContent and generateImages. Unknown actions are excluded only when
     // Google supplies them; absent action metadata falls back to the known-family/name policy above.

--- a/drivers/src/vertexai/models.ts
+++ b/drivers/src/vertexai/models.ts
@@ -10,7 +10,7 @@ import type {
 import type { VertexAIDriver, VertexAIPrompt } from './index.js';
 import { ClaudeModelDefinition } from './models/claude.js';
 import { GeminiModelDefinition } from './models/gemini.js';
-import { GEMINI_OMNI_VIDEO_MODEL, GeminiOmniVideoModelDefinition } from './models/omni-video.js';
+import { GeminiOmniVideoModelDefinition, isGeminiOmniVideoModel } from './models/omni-video.js';
 import { OpenAIChatCompletionsModelDefinition } from './models/openai_chat_completions.js';
 import { getVertexOpenMaaSRequestModel } from './open-maas-models.js';
 
@@ -84,8 +84,8 @@ export function getModelDefinition(model: string): ModelDefinition {
         }
     }
 
-    if (modelName === GEMINI_OMNI_VIDEO_MODEL) {
-        return new GeminiOmniVideoModelDefinition();
+    if (isGeminiOmniVideoModel(modelName)) {
+        return new GeminiOmniVideoModelDefinition(modelName);
     }
 
     if (publisher === 'xai') {

--- a/drivers/src/vertexai/models/omni-video.test.ts
+++ b/drivers/src/vertexai/models/omni-video.test.ts
@@ -1,12 +1,23 @@
-import { type DataSource, type ExecutionOptions, LlumiverseError, PromptRole } from '@llumiverse/core';
+import {
+    type CompletionResult,
+    type DataSource,
+    type ExecutionOptions,
+    LlumiverseError,
+    PromptRole,
+} from '@llumiverse/core';
 import { describe, expect, it, vi } from 'vitest';
 import type { VertexAIDriver } from '../index.js';
 import { getModelDefinition } from '../models.js';
-import { GEMINI_OMNI_VIDEO_MODEL, GeminiOmniVideoModelDefinition } from './omni-video.js';
+import {
+    GEMINI_OMNI_1_1_VIDEO_MODEL,
+    GEMINI_OMNI_VIDEO_MODEL,
+    type GeminiOmniVideoModel,
+    GeminiOmniVideoModelDefinition,
+} from './omni-video.js';
 
 const OUTPUT_PREFIX = 'gs://project-bucket/runs/run-1/media/';
 
-function image(uri = 'gs://project-bucket/input/frame.png', mimeType = 'image/png'): DataSource {
+function media(uri = 'gs://project-bucket/input/frame.png', mimeType = 'image/png'): DataSource {
     return {
         name: 'frame.png',
         mime_type: mimeType,
@@ -16,16 +27,27 @@ function image(uri = 'gs://project-bucket/input/frame.png', mimeType = 'image/pn
     };
 }
 
-function options(overrides: Partial<ExecutionOptions> = {}): ExecutionOptions {
+function image(uri = 'gs://project-bucket/input/frame.png', mimeType = 'image/png'): DataSource {
+    return media(uri, mimeType);
+}
+
+function video(uri = 'gs://project-bucket/input/clip.mp4', mimeType = 'video/mp4'): DataSource {
+    return media(uri, mimeType);
+}
+
+function options(
+    overrides: Partial<ExecutionOptions> = {},
+    model: GeminiOmniVideoModel = GEMINI_OMNI_VIDEO_MODEL,
+): ExecutionOptions {
     return {
-        model: GEMINI_OMNI_VIDEO_MODEL,
+        model,
         model_options: { _option_id: 'vertexai-gemini-omni-video' },
         output_storage_uri: OUTPUT_PREFIX,
         ...overrides,
     };
 }
 
-function completedResponse(...uris: string[]) {
+function completedResponse(...results: CompletionResult[]) {
     return {
         id: 'interaction-1',
         status: 'completed',
@@ -34,7 +56,11 @@ function completedResponse(...uris: string[]) {
             { type: 'thought', summary: [{ type: 'text', text: 'hidden' }] },
             {
                 type: 'model_output',
-                content: uris.map((uri) => ({ type: 'video', uri, mime_type: 'video/mp4' })),
+                content: results.map((result) =>
+                    result.type === 'video'
+                        ? { type: 'video', uri: result.value, mime_type: 'video/mp4' }
+                        : { type: 'text', text: String(result.value) },
+                ),
             },
         ],
     };
@@ -53,12 +79,15 @@ function driverWithResponse(response: unknown) {
 }
 
 describe('GeminiOmniVideoModelDefinition', () => {
-    it('routes the exact model to the dedicated non-streaming definition', () => {
-        const definition = getModelDefinition('publishers/google/models/gemini-omni-flash-preview');
+    it.each([GEMINI_OMNI_VIDEO_MODEL, GEMINI_OMNI_1_1_VIDEO_MODEL])(
+        'routes %s to the dedicated non-streaming definition',
+        (model) => {
+            const definition = getModelDefinition(`publishers/google/models/${model}`);
 
-        expect(definition).toBeInstanceOf(GeminiOmniVideoModelDefinition);
-        expect(definition.model).toMatchObject({ type: 'video', can_stream: false });
-    });
+            expect(definition).toBeInstanceOf(GeminiOmniVideoModelDefinition);
+            expect(definition.model).toMatchObject({ id: model, type: 'video', can_stream: false });
+        },
+    );
 
     it('constructs a text-to-video request with defaults and the global beta endpoint', async () => {
         const definition = new GeminiOmniVideoModelDefinition();
@@ -70,7 +99,7 @@ describe('GeminiOmniVideoModelDefinition', () => {
             ],
             options(),
         );
-        const stub = driverWithResponse(completedResponse(`${OUTPUT_PREFIX}video.mp4`));
+        const stub = driverWithResponse(completedResponse({ type: 'video', value: `${OUTPUT_PREFIX}video.mp4` }));
 
         const completion = await definition.requestTextCompletion(stub.driver, prompt, options());
 
@@ -108,7 +137,12 @@ describe('GeminiOmniVideoModelDefinition', () => {
             [{ role: PromptRole.user, content: 'Animate this', files: [source] }],
             configured,
         );
-        const stub = driverWithResponse(completedResponse(`${OUTPUT_PREFIX}one.mp4`, `${OUTPUT_PREFIX}two.mp4`));
+        const stub = driverWithResponse(
+            completedResponse(
+                { type: 'video', value: `${OUTPUT_PREFIX}one.mp4` },
+                { type: 'video', value: `${OUTPUT_PREFIX}two.mp4` },
+            ),
+        );
 
         const completion = await definition.requestTextCompletion(stub.driver, prompt, configured);
 
@@ -127,7 +161,7 @@ describe('GeminiOmniVideoModelDefinition', () => {
         expect(completion.result).toHaveLength(2);
     });
 
-    it('accepts one to three reference images and requires an explicit image task', async () => {
+    it('accepts references and requires an explicit media task', async () => {
         const definition = new GeminiOmniVideoModelDefinition();
         const references = [image('gs://inputs/1.png'), image('gs://inputs/2.png'), image('gs://inputs/3.png')];
         const configured = options({
@@ -140,7 +174,7 @@ describe('GeminiOmniVideoModelDefinition', () => {
             configured,
         );
 
-        expect(prompt.images).toHaveLength(3);
+        expect(prompt.media).toHaveLength(3);
         await expect(
             definition.createPrompt(
                 {} as VertexAIDriver,
@@ -150,12 +184,168 @@ describe('GeminiOmniVideoModelDefinition', () => {
         ).rejects.toThrow('requires an explicit');
     });
 
+    it('supports first and last frames and 1.1 output resolutions', async () => {
+        const definition = new GeminiOmniVideoModelDefinition(GEMINI_OMNI_1_1_VIDEO_MODEL);
+        const configured = options(
+            {
+                model_options: {
+                    _option_id: 'vertexai-gemini-omni-video',
+                    task: 'image_to_video',
+                    resolution: '4k',
+                },
+            },
+            GEMINI_OMNI_1_1_VIDEO_MODEL,
+        );
+        const prompt = await definition.createPrompt(
+            {} as VertexAIDriver,
+            [
+                {
+                    role: PromptRole.user,
+                    content: 'Transition between these frames',
+                    files: [image('gs://inputs/first.png'), image('gs://inputs/last.png')],
+                },
+            ],
+            configured,
+        );
+        const stub = driverWithResponse(completedResponse({ type: 'video', value: `${OUTPUT_PREFIX}result.mp4` }));
+
+        await definition.requestTextCompletion(stub.driver, prompt, configured);
+
+        expect(stub.post.mock.calls[0]?.[1]).toMatchObject({
+            payload: {
+                model: GEMINI_OMNI_1_1_VIDEO_MODEL,
+                input: [
+                    { type: 'text', text: 'Transition between these frames' },
+                    { type: 'image', uri: 'gs://inputs/first.png', mime_type: 'image/png' },
+                    { type: 'image', uri: 'gs://inputs/last.png', mime_type: 'image/png' },
+                ],
+                response_format: [expect.objectContaining({ resolution: '4k' })],
+                generation_config: { video_config: { task: 'image_to_video' } },
+            },
+        });
+    });
+
+    it.each([
+        ['reference_to_video', [image('gs://inputs/reference.png'), video('gs://inputs/reference.mp4')]],
+        ['edit', [video('gs://inputs/source.mp4')]],
+        ['extend', [video('gs://inputs/source.mp4')]],
+    ] as const)('maps media inputs for the 1.1 %s task', async (task, files) => {
+        const definition = new GeminiOmniVideoModelDefinition(GEMINI_OMNI_1_1_VIDEO_MODEL);
+        const configured = options(
+            { model_options: { _option_id: 'vertexai-gemini-omni-video', task } },
+            GEMINI_OMNI_1_1_VIDEO_MODEL,
+        );
+
+        const prompt = await definition.createPrompt(
+            {} as VertexAIDriver,
+            [{ role: PromptRole.user, content: 'Transform this', files: [...files] }],
+            configured,
+        );
+
+        expect(prompt.media.map((item) => item.type)).toEqual(files.map((file) => file.mime_type.split('/')[0]));
+    });
+
+    it('supports video editing on the 1.0 model', async () => {
+        const definition = new GeminiOmniVideoModelDefinition();
+        const configured = options({
+            model_options: { _option_id: 'vertexai-gemini-omni-video', task: 'edit' },
+        });
+
+        const prompt = await definition.createPrompt(
+            {} as VertexAIDriver,
+            [{ role: PromptRole.user, content: 'Remove the sign', files: [video()] }],
+            configured,
+        );
+
+        expect(prompt.media).toEqual([
+            { type: 'video', uri: 'gs://project-bucket/input/clip.mp4', mime_type: 'video/mp4' },
+        ]);
+    });
+
+    it.each([
+        [GEMINI_OMNI_VIDEO_MODEL, 'extend', [video()], 'does not support extend'],
+        [GEMINI_OMNI_VIDEO_MODEL, 'image_to_video', [image(), image('gs://inputs/last.png')], 'exactly one'],
+        [GEMINI_OMNI_1_1_VIDEO_MODEL, 'edit', [image()], 'exactly one video'],
+        [GEMINI_OMNI_1_1_VIDEO_MODEL, 'extend', [video(), video('gs://inputs/second.mp4')], 'exactly one video'],
+    ] as const)('rejects invalid %s %s media combinations', async (model, task, files, message) => {
+        const configured = options({ model_options: { _option_id: 'vertexai-gemini-omni-video', task } }, model);
+
+        await expect(
+            new GeminiOmniVideoModelDefinition(model).createPrompt(
+                {} as VertexAIDriver,
+                [{ role: PromptRole.user, content: 'prompt', files: [...files] }],
+                configured,
+            ),
+        ).rejects.toThrow(message);
+    });
+
+    it.each([
+        [Array.from({ length: 11 }, (_, index) => image(`gs://inputs/${index}.png`)), 'ten images'],
+        [Array.from({ length: 4 }, (_, index) => video(`gs://inputs/${index}.mp4`)), 'three videos'],
+    ])('enforces documented 1.1 reference attachment limits', async (files, message) => {
+        const configured = options(
+            { model_options: { _option_id: 'vertexai-gemini-omni-video', task: 'reference_to_video' } },
+            GEMINI_OMNI_1_1_VIDEO_MODEL,
+        );
+
+        await expect(
+            new GeminiOmniVideoModelDefinition(GEMINI_OMNI_1_1_VIDEO_MODEL).createPrompt(
+                {} as VertexAIDriver,
+                [{ role: PromptRole.user, content: 'prompt', files }],
+                configured,
+            ),
+        ).rejects.toThrow(message);
+    });
+
+    it('rejects non-720p output on 1.0', async () => {
+        const configured = options({
+            model_options: { _option_id: 'vertexai-gemini-omni-video', resolution: '1080p' },
+        });
+
+        await expect(
+            new GeminiOmniVideoModelDefinition().createPrompt(
+                {} as VertexAIDriver,
+                [{ role: PromptRole.user, content: 'prompt' }],
+                configured,
+            ),
+        ).rejects.toThrow('only supports 720p');
+    });
+
+    it('returns supported text output alongside video output', async () => {
+        const definition = new GeminiOmniVideoModelDefinition(GEMINI_OMNI_1_1_VIDEO_MODEL);
+        const configured = options({}, GEMINI_OMNI_1_1_VIDEO_MODEL);
+        const prompt = await definition.createPrompt(
+            {} as VertexAIDriver,
+            [{ role: PromptRole.user, content: 'prompt' }],
+            configured,
+        );
+        const stub = driverWithResponse(
+            completedResponse(
+                { type: 'text', value: 'Generated video' },
+                { type: 'video', value: `${OUTPUT_PREFIX}result.mp4` },
+            ),
+        );
+
+        const completion = await definition.requestTextCompletion(stub.driver, prompt, configured);
+
+        expect(completion.result).toEqual([
+            { type: 'text', value: 'Generated video' },
+            { type: 'video', value: `${OUTPUT_PREFIX}result.mp4` },
+        ]);
+    });
+
     it.each([
         ['empty prompt', [{ role: PromptRole.user, content: '  ' }], options(), 'non-empty'],
         [
             'unsupported MIME type',
             [{ role: PromptRole.user, content: 'prompt', files: [image('gs://inputs/a.gif', 'image/gif')] }],
             options({ model_options: { _option_id: 'vertexai-gemini-omni-video', task: 'image_to_video' } }),
+            'MIME type',
+        ],
+        [
+            'audio reference',
+            [{ role: PromptRole.user, content: 'prompt', files: [media('gs://inputs/a.wav', 'audio/wav')] }],
+            options({ model_options: { _option_id: 'vertexai-gemini-omni-video', task: 'edit' } }),
             'MIME type',
         ],
         [
@@ -171,10 +361,35 @@ describe('GeminiOmniVideoModelDefinition', () => {
     });
 
     it.each([
+        ['tools', options({ tools: [{ name: 'lookup', input_schema: { type: 'object' } }] }), 'tools'],
+        ['result schemas', options({ result_schema: { type: 'object' } }), 'result schemas'],
+        ['conversation continuation', options({ conversation: { id: 'interaction-0' } }), 'conversation resume'],
+    ])('rejects unsupported %s', async (_name, configured, message) => {
+        await expect(
+            new GeminiOmniVideoModelDefinition().createPrompt(
+                {} as VertexAIDriver,
+                [{ role: PromptRole.user, content: 'prompt' }],
+                configured,
+            ),
+        ).rejects.toThrow(message);
+    });
+
+    it.each([
         [{ status: 'in_progress' }, 'did not complete'],
         [completedResponse(), 'without a video'],
-        [completedResponse('gs://foreign-bucket/video.mp4'), 'outside the requested output prefix'],
-        [completedResponse('https://example.com/video.mp4'), 'invalid GCS video URI'],
+        [
+            completedResponse({ type: 'video', value: 'gs://foreign-bucket/video.mp4' }),
+            'outside the requested output prefix',
+        ],
+        [completedResponse({ type: 'video', value: 'https://example.com/video.mp4' }), 'invalid GCS video URI'],
+        [
+            {
+                id: 'interaction-1',
+                status: 'completed',
+                steps: [{ type: 'model_output', content: [{ type: 'video', data: 'AAAA', mime_type: 'video/mp4' }] }],
+            },
+            'inline video data',
+        ],
     ])('rejects incomplete or invalid provider output', async (response, message) => {
         const definition = new GeminiOmniVideoModelDefinition();
         const prompt = await definition.createPrompt(
@@ -186,6 +401,31 @@ describe('GeminiOmniVideoModelDefinition', () => {
         await expect(
             definition.requestTextCompletion(driverWithResponse(response).driver, prompt, options()),
         ).rejects.toThrow(message);
+    });
+
+    it('preserves the original response when requested', async () => {
+        const response = completedResponse({ type: 'video', value: `${OUTPUT_PREFIX}result.mp4` });
+        const definition = new GeminiOmniVideoModelDefinition();
+        const configured = options({ include_original_response: true });
+        const prompt = await definition.createPrompt(
+            {} as VertexAIDriver,
+            [{ role: PromptRole.user, content: 'prompt' }],
+            configured,
+        );
+
+        const completion = await definition.requestTextCompletion(
+            driverWithResponse(response).driver,
+            prompt,
+            configured,
+        );
+
+        expect(completion.original_response).toBe(response);
+    });
+
+    it('rejects streaming', async () => {
+        await expect(new GeminiOmniVideoModelDefinition().requestTextCompletionStream()).rejects.toThrow(
+            'does not support streaming',
+        );
     });
 
     it('keeps deliberate cancellation terminal and delegates transport failures to shared retry handling', () => {

--- a/drivers/src/vertexai/models/omni-video.ts
+++ b/drivers/src/vertexai/models/omni-video.ts
@@ -2,6 +2,7 @@ import type { Interactions } from '@google/genai';
 import {
     type AIModel,
     type Completion,
+    type CompletionResult,
     type DriverCompletionStream,
     type ExecutionOptions,
     type ExecutionTokenUsage,
@@ -15,18 +16,34 @@ import type { VertexAIDriver } from '../index.js';
 import type { ModelDefinition } from '../models.js';
 
 export const GEMINI_OMNI_VIDEO_MODEL = 'gemini-omni-flash-preview';
+export const GEMINI_OMNI_1_1_VIDEO_MODEL = 'gemini-omni-1.1-flash-preview';
+export const GEMINI_OMNI_VIDEO_MODELS = [GEMINI_OMNI_VIDEO_MODEL, GEMINI_OMNI_1_1_VIDEO_MODEL] as const;
+
+export type GeminiOmniVideoModel = (typeof GEMINI_OMNI_VIDEO_MODELS)[number];
+
+export function isGeminiOmniVideoModel(model: string): model is GeminiOmniVideoModel {
+    return GEMINI_OMNI_VIDEO_MODELS.some((candidate) => candidate === model);
+}
 
 const SUPPORTED_IMAGE_MIME_TYPES = new Set(['image/png', 'image/jpeg', 'image/webp', 'image/heic', 'image/heif']);
+const SUPPORTED_VIDEO_MIME_TYPES = new Set([
+    'video/3gpp',
+    'video/mp4',
+    'video/mpeg',
+    'video/mpegs',
+    'video/mpg',
+    'video/quicktime',
+    'video/webm',
+    'video/wmv',
+    'video/x-flv',
+    'video/x-ms-wmv',
+]);
 
-interface OmniVideoImageInput {
-    type: 'image';
-    uri: string;
-    mime_type: string;
-}
+type OmniVideoMediaInput = Extract<Interactions.Content, { type: 'image' | 'video' }>;
 
 export interface OmniVideoPrompt {
     text: string;
-    images: OmniVideoImageInput[];
+    media: OmniVideoMediaInput[];
 }
 
 class OmniVideoTerminalError extends Error {
@@ -58,21 +75,53 @@ function normalizeOutputPrefix(value: string | undefined): string {
     return value.endsWith('/') ? value : `${value}/`;
 }
 
-function resolveTask(options: VertexAIGeminiOmniVideoOptions | undefined, imageCount: number) {
-    const task = options?.task ?? (imageCount === 0 ? 'text_to_video' : undefined);
+function resolveTask(
+    model: GeminiOmniVideoModel,
+    options: VertexAIGeminiOmniVideoOptions | undefined,
+    media: OmniVideoMediaInput[],
+) {
+    const imageCount = media.filter((item) => item.type === 'image').length;
+    const videoCount = media.filter((item) => item.type === 'video').length;
+    const task = options?.task ?? (media.length === 0 ? 'text_to_video' : undefined);
     if (!task) {
-        throw new OmniVideoTerminalError(
-            'Gemini Omni video generation with images requires an explicit image_to_video or reference_to_video task',
-        );
+        throw new OmniVideoTerminalError('Gemini Omni video generation with media requires an explicit task');
     }
-    if (task === 'text_to_video' && imageCount !== 0) {
-        throw new OmniVideoTerminalError('text_to_video does not accept image inputs');
+    if (task === 'extend' && model !== GEMINI_OMNI_1_1_VIDEO_MODEL) {
+        throw new OmniVideoTerminalError(`${model} does not support extend`);
     }
-    if (task === 'image_to_video' && imageCount !== 1) {
-        throw new OmniVideoTerminalError('image_to_video requires exactly one image input');
+    if (options?.resolution && model === GEMINI_OMNI_VIDEO_MODEL && options.resolution !== '720p') {
+        throw new OmniVideoTerminalError(`${model} only supports 720p output`);
     }
-    if (task === 'reference_to_video' && (imageCount < 1 || imageCount > 3)) {
-        throw new OmniVideoTerminalError('reference_to_video requires between one and three image inputs');
+
+    switch (task) {
+        case 'text_to_video':
+            if (media.length !== 0) throw new OmniVideoTerminalError('text_to_video does not accept media inputs');
+            break;
+        case 'image_to_video': {
+            const maximumImages = model === GEMINI_OMNI_1_1_VIDEO_MODEL ? 2 : 1;
+            if (videoCount !== 0 || imageCount < 1 || imageCount > maximumImages) {
+                const expected = maximumImages === 1 ? 'exactly one image input' : 'one or two image inputs';
+                throw new OmniVideoTerminalError(`image_to_video requires ${expected}`);
+            }
+            break;
+        }
+        case 'reference_to_video':
+            if (media.length === 0 || imageCount > 10 || videoCount > 3) {
+                throw new OmniVideoTerminalError(
+                    'reference_to_video requires media with at most ten images and three videos',
+                );
+            }
+            break;
+        case 'edit':
+            if (imageCount !== 0 || videoCount !== 1) {
+                throw new OmniVideoTerminalError('edit requires exactly one video input');
+            }
+            break;
+        case 'extend':
+            if (imageCount !== 0 || videoCount !== 1) {
+                throw new OmniVideoTerminalError('extend requires exactly one video input');
+            }
+            break;
     }
     return task;
 }
@@ -105,7 +154,7 @@ function interactionFailureRetryable(errors: Interactions.Error[] | undefined): 
     return undefined;
 }
 
-function parseVideoResults(response: Interactions.Interaction, outputPrefix: string) {
+function parseOmniResults(response: Interactions.Interaction, outputPrefix: string) {
     if (response.status !== 'completed') {
         const details = response.errors?.length ? `: ${JSON.stringify(response.errors)}` : '';
         const permanent = new Set(['requires_action', 'cancelled', 'budget_exceeded']);
@@ -120,38 +169,49 @@ function parseVideoResults(response: Interactions.Interaction, outputPrefix: str
         );
     }
 
-    const videoParts = (response.steps ?? [])
+    const outputParts = (response.steps ?? [])
         .filter((step) => step.type === 'model_output')
-        .flatMap((step) => step.content ?? [])
-        .filter((part) => part.type === 'video');
-    if (videoParts.length === 0) {
+        .flatMap((step) => step.content ?? []);
+
+    const results: CompletionResult[] = [];
+    let hasVideoOutput = false;
+    for (const part of outputParts) {
+        if (part.type === 'text') {
+            if (part.text) results.push({ type: 'text', value: part.text });
+            continue;
+        }
+        if (part.type === 'video') {
+            hasVideoOutput = true;
+            if (part.data !== undefined) {
+                throw new OmniVideoTerminalError('Gemini Omni returned inline video data instead of URI delivery');
+            }
+            if (!part.uri || !isGcsUri(part.uri, true)) {
+                throw new OmniVideoTerminalError('Gemini Omni returned a missing or invalid GCS video URI');
+            }
+            if (!part.uri.startsWith(outputPrefix)) {
+                throw new OmniVideoTerminalError(
+                    'Gemini Omni returned a video URI outside the requested output prefix',
+                );
+            }
+            if (part.mime_type && !part.mime_type.startsWith('video/')) {
+                throw new OmniVideoTerminalError(`Gemini Omni returned an invalid video MIME type: ${part.mime_type}`);
+            }
+            results.push({ type: 'video', value: part.uri });
+        }
+    }
+    if (!hasVideoOutput) {
         throw new OmniVideoTerminalError('Gemini Omni completed without a video output URI');
     }
-
-    return videoParts.map((part) => {
-        if (part.data !== undefined) {
-            throw new OmniVideoTerminalError('Gemini Omni returned inline video data instead of URI delivery');
-        }
-        if (!part.uri || !isGcsUri(part.uri, true)) {
-            throw new OmniVideoTerminalError('Gemini Omni returned a missing or invalid GCS video URI');
-        }
-        if (!part.uri.startsWith(outputPrefix)) {
-            throw new OmniVideoTerminalError('Gemini Omni returned a video URI outside the requested output prefix');
-        }
-        if (part.mime_type && !part.mime_type.startsWith('video/')) {
-            throw new OmniVideoTerminalError(`Gemini Omni returned an invalid video MIME type: ${part.mime_type}`);
-        }
-        return { type: 'video' as const, value: part.uri };
-    });
+    return results;
 }
 
 export class GeminiOmniVideoModelDefinition implements ModelDefinition<OmniVideoPrompt> {
     readonly model: AIModel;
 
-    constructor() {
+    constructor(private readonly modelId: GeminiOmniVideoModel = GEMINI_OMNI_VIDEO_MODEL) {
         this.model = {
-            id: GEMINI_OMNI_VIDEO_MODEL,
-            name: GEMINI_OMNI_VIDEO_MODEL,
+            id: modelId,
+            name: modelId,
             provider: 'vertexai',
             type: ModelType.Video,
             can_stream: false,
@@ -175,24 +235,29 @@ export class GeminiOmniVideoModelDefinition implements ModelDefinition<OmniVideo
             .join('\n');
         if (!text) throw new OmniVideoTerminalError('Gemini Omni video requires a non-empty text prompt');
 
-        const images: OmniVideoImageInput[] = [];
+        const media: OmniVideoMediaInput[] = [];
         for (const segment of segments) {
             for (const file of segment.files ?? []) {
-                if (!SUPPORTED_IMAGE_MIME_TYPES.has(file.mime_type)) {
+                const type = SUPPORTED_IMAGE_MIME_TYPES.has(file.mime_type)
+                    ? 'image'
+                    : SUPPORTED_VIDEO_MIME_TYPES.has(file.mime_type)
+                      ? 'video'
+                      : undefined;
+                if (!type) {
                     throw new OmniVideoTerminalError(
                         `Gemini Omni video does not support input MIME type ${file.mime_type}`,
                     );
                 }
                 const uri = await file.getURI();
                 if (!isGcsUri(uri, true)) {
-                    throw new OmniVideoTerminalError('Gemini Omni video image inputs must expose a GCS object URI');
+                    throw new OmniVideoTerminalError('Gemini Omni video media inputs must expose a GCS object URI');
                 }
-                images.push({ type: 'image', uri, mime_type: file.mime_type });
+                media.push({ type, uri, mime_type: file.mime_type });
             }
         }
 
-        resolveTask(options.model_options as VertexAIGeminiOmniVideoOptions | undefined, images.length);
-        return { text, images };
+        resolveTask(this.modelId, options.model_options as VertexAIGeminiOmniVideoOptions | undefined, media);
+        return { text, media };
     }
 
     async requestTextCompletion(
@@ -202,7 +267,7 @@ export class GeminiOmniVideoModelDefinition implements ModelDefinition<OmniVideo
         signal?: AbortSignal,
     ): Promise<Completion> {
         const modelOptions = options.model_options as VertexAIGeminiOmniVideoOptions | undefined;
-        const task = resolveTask(modelOptions, prompt.images.length);
+        const task = resolveTask(this.modelId, modelOptions, prompt.media);
         const outputPrefix = normalizeOutputPrefix(options.output_storage_uri);
         const responseFormat = {
             type: 'video' as const,
@@ -210,10 +275,11 @@ export class GeminiOmniVideoModelDefinition implements ModelDefinition<OmniVideo
             gcs_uri: outputPrefix,
             duration: `${modelOptions?.duration_seconds ?? 5}s`,
             ...(modelOptions?.aspect_ratio ? { aspect_ratio: modelOptions.aspect_ratio } : {}),
-        };
+            ...(modelOptions?.resolution ? { resolution: modelOptions.resolution } : {}),
+        } satisfies Interactions.VideoResponseFormat;
         const payload = {
-            model: GEMINI_OMNI_VIDEO_MODEL,
-            input: [{ type: 'text' as const, text: prompt.text }, ...prompt.images],
+            model: this.modelId,
+            input: [{ type: 'text' as const, text: prompt.text }, ...prompt.media],
             response_format: [responseFormat],
             generation_config: { video_config: { task } },
         } satisfies Interactions.CreateModelInteractionParamsNonStreaming;
@@ -231,7 +297,7 @@ export class GeminiOmniVideoModelDefinition implements ModelDefinition<OmniVideo
             result: response.usage?.total_output_tokens,
         };
         return {
-            result: parseVideoResults(response, outputPrefix),
+            result: parseOmniResults(response, outputPrefix),
             token_usage: tokenUsage,
             finish_reason: 'stop',
             ...(options.include_original_response ? { original_response: response } : {}),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ catalogs:
       version: 7.0.2
 
 overrides:
-  google-auth-library: ^11.0.0
+  google-auth-library: ^11.0.2
   '@types/node': ^24.13.3
   vite: ^8.0.16
   brace-expansion@>=3.0.0 <5.0.8: 5.0.9
@@ -144,8 +144,8 @@ importers:
         specifier: ^7.0.0
         version: 7.1.0
       '@google/genai':
-        specifier: ^2.17.0
-        version: 2.17.1
+        specifier: ^2.21.0
+        version: 2.21.0
       '@huggingface/inference':
         specifier: ^4.13.25
         version: 4.13.25
@@ -165,8 +165,8 @@ importers:
         specifier: ^4.1.1
         version: 4.1.1
       google-auth-library:
-        specifier: ^11.0.0
-        version: 11.0.0
+        specifier: ^11.0.2
+        version: 11.0.2
       groq-sdk:
         specifier: ^1.5.0
         version: 1.5.0
@@ -526,8 +526,8 @@ packages:
     resolution: {integrity: sha512-2vBc4dQK6/qhulcMzSR7FZTkYJmUYBFdZuam9ZF9pusYHaOuUDZd7yI3oHdeQXiE3WY0jv7G9yS6tltcjaepaw==}
     engines: {node: '>=22'}
 
-  '@google/genai@2.17.1':
-    resolution: {integrity: sha512-CdZ3M/titoH81hXXkvOikrOW26bC9IXh9iYT7u+r+5p7wi1LnMEnB0AbJfDeWAkjuneP4oJ299BtCt6twmORWg==}
+  '@google/genai@2.21.0':
+    resolution: {integrity: sha512-+PDtco2/Z0ONdzCGekCoCT+O1VJS9xJQNN4XzQpXG/t3El/SWWMkCWlFRO1KmivOHPa4Q0VjUYu1HBKCZ/v33Q==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.25.2
@@ -622,8 +622,8 @@ packages:
   '@protobufjs/pool@1.1.0':
     resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
 
-  '@protobufjs/utf8@1.1.1':
-    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
+  '@protobufjs/utf8@1.1.2':
+    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
   '@rolldown/binding-android-arm64@1.0.3':
     resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
@@ -1305,13 +1305,13 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  gaxios@7.1.4:
-    resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
+  gaxios@7.3.1:
+    resolution: {integrity: sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==}
     engines: {node: '>=18'}
 
-  gcp-metadata@8.1.2:
-    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
-    engines: {node: '>=18'}
+  gcp-metadata@9.0.3:
+    resolution: {integrity: sha512-2YYnIlHaKBGT2IPg3G2M57hia9Galz15zsEOvw9T3oRf0lSn6KN6VcHQLqby7x8ksYKnjXvp3rp2KJyLCN6zfQ==}
+    engines: {node: '>=22'}
 
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -1321,17 +1321,13 @@ packages:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
 
-  google-auth-library@11.0.0:
-    resolution: {integrity: sha512-WC5gkb2pElGhZKgGx9r799trH3ZUx90ecgIOIMmgiiHS/gzO3r4vvFoQWuKI0QmR2xU5uee2M4hDUxRZDh/x7w==}
+  google-auth-library@11.0.2:
+    resolution: {integrity: sha512-vzpgPutxrghPsnjrjpzLX2bdv8IOL719Rh0oEjGnQu8YCIbnbMuTTQ5zU9LcKvLdOPgCxBwppbvnhgW90Qna5Q==}
     engines: {node: '>=22'}
 
   google-gax@6.0.2:
     resolution: {integrity: sha512-9O+aJyiZrGcEggeG9FoA1R3HRQEUi32ydPSvE42lFbh+D8KwQS57CgMsZ0JPpGCM1LFwEWe+yr2h/53xmgHnQA==}
     engines: {node: '>=22'}
-
-  google-logging-utils@1.1.3:
-    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
-    engines: {node: '>=14'}
 
   google-logging-utils@2.0.1:
     resolution: {integrity: sha512-HMhaQghlOTvbcb3c4T5jmmOMtG3JUF1iOQMezaJXL86CDS+Tm2vHd0IeLFRAx3+ewd+bo9E1HFHoy17X5aJa9A==}
@@ -1875,6 +1871,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   xml-naming@0.1.0:
     resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
     engines: {node: '>=16.0.0'}
@@ -1927,7 +1935,7 @@ snapshots:
   '@anthropic-ai/vertex-sdk@0.19.4(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.116.0(zod@4.4.3)
-      google-auth-library: 11.0.0
+      google-auth-library: 11.0.2
     transitivePeerDependencies:
       - supports-color
       - zod
@@ -2480,12 +2488,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@google/genai@2.17.1':
+  '@google/genai@2.21.0':
     dependencies:
-      google-auth-library: 11.0.0
+      google-auth-library: 11.0.2
       p-retry: 4.6.2
       protobufjs: 7.6.5
-      ws: 8.21.0
+      ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -2561,7 +2569,7 @@ snapshots:
 
   '@protobufjs/pool@1.1.0': {}
 
-  '@protobufjs/utf8@1.1.1': {}
+  '@protobufjs/utf8@1.1.2': {}
 
   '@rolldown/binding-android-arm64@1.0.3':
     optional: true
@@ -3194,7 +3202,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  gaxios@7.1.4:
+  gaxios@7.3.1:
     dependencies:
       extend: 3.0.2
       https-proxy-agent: 7.0.6
@@ -3202,10 +3210,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  gcp-metadata@8.1.2:
+  gcp-metadata@9.0.3:
     dependencies:
-      gaxios: 7.1.4
-      google-logging-utils: 1.1.3
+      gaxios: 7.3.1
+      google-logging-utils: 2.0.1
       json-bigint: 1.0.0
     transitivePeerDependencies:
       - supports-color
@@ -3218,13 +3226,13 @@ snapshots:
       minipass: 7.1.3
       path-scurry: 2.0.2
 
-  google-auth-library@11.0.0:
+  google-auth-library@11.0.2:
     dependencies:
       base64-js: 1.5.1
       ecdsa-sig-formatter: 1.0.11
-      gaxios: 7.1.4
-      gcp-metadata: 8.1.2
-      google-logging-utils: 1.1.3
+      gaxios: 7.3.1
+      gcp-metadata: 9.0.3
+      google-logging-utils: 2.0.1
       jws: 4.0.1
     transitivePeerDependencies:
       - supports-color
@@ -3234,7 +3242,7 @@ snapshots:
       '@grpc/grpc-js': 1.14.4
       '@grpc/proto-loader': 0.8.0
       duplexify: 4.1.3
-      google-auth-library: 11.0.0
+      google-auth-library: 11.0.2
       google-logging-utils: 2.0.1
       node-fetch: 3.3.2
       object-hash: 3.0.0
@@ -3243,8 +3251,6 @@ snapshots:
       retry-request: 9.0.1
     transitivePeerDependencies:
       - supports-color
-
-  google-logging-utils@1.1.3: {}
 
   google-logging-utils@2.0.1: {}
 
@@ -3493,7 +3499,7 @@ snapshots:
       '@protobufjs/float': 1.0.2
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.1
+      '@protobufjs/utf8': 1.1.2
       '@types/node': 24.13.3
       long: 5.3.2
 
@@ -3724,6 +3730,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.21.0: {}
+
+  ws@8.21.3: {}
 
   xml-naming@0.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,11 +14,12 @@ minimumReleaseAgeStrict: true
 minimumReleaseAgeExclude:
   - '@vertesia/*'
   - '@llumiverse/*'
+  - '@google/genai@2.21.0'
 
 catalog:
   typescript: "7.0.2"
   "@types/node": "^24.13.3"
-  google-auth-library: "^11.0.0"
+  google-auth-library: "^11.0.2"
 overrides:
   # ============================
   # Special Overrides


### PR DESCRIPTION
## Summary
- add Gemini Omni Flash 1.1 Preview alongside the existing Omni Flash Preview model
- support model-specific video generation, first/last frames, references, editing, extension, and output resolutions through the existing synchronous Vertex request path
- validate GCS media inputs, task combinations, output delivery, and unsupported features locally
- update @google/genai to 2.21.0 and use its interaction media and response types where compatible
- complete Omni 1.0 capabilities, video input handling, editing, and text-plus-video response parsing

## Test Plan
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `pnpm typecheck:test`
- [x] focused common tests: 43 passed
- [x] focused Vertex routing and Omni driver tests: 44 passed
- [x] synchronous GCS-delivery smoke generation for both Omni model IDs
- [x] basic end-to-end manual smoke test
- [ ] `pnpm test` currently reaches configured live suites but local Bedrock cases fail because the AWS SSO token is expired; 53 driver test files passed, including all 41 Omni driver tests, and Google Vertex live coverage passed
