### PR TITLE
fix: honor Gemini HTTP transport timeouts

### DIFF
--- a/core/src/Driver.ts
+++ b/core/src/Driver.ts
@@ -191,10 +191,15 @@ export abstract class AbstractDriver<OptionsT extends DriverOptions = DriverOpti
         }
     }
 
+    /** Provider SDKs without a fetch hook can scope their global HTTP requests here. */
+    protected runInHttpContext<T>(operation: () => T): T {
+        return operation();
+    }
+
     private async runOperation<T>(operation: () => Promise<T>): Promise<T> {
         const release = this.acquireOperationLease();
         try {
-            return await operation();
+            return await this.runInHttpContext(operation);
         } finally {
             release();
         }
@@ -203,7 +208,7 @@ export abstract class AbstractDriver<OptionsT extends DriverOptions = DriverOpti
     private async runStreamOperation(operation: () => Promise<CompletionStream<PromptT>>, signal?: AbortSignal) {
         const release = this.acquireOperationLease();
         try {
-            const stream = await operation();
+            const stream = await this.runInHttpContext(operation);
             return leaseCompletionStream(
                 stream,
                 release,
@@ -269,7 +274,11 @@ export abstract class AbstractDriver<OptionsT extends DriverOptions = DriverOpti
         options: Pick<ExecutionOptions, 'httpTimeout'>,
         force = false,
     ): DriverHttpAgentScope {
-        return createDriverHttpAgentScope(this.options.httpTimeout, options.httpTimeout, force);
+        const scope = createDriverHttpAgentScope(this.options.httpTimeout, options.httpTimeout, force);
+        return {
+            ...scope,
+            run: <T>(callback: () => T): T => this.runInHttpContext(() => scope.run(callback)),
+        };
     }
 
     async createTrainingPrompt(options: TrainingPromptOptions): Promise<string> {

--- a/core/src/http-agent.test.ts
+++ b/core/src/http-agent.test.ts
@@ -11,17 +11,19 @@ import {
     type ModelSearchPayload,
     PromptRole,
 } from '@llumiverse/common';
-import type { Agent } from 'undici';
+import { type Agent, getGlobalDispatcher, setGlobalDispatcher } from 'undici';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AbstractDriver } from './Driver.js';
 import {
     createAgentBackedFetch,
     createDriverHttpAgent,
+    createDriverHttpAgentScope,
     DEFAULT_DRIVER_HTTP_TIMEOUTS,
     DEFAULT_DRIVER_REQUEST_TIMEOUT_MS,
     mergeDriverHttpTimeoutOptions,
     resolveDriverHttpTimeouts,
     resolveDriverRequestTimeoutMs,
+    runWithDriverHttpAgent,
 } from './http-agent.js';
 
 class TestDriver extends AbstractDriver<DriverOptions, string> {
@@ -261,6 +263,55 @@ describe('driver HTTP agent helpers', () => {
             await expect(response.text()).rejects.toThrow();
             expect(Date.now() - startedAt).toBeLessThan(2_500);
         } finally {
+            await agent.close();
+            await server.close();
+        }
+    });
+
+    it('isolates global SDK fetch timeouts from concurrent and unrelated requests', async () => {
+        const previousDispatcher = getGlobalDispatcher();
+        const shortAgent = createDriverHttpAgent({ headersTimeout: 100 });
+        const longAgent = createDriverHttpAgent({ headersTimeout: 5_000 });
+        const server = await startServer((_req, res) => {
+            const timer = setTimeout(() => res.end('late'), 1_500);
+            res.on('close', () => clearTimeout(timer));
+        });
+        setGlobalDispatcher(shortAgent);
+        try {
+            const [long, short, unrelated] = await Promise.allSettled([
+                runWithDriverHttpAgent(longAgent, async () => (await fetch(server.url)).text()),
+                runWithDriverHttpAgent(shortAgent, () => fetch(server.url)),
+                fetch(server.url),
+            ]);
+            expect(long).toEqual({ status: 'fulfilled', value: 'late' });
+            expect(short).toMatchObject({ status: 'rejected', reason: { cause: { code: 'UND_ERR_HEADERS_TIMEOUT' } } });
+            expect(unrelated).toMatchObject({ status: 'rejected' });
+        } finally {
+            setGlobalDispatcher(previousDispatcher);
+            await Promise.all([shortAgent.close(), longAgent.close()]);
+            await server.close();
+        }
+    });
+
+    it('routes global SDK fetch through the per-call agent and supports aborting it', async () => {
+        const previousDispatcher = getGlobalDispatcher();
+        const agent = createDriverHttpAgent();
+        const scope = createDriverHttpAgentScope(undefined, { headersTimeout: 100 });
+        const server = await startServer((_req, res) => {
+            const timer = setTimeout(() => res.end('late'), 3_000);
+            res.on('close', () => clearTimeout(timer));
+        });
+        try {
+            await expect(runWithDriverHttpAgent(agent, () => scope.run(() => fetch(server.url)))).rejects.toMatchObject(
+                { cause: { code: 'UND_ERR_HEADERS_TIMEOUT' } },
+            );
+            const request = runWithDriverHttpAgent(agent, () => scope.run(() => fetch(server.url)));
+            const rejected = expect(request).rejects.toThrow();
+            await scope.abort();
+            await rejected;
+        } finally {
+            setGlobalDispatcher(previousDispatcher);
+            await scope.close();
             await agent.close();
             await server.close();
         }

--- a/core/src/http-agent.ts
+++ b/core/src/http-agent.ts
@@ -1,6 +1,6 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import type { HttpTimeoutOptions } from '@llumiverse/common';
-import { Agent } from 'undici';
+import { Agent, getGlobalDispatcher, setGlobalDispatcher } from 'undici';
 
 /**
  * Default HTTP timeouts used by {@link createDriverHttpAgent} when the
@@ -26,6 +26,24 @@ export function resolveDriverRequestTimeoutMs(defaults?: HttpTimeoutOptions, ove
 }
 
 const scopedHttpAgent = new AsyncLocalStorage<Agent>();
+
+// SDKs without a fetch hook can opt in without changing unrelated HTTP traffic.
+const sdkHttpAgent = new AsyncLocalStorage<Agent>();
+let scopedGlobalDispatcher: ReturnType<typeof getGlobalDispatcher> | undefined;
+
+export function runWithDriverHttpAgent<T>(agent: Agent, callback: () => T): T {
+    const currentDispatcher = getGlobalDispatcher();
+    if (currentDispatcher !== scopedGlobalDispatcher) {
+        scopedGlobalDispatcher = currentDispatcher.compose((dispatch) => (options, handler) => {
+            const sdkAgent = sdkHttpAgent.getStore();
+            return sdkAgent
+                ? (scopedHttpAgent.getStore() ?? sdkAgent).dispatch(options, handler)
+                : dispatch(options, handler);
+        });
+        setGlobalDispatcher(scopedGlobalDispatcher);
+    }
+    return sdkHttpAgent.run(agent, callback);
+}
 
 export function resolveDriverHttpTimeouts(opts?: HttpTimeoutOptions): Required<HttpTimeoutOptions> {
     return {

--- a/drivers/src/vertexai/gemini-http-transport.test.ts
+++ b/drivers/src/vertexai/gemini-http-transport.test.ts
@@ -1,0 +1,55 @@
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { GoogleGenAI } from '@google/genai';
+import { PromptRole } from '@llumiverse/core';
+import { expect, it, vi } from 'vitest';
+import { VertexAIDriver } from './index.js';
+
+it.each(['execute', 'stream'] as const)('applies per-call transport timeouts to Google SDK %s', async (mode) => {
+    const server = createServer((req, res) => {
+        const timer = setTimeout(() => {
+            const data = JSON.stringify({
+                candidates: [{ content: { parts: [{ text: 'ok' }] }, finishReason: 'STOP' }],
+            });
+            const streaming = req.url?.includes('streamGenerateContent');
+            res.setHeader('content-type', streaming ? 'text/event-stream' : 'application/json');
+            res.end(streaming ? `data: ${data}\n\n` : data);
+        }, 1_500);
+        res.on('close', () => clearTimeout(timer));
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const driver = new VertexAIDriver({ project: 'test', region: 'global', geminiContextCache: false });
+    const client = new GoogleGenAI({
+        apiKey: 'test',
+        httpOptions: {
+            baseUrl: `http://127.0.0.1:${(server.address() as AddressInfo).port}`,
+            timeout: 5_000,
+        },
+    });
+    const spy = vi.spyOn(driver, 'getGoogleGenAIClient').mockReturnValue(client);
+    const prompt = [{ role: PromptRole.user, content: 'hello' }];
+    const execute = async (headersTimeout?: number) => {
+        const options = {
+            model: 'gemini-3-flash-preview',
+            ...(headersTimeout ? { httpTimeout: { headersTimeout } } : {}),
+        };
+        if (mode === 'execute') return driver.execute(prompt, options);
+        const stream = await driver.stream(prompt, options);
+        let text = '';
+        for await (const chunk of stream) text += chunk;
+        return text;
+    };
+    try {
+        const [normal, short] = await Promise.allSettled([execute(), execute(100)]);
+        expect(normal.status).toBe('fulfilled');
+        expect(short).toMatchObject({ status: 'rejected' });
+        if (short.status === 'rejected') {
+            expect(String(short.reason)).toContain('fetch failed');
+        }
+    } finally {
+        spy.mockRestore();
+        driver.destroy();
+        server.closeAllConnections();
+        await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+    }
+});

--- a/drivers/src/vertexai/index.ts
+++ b/drivers/src/vertexai/index.ts
@@ -24,6 +24,7 @@ import {
     truncateLargeTextInConversation,
 } from '@llumiverse/core';
 import { AbstractDriver } from '@llumiverse/core/driver';
+import { runWithDriverHttpAgent } from '@llumiverse/core/http-agent';
 import { type FETCH_FN, FetchClient } from '@vertesia/api-fetch-client';
 import { type AuthClient, GoogleAuth, type GoogleAuthOptions } from 'google-auth-library';
 import {
@@ -203,6 +204,11 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
                 }
             }
         });
+    }
+
+    protected override runInHttpContext<T>(operation: () => T): T {
+        // GoogleGenAI uses global fetch rather than accepting the driver's fetch hook.
+        return runWithDriverHttpAgent(this.getHttpAgent(), operation);
     }
 
     private async getAuthClient(): Promise<AuthClient> {


### PR DESCRIPTION
Gemini requests can fail with `Headers Timeout Error` after five minutes even when the driver configures a 15-minute deadline. GoogleGenAI uses global fetch and does not accept a custom fetch implementation, so its requests bypassed the driver HTTP agent.

Route global SDK requests through an async-scoped dispatcher that selects the driver agent or per-call override. Unrelated requests retain the existing dispatcher. Apply the scope to provider operations and deferred stream consumption, preserving pooled-agent ownership and cancellation. No default timeout or service tier changes.

Validation:
- `pnpm --prefix core lint` and `pnpm --prefix drivers lint` passed (workspace binaries added to PATH).
- `pnpm build` passed from the llumiverse root.
- `pnpm --prefix core typecheck:test` and `pnpm --prefix drivers typecheck:test` passed.
- `pnpm --prefix core test`: 186 tests passed.
- `pnpm --prefix drivers test src/vertexai/gemini-http-transport.test.ts src/http-timeout-wiring.test.ts`: 10 tests passed.
- Regression coverage uses real local HTTP servers and the Google SDK for unary and streaming requests, concurrent timeout isolation, unrelated fetch traffic, and scoped-agent cancellation. No live provider calls were needed.

Publish core and drivers together. Target: release/1.5; forward-port to main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Node's global undici dispatcher composition for opt-in SDK paths; incorrect scoping could affect unrelated fetch traffic, though tests assert isolation.
> 
> **Overview**
> Fixes Gemini (and similar SDK) calls ignoring driver **`httpTimeout`** because **GoogleGenAI** uses global `fetch` instead of the driver's agent-backed fetch.
> 
> Adds **`runWithDriverHttpAgent`**, which installs a composed undici global dispatcher that picks the async-scoped driver agent or per-call override from existing execution scopes, without affecting unrelated HTTP traffic. **`AbstractDriver`** introduces **`runInHttpContext`** and runs guarded operations, streams, and **`createExecutionHttpAgentScope.run`** through it; **Vertex AI** overrides the hook to wrap provider work with the driver's pooled agent.
> 
> Regression tests cover concurrent timeout isolation, scoped abort, and Vertex **execute**/**stream** paths against a local server with the real Google SDK.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65c94ea890aad6ac355f516940a0d6f3eb9cad8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->