### PR TITLE
feat: add embedding batch provider adapter with Vertex support

### DIFF
--- a/core/src/embedding-batch.ts
+++ b/core/src/embedding-batch.ts
@@ -1,0 +1,86 @@
+import type { EmbeddingInput } from '@llumiverse/common';
+import type { Driver } from './Driver.js';
+
+export type EmbeddingBatchModality = 'text' | 'image';
+export type EmbeddingBatchState = 'pending' | 'running' | 'succeeded' | 'failed' | 'cancelled' | 'paused';
+
+export interface EmbeddingBatchCapability {
+    model: string;
+    inputFormat: string;
+    maxRows: number;
+    location?: string;
+}
+
+/** Durable application artifacts, not provider file IDs or signed URLs. Implementations enforce tenant scope. */
+export interface EmbeddingBatchArtifactStore {
+    list(prefix: string): Promise<string[]>;
+    read(uri: string): Promise<ReadableStream<Uint8Array>>;
+    write(uri: string, content: ReadableStream<Uint8Array>): Promise<void>;
+}
+
+export interface EmbeddingBatchJob {
+    /** Opaque provider job identity. */
+    name: string;
+    displayName?: string;
+    state: EmbeddingBatchState;
+    model?: string;
+    /** Original application artifact locations, retained for ownership checks even with uploaded-file providers. */
+    inputUri?: string;
+    outputUri?: string;
+    error?: string;
+}
+
+export interface EmbeddingBatchJobOptions {
+    model: string;
+    modality: EmbeddingBatchModality;
+    name: string;
+}
+
+export interface EmbeddingBatchCreateOptions {
+    model: string;
+    modality: EmbeddingBatchModality;
+    dimensions?: number;
+    displayName: string;
+    inputUri: string;
+    outputUri: string;
+}
+
+export interface ParsedEmbeddingBatchResult {
+    key?: string;
+    vector?: number[];
+    providerError: boolean;
+    failureCategory?: string;
+}
+
+/** Optional provider support. Native payloads and file handles stay behind this interface.
+ * Lifecycle methods must validate the requested model and preserve original artifact URIs for ownership checks.
+ * Create retries must recover a matching displayName/model/input/output submission rather than create duplicates.
+ * Result parsers return sanitized failure categories, never input content or native error payloads.
+ */
+export interface EmbeddingBatchAdapter {
+    capability(
+        model: string,
+        modality: EmbeddingBatchModality,
+        location?: string,
+    ): EmbeddingBatchCapability | undefined;
+    formatRow(options: {
+        key: string;
+        model: string;
+        input: EmbeddingInput;
+        dimensions: number;
+        inputFormat: string;
+    }): Promise<{ row: Record<string, unknown>; resultKey: string }>;
+    parseResult(record: Record<string, unknown>): ParsedEmbeddingBatchResult;
+    create(
+        driver: Driver,
+        options: EmbeddingBatchCreateOptions,
+        artifacts: EmbeddingBatchArtifactStore,
+    ): Promise<EmbeddingBatchJob>;
+    get(driver: Driver, options: EmbeddingBatchJobOptions): Promise<EmbeddingBatchJob>;
+    cancel(driver: Driver, options: EmbeddingBatchJobOptions): Promise<EmbeddingBatchJob>;
+    delete(driver: Driver, options: EmbeddingBatchJobOptions): Promise<EmbeddingBatchJob>;
+    /** Called only after job ownership validation. Include partial successes and errors on every terminal state.
+     * Return existing object-store artifacts, or materialize provider files idempotently under job.outputUri.
+     */
+    outputArtifacts(driver: Driver, job: EmbeddingBatchJob, artifacts: EmbeddingBatchArtifactStore): Promise<string[]>;
+}

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -1,6 +1,7 @@
 export * from '@llumiverse/common';
 export * from './conversation-utils.js';
 export type { AbstractDriver, Driver } from './Driver.js';
+export type * from './embedding-batch.js';
 export * from './embeddings.js';
 export * from './json.js';
 export * from './logger.js';

--- a/drivers/package.json
+++ b/drivers/package.json
@@ -38,6 +38,10 @@
             "types": "./lib/vertexai/index.d.ts",
             "default": "./lib/vertexai/index.js"
         },
+        "./vertexai/embedding-batch": {
+            "types": "./lib/vertexai/embeddings/batch.d.ts",
+            "default": "./lib/vertexai/embeddings/batch.js"
+        },
         "./groq": {
             "types": "./lib/groq/index.d.ts",
             "default": "./lib/groq/index.js"

--- a/drivers/package.json
+++ b/drivers/package.json
@@ -10,6 +10,10 @@
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
     "exports": {
+        "./embedding-batch": {
+            "types": "./lib/embedding-batch.d.ts",
+            "default": "./lib/embedding-batch.js"
+        },
         ".": {
             "types": "./lib/index.d.ts",
             "default": "./lib/index.js"

--- a/drivers/src/embedding-batch.test.ts
+++ b/drivers/src/embedding-batch.test.ts
@@ -1,0 +1,82 @@
+import type { Driver, EmbeddingBatchArtifactStore } from '@llumiverse/core';
+import { URLDataSource } from '@llumiverse/core';
+import { assert, describe, expect, it, vi } from 'vitest';
+import { getEmbeddingBatchAdapter } from './embedding-batch.js';
+
+describe('embedding batch adapter', () => {
+    it('rejects unsupported batch media locations before downloading or copying', async () => {
+        const adapter = getEmbeddingBatchAdapter('vertexai');
+        assert(adapter);
+        const source = new URLDataSource('image.jpg', 'image/jpeg', 'https://example.com/image.jpg');
+        const read = vi.spyOn(source, 'getStream');
+        await expect(
+            adapter.formatRow({
+                key: 'row',
+                model: 'gemini-embedding-2',
+                dimensions: 2,
+                inputFormat: 'gemini',
+                input: { type: 'image', source },
+            }),
+        ).rejects.toThrow('gs://');
+        expect(read).not.toHaveBeenCalled();
+    });
+    it('opts in explicitly and resolves model-specific location and limits', () => {
+        expect(getEmbeddingBatchAdapter('openai')).toBeUndefined();
+        const adapter = getEmbeddingBatchAdapter('vertexai');
+        assert(adapter);
+        expect(adapter.capability('gemini-embedding-2', 'image', 'us-central1')).toMatchObject({
+            inputFormat: 'gemini',
+            location: 'global',
+            maxRows: 1_000_000,
+        });
+        expect(adapter.capability('text-embedding-004', 'text', 'us-central1')).toMatchObject({
+            inputFormat: 'legacy',
+            location: 'us-central1',
+            maxRows: 30_000,
+        });
+        expect(adapter.capability('multimodalembedding@001', 'image')).toBeUndefined();
+    });
+
+    it.each(['gemini', 'legacy'])('owns input/output correlation for %s rows', async (inputFormat) => {
+        const adapter = getEmbeddingBatchAdapter('vertexai');
+        assert(adapter);
+        const { row, resultKey } = await adapter.formatRow({
+            key: 'source-key',
+            model: inputFormat === 'legacy' ? 'text-embedding-004' : 'gemini-embedding-2',
+            input: { type: 'text', text: 'hello' },
+            dimensions: 2,
+            inputFormat,
+        });
+        const record =
+            inputFormat === 'legacy'
+                ? { instance: row, predictions: [{ embeddings: { values: [1, 2] } }] }
+                : { key: row.key, response: { embedding: { values: [1, 2] } } };
+        expect(adapter.parseResult(record)).toMatchObject({ key: resultKey, vector: [1, 2], providerError: false });
+    });
+
+    it.each(['succeeded', 'failed', 'cancelled'] as const)('discovers all %s shards without copying', async (state) => {
+        const artifacts: EmbeddingBatchArtifactStore = {
+            list: vi
+                .fn()
+                .mockResolvedValue(['gs://bucket/output/a/predictions.jsonl', 'gs://bucket/output/b/errors.jsonl']),
+            read: vi.fn(),
+            write: vi.fn(),
+        };
+        const adapter = getEmbeddingBatchAdapter('vertexai');
+        assert(adapter);
+        await expect(
+            adapter.outputArtifacts(
+                {} as Driver,
+                {
+                    name: 'jobs/1',
+                    state,
+                    outputUri: 'gs://bucket/output/',
+                },
+                artifacts,
+            ),
+        ).resolves.toHaveLength(2);
+        expect(artifacts.list).toHaveBeenCalledWith('gs://bucket/output/');
+        expect(artifacts.read).not.toHaveBeenCalled();
+        expect(artifacts.write).not.toHaveBeenCalled();
+    });
+});

--- a/drivers/src/embedding-batch.ts
+++ b/drivers/src/embedding-batch.ts
@@ -1,0 +1,7 @@
+import type { EmbeddingBatchAdapter } from '@llumiverse/core';
+import { vertexEmbeddingBatchAdapter } from './vertexai/embeddings/batch-adapter.js';
+
+/** Providers opt in explicitly; unsupported providers keep their synchronous embedding path. */
+export function getEmbeddingBatchAdapter(provider: string): EmbeddingBatchAdapter | undefined {
+    return provider === 'vertexai' ? vertexEmbeddingBatchAdapter : undefined;
+}

--- a/drivers/src/vertexai/embeddings/batch-adapter.ts
+++ b/drivers/src/vertexai/embeddings/batch-adapter.ts
@@ -1,0 +1,48 @@
+import type { EmbeddingBatchAdapter } from '@llumiverse/core';
+import type { VertexAIDriver } from '../index.js';
+import {
+    cancelVertexEmbeddingBatch,
+    createVertexEmbeddingBatch,
+    deleteVertexEmbeddingBatch,
+    formatVertexEmbeddingBatchRow,
+    getVertexEmbeddingBatch,
+    getVertexEmbeddingBatchCapability,
+    parseVertexEmbeddingBatchResult,
+    vertexEmbeddingBatchCorrelationKey,
+} from './batch.js';
+
+export const vertexEmbeddingBatchAdapter: EmbeddingBatchAdapter = {
+    capability(model, modality, location) {
+        const profile = getVertexEmbeddingBatchCapability(model, modality);
+        return profile
+            ? {
+                  model: profile.model,
+                  inputFormat: profile.schema,
+                  maxRows: profile.maxRows,
+                  location: profile.location === 'global' ? 'global' : location,
+              }
+            : undefined;
+    },
+    async formatRow({ inputFormat, ...options }) {
+        if (inputFormat !== 'gemini' && inputFormat !== 'legacy') {
+            throw new Error(`Unsupported Vertex embedding batch input format ${inputFormat}`);
+        }
+        const row = await formatVertexEmbeddingBatchRow({ ...options, schema: inputFormat });
+        const resultKey = vertexEmbeddingBatchCorrelationKey(row);
+        if (!resultKey) throw new Error('Embedding batch input cannot be correlated with its result');
+        return { row, resultKey };
+    },
+    parseResult: parseVertexEmbeddingBatchResult,
+    create: (driver, options) => createVertexEmbeddingBatch(driver as VertexAIDriver, options),
+    get: (driver, options) =>
+        getVertexEmbeddingBatch(driver as VertexAIDriver, options.model, options.modality, options.name),
+    cancel: (driver, options) =>
+        cancelVertexEmbeddingBatch(driver as VertexAIDriver, options.model, options.modality, options.name),
+    delete: (driver, options) =>
+        deleteVertexEmbeddingBatch(driver as VertexAIDriver, options.model, options.modality, options.name),
+    async outputArtifacts(_driver, job, artifacts) {
+        if (!job.outputUri) throw new Error('Vertex embedding batch omitted its output prefix');
+        // Vertex writes shards directly to application storage; never copy the output or source media.
+        return artifacts.list(job.outputUri);
+    },
+};

--- a/drivers/src/vertexai/embeddings/batch-result.test.ts
+++ b/drivers/src/vertexai/embeddings/batch-result.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { parseVertexEmbeddingBatchResult } from './batch.js';
+
+describe('embedding batch result parsing', () => {
+    it('parses the alternate embeddings array and ignores non-string keys', () => {
+        expect(
+            parseVertexEmbeddingBatchResult({
+                key: 42,
+                response: { embeddings: [{ values: [1, 2] }] },
+            }),
+        ).toEqual({ key: undefined, vector: [1, 2], providerError: false });
+    });
+
+    it.each([JSON.stringify({ code: 7, message: 'private details' }), { code: 7 }])(
+        'recognizes Gemini status permission failures without exposing provider messages',
+        (status) => {
+            expect(parseVertexEmbeddingBatchResult({ key: 'row', status, response: {} })).toEqual({
+                key: 'row',
+                vector: undefined,
+                providerError: true,
+                failureCategory: 'provider_permission_denied',
+            });
+        },
+    );
+
+    it.each(['', { code: 0 }, JSON.stringify({ code: 0 })])('accepts successful status %j', (status) => {
+        expect(parseVertexEmbeddingBatchResult({ status }).providerError).toBe(false);
+    });
+
+    it('treats an unparseable status as a provider error', () => {
+        expect(parseVertexEmbeddingBatchResult({ status: 'unexpected failure' }).providerError).toBe(true);
+    });
+    it('parses Gemini output by top-level key', () => {
+        expect(parseVertexEmbeddingBatchResult({ key: 'gemini', response: { embedding: { values: [1, 2] } } })).toEqual(
+            {
+                key: 'gemini',
+                vector: [1, 2],
+                providerError: false,
+            },
+        );
+    });
+
+    it('parses legacy output by the echoed instance key', () => {
+        expect(
+            parseVertexEmbeddingBatchResult({
+                instance: { key: 'legacy', content: 'omitted' },
+                predictions: [{ embeddings: { values: [3, 4] } }],
+            }),
+        ).toEqual({ key: 'legacy', vector: [3, 4], providerError: false });
+    });
+
+    it('classifies provider row errors without retaining their message', () => {
+        expect(
+            parseVertexEmbeddingBatchResult({ key: 'failed', error: { message: 'sensitive provider detail' } }),
+        ).toEqual({
+            key: 'failed',
+            vector: undefined,
+            providerError: true,
+        });
+    });
+});

--- a/drivers/src/vertexai/embeddings/batch-result.test.ts
+++ b/drivers/src/vertexai/embeddings/batch-result.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { parseVertexEmbeddingBatchResult } from './batch.js';
+import {
+    formatVertexEmbeddingBatchRow,
+    parseVertexEmbeddingBatchResult,
+    vertexEmbeddingBatchCorrelationKey,
+} from './batch.js';
 
 describe('embedding batch result parsing', () => {
     it('parses the alternate embeddings array and ignores non-string keys', () => {
@@ -40,13 +44,50 @@ describe('embedding batch result parsing', () => {
         );
     });
 
-    it('parses legacy output by the echoed instance key', () => {
+    it('parses legacy output by echoed input fields, not discarded custom keys', () => {
         expect(
             parseVertexEmbeddingBatchResult({
                 instance: { key: 'legacy', content: 'omitted' },
                 predictions: [{ embeddings: { values: [3, 4] } }],
             }),
-        ).toEqual({ key: 'legacy', vector: [3, 4], providerError: false });
+        ).toEqual({
+            key: vertexEmbeddingBatchCorrelationKey({ content: 'omitted' }),
+            vector: [3, 4],
+            providerError: false,
+        });
+    });
+
+    it('correlates actual legacy output independently of field order and preserves all input semantics', async () => {
+        const row = await formatVertexEmbeddingBatchRow({
+            key: 'object-snapshot',
+            model: 'text-embedding-004',
+            dimensions: 256,
+            input: { type: 'text', text: 'Café\nsecond line 🐈' },
+        });
+        const key = vertexEmbeddingBatchCorrelationKey(row);
+        expect(key).toMatch(/^input:[a-f0-9]{64}$/);
+        expect(
+            parseVertexEmbeddingBatchResult({
+                instance: { content: 'Café\nsecond line 🐈' },
+                status: '',
+                predictions: [{ embeddings: { values: [1, 2] } }],
+            }),
+        ).toEqual({ key, providerError: false, vector: [1, 2] });
+        expect(vertexEmbeddingBatchCorrelationKey({ key: 'another-object', content: 'Café\nsecond line 🐈' })).toBe(
+            key,
+        );
+        for (const changed of [
+            { content: 'different' },
+            { content: 'Café\nsecond line 🐈', task_type: 'RETRIEVAL_QUERY' },
+            { content: 'Café\nsecond line 🐈', title: 'title' },
+        ]) {
+            expect(vertexEmbeddingBatchCorrelationKey(changed)).not.toBe(key);
+        }
+        expect(vertexEmbeddingBatchCorrelationKey({ content: 'x', task_type: 42 })).toBeUndefined();
+        expect(vertexEmbeddingBatchCorrelationKey({ content: 42 })).toBeUndefined();
+        expect(
+            parseVertexEmbeddingBatchResult({ instance: { content: 'Café\nsecond line 🐈' }, status: 'row failed' }),
+        ).toMatchObject({ key, providerError: true });
     });
 
     it('classifies provider row errors without retaining their message', () => {

--- a/drivers/src/vertexai/embeddings/batch.test.ts
+++ b/drivers/src/vertexai/embeddings/batch.test.ts
@@ -105,11 +105,13 @@ describe('Vertex embedding batch rows', () => {
             }),
         ).resolves.toEqual({
             key: 'text:1:etag',
-            request: { content: { parts: [{ text: 'hello' }] } },
-            embed_content_config: {
-                output_dimensionality: 768,
-                task_type: 'RETRIEVAL_DOCUMENT',
-                title: 'Greeting',
+            request: {
+                content: { parts: [{ text: 'hello' }] },
+                embed_content_config: {
+                    output_dimensionality: 768,
+                    task_type: 'RETRIEVAL_DOCUMENT',
+                    title: 'Greeting',
+                },
             },
         });
     });
@@ -124,8 +126,10 @@ describe('Vertex embedding batch rows', () => {
         });
         expect(row).toEqual({
             key: 'text:1:etag',
-            request: { content: { parts: [{ text: 'title: none | text: hello' }] } },
-            embed_content_config: { output_dimensionality: 1024 },
+            request: {
+                content: { parts: [{ text: 'title: none | text: hello' }] },
+                embed_content_config: { output_dimensionality: 1024 },
+            },
         });
         expect(vertexBatchTextForParity(input, 'gemini-embedding-2')).toBe('title: none | text: hello');
     });
@@ -151,8 +155,8 @@ describe('Vertex embedding batch rows', () => {
                         },
                     ],
                 },
+                embed_content_config: { output_dimensionality: 768 },
             },
-            embed_content_config: { output_dimensionality: 768 },
         });
     });
 

--- a/drivers/src/vertexai/embeddings/batch.test.ts
+++ b/drivers/src/vertexai/embeddings/batch.test.ts
@@ -1,0 +1,173 @@
+import { URLDataSource } from '@llumiverse/core';
+import { describe, expect, it, vi } from 'vitest';
+import type { VertexAIDriver } from '../index.js';
+import {
+    cancelVertexEmbeddingBatch,
+    createVertexEmbeddingBatch,
+    deleteVertexEmbeddingBatch,
+    formatVertexEmbeddingBatchRow,
+    getVertexEmbeddingBatchCapability,
+    normalizeVertexEmbeddingModelId,
+    vertexBatchTextForParity,
+} from './batch.js';
+
+describe('Vertex embedding batch capabilities', () => {
+    it('uses an explicit model and modality matrix', () => {
+        expect(getVertexEmbeddingBatchCapability('gemini-embedding-2', 'image')).toMatchObject({
+            schema: 'gemini',
+            maxRows: 1_000_000,
+            location: 'global',
+        });
+        expect(getVertexEmbeddingBatchCapability('gemini-embedding-001', 'image')).toBeUndefined();
+        expect(getVertexEmbeddingBatchCapability('text-embedding-005', 'text')).toMatchObject({
+            schema: 'legacy',
+            maxRows: 30_000,
+        });
+        expect(getVertexEmbeddingBatchCapability('multimodalembedding@001', 'image')).toBeUndefined();
+        expect(getVertexEmbeddingBatchCapability('future-gemini-embedding-2', 'text')).toBeUndefined();
+    });
+
+    it('normalizes a Vertex resource name without fuzzy matching', () => {
+        expect(normalizeVertexEmbeddingModelId('publishers/google/models/gemini-embedding-2')).toBe(
+            'gemini-embedding-2',
+        );
+    });
+});
+
+describe('Vertex embedding batch lifecycle', () => {
+    it('adopts an exact matching deterministic display name before creating', async () => {
+        const create = vi.fn();
+        const existing = {
+            name: 'projects/p/locations/global/batchPredictionJobs/1',
+            displayName: 'stable-name',
+            state: 'JOB_STATE_RUNNING',
+            model: 'gemini-embedding-2',
+            src: { gcsUri: ['gs://bucket/input.jsonl'] },
+            dest: { gcsUri: 'gs://bucket/output/' },
+        };
+        const client = {
+            batches: {
+                list: vi.fn().mockResolvedValue({
+                    async *[Symbol.asyncIterator]() {
+                        yield existing;
+                    },
+                }),
+                create,
+            },
+        };
+        const driver = { getGoogleGenAIClient: vi.fn(() => client) } as unknown as VertexAIDriver;
+        await expect(
+            createVertexEmbeddingBatch(driver, {
+                model: 'gemini-embedding-2',
+                modality: 'text',
+                displayName: 'stable-name',
+                inputUri: 'gs://bucket/input.jsonl',
+                outputUri: 'gs://bucket/output/',
+            }),
+        ).resolves.toMatchObject({ name: existing.name, state: 'running' });
+        expect(create).not.toHaveBeenCalled();
+    });
+
+    it('creates, cancels, polls and deletes through the generic batches API', async () => {
+        const job = { name: 'jobs/1', state: 'JOB_STATE_PENDING', model: 'gemini-embedding-001' };
+        const batches = {
+            list: vi.fn().mockResolvedValue({ async *[Symbol.asyncIterator]() {} }),
+            create: vi.fn().mockResolvedValue(job),
+            get: vi.fn().mockResolvedValue(job),
+            cancel: vi.fn().mockResolvedValue(undefined),
+            delete: vi.fn().mockResolvedValue(undefined),
+        };
+        const driver = { getGoogleGenAIClient: vi.fn(() => ({ batches })) } as unknown as VertexAIDriver;
+        await createVertexEmbeddingBatch(driver, {
+            model: 'gemini-embedding-001',
+            modality: 'text',
+            displayName: 'stable-name',
+            inputUri: 'gs://bucket/input.jsonl',
+            outputUri: 'gs://bucket/output/',
+        });
+        await cancelVertexEmbeddingBatch(driver, 'gemini-embedding-001', 'text', 'jobs/1');
+        await deleteVertexEmbeddingBatch(driver, 'gemini-embedding-001', 'text', 'jobs/1');
+        expect(batches.create).toHaveBeenCalledWith(expect.objectContaining({ model: 'gemini-embedding-001' }));
+        expect(batches.cancel).toHaveBeenCalledWith({ name: 'jobs/1' });
+        expect(batches.get).toHaveBeenCalledWith({ name: 'jobs/1' });
+        expect(batches.delete).toHaveBeenCalledWith({ name: 'jobs/1' });
+    });
+});
+
+describe('Vertex embedding batch rows', () => {
+    it('formats Gemini 001 text with API task configuration', async () => {
+        await expect(
+            formatVertexEmbeddingBatchRow({
+                key: 'text:1:etag',
+                model: 'gemini-embedding-001',
+                dimensions: 768,
+                input: { type: 'text', text: 'hello', task_type: 'document', title: 'Greeting' },
+            }),
+        ).resolves.toEqual({
+            key: 'text:1:etag',
+            request: { content: { parts: [{ text: 'hello' }] } },
+            embed_content_config: {
+                output_dimensionality: 768,
+                task_type: 'RETRIEVAL_DOCUMENT',
+                title: 'Greeting',
+            },
+        });
+    });
+
+    it('formats Gemini 2 text with the same prompt prefix as synchronous embedding', async () => {
+        const input = { type: 'text', text: 'hello', task_type: 'document' } as const;
+        const row = await formatVertexEmbeddingBatchRow({
+            key: 'text:1:etag',
+            model: 'gemini-embedding-2',
+            dimensions: 1024,
+            input,
+        });
+        expect(row).toEqual({
+            key: 'text:1:etag',
+            request: { content: { parts: [{ text: 'title: none | text: hello' }] } },
+            embed_content_config: { output_dimensionality: 1024 },
+        });
+        expect(vertexBatchTextForParity(input, 'gemini-embedding-2')).toBe('title: none | text: hello');
+    });
+
+    it('formats Gemini 2 images as GCS file data', async () => {
+        await expect(
+            formatVertexEmbeddingBatchRow({
+                key: 'image:1:etag',
+                model: 'gemini-embedding-2',
+                dimensions: 768,
+                input: {
+                    type: 'image',
+                    source: new URLDataSource('rendition.jpg', 'image/jpeg', 'gs://bucket/rendition.jpg'),
+                },
+            }),
+        ).resolves.toEqual({
+            key: 'image:1:etag',
+            request: {
+                content: {
+                    parts: [
+                        {
+                            fileData: { fileUri: 'gs://bucket/rendition.jpg', mimeType: 'image/jpeg' },
+                        },
+                    ],
+                },
+            },
+            embed_content_config: { output_dimensionality: 768 },
+        });
+    });
+
+    it('formats stable legacy text rows', async () => {
+        await expect(
+            formatVertexEmbeddingBatchRow({
+                key: 'properties:1:etag',
+                model: 'text-embedding-005',
+                dimensions: 768,
+                input: { type: 'text', text: '{"name":"Ada"}' },
+            }),
+        ).resolves.toEqual({
+            key: 'properties:1:etag',
+            content: '{"name":"Ada"}',
+            outputDimensionality: 768,
+        });
+    });
+});

--- a/drivers/src/vertexai/embeddings/batch.test.ts
+++ b/drivers/src/vertexai/embeddings/batch.test.ts
@@ -6,6 +6,7 @@ import {
     createVertexEmbeddingBatch,
     deleteVertexEmbeddingBatch,
     formatVertexEmbeddingBatchRow,
+    getVertexEmbeddingBatch,
     getVertexEmbeddingBatchCapability,
     normalizeVertexEmbeddingModelId,
     vertexBatchTextForParity,
@@ -17,6 +18,8 @@ describe('Vertex embedding batch capabilities', () => {
             schema: 'gemini',
             maxRows: 1_000_000,
             location: 'global',
+            taskEncoding: 'prefix',
+            maxSynchronousInputs: 1,
         });
         expect(getVertexEmbeddingBatchCapability('gemini-embedding-001', 'image')).toBeUndefined();
         expect(getVertexEmbeddingBatchCapability('text-embedding-005', 'text')).toMatchObject({
@@ -91,6 +94,21 @@ describe('Vertex embedding batch lifecycle', () => {
         expect(batches.cancel).toHaveBeenCalledWith({ name: 'jobs/1' });
         expect(batches.get).toHaveBeenCalledWith({ name: 'jobs/1' });
         expect(batches.delete).toHaveBeenCalledWith({ name: 'jobs/1' });
+    });
+
+    it('rejects a provider job that belongs to a different model', async () => {
+        const batches = {
+            get: vi.fn().mockResolvedValue({
+                name: 'jobs/1',
+                state: 'JOB_STATE_RUNNING',
+                model: 'publishers/google/models/text-embedding-005',
+            }),
+        };
+        const driver = { getGoogleGenAIClient: vi.fn(() => ({ batches })) } as unknown as VertexAIDriver;
+
+        await expect(getVertexEmbeddingBatch(driver, 'gemini-embedding-001', 'text', 'jobs/1')).rejects.toThrow(
+            'belongs to model',
+        );
     });
 });
 
@@ -173,5 +191,17 @@ describe('Vertex embedding batch rows', () => {
             content: '{"name":"Ada"}',
             outputDimensionality: 768,
         });
+    });
+
+    it('rejects a row format that does not match the snapshotted model profile', async () => {
+        await expect(
+            formatVertexEmbeddingBatchRow({
+                key: 'text:1:etag',
+                model: 'gemini-embedding-001',
+                dimensions: 768,
+                schema: 'legacy',
+                input: { type: 'text', text: 'hello' },
+            }),
+        ).rejects.toThrow('uses gemini batch rows');
     });
 });

--- a/drivers/src/vertexai/embeddings/batch.test.ts
+++ b/drivers/src/vertexai/embeddings/batch.test.ts
@@ -91,9 +91,80 @@ describe('Vertex embedding batch lifecycle', () => {
         await cancelVertexEmbeddingBatch(driver, 'gemini-embedding-001', 'text', 'jobs/1');
         await deleteVertexEmbeddingBatch(driver, 'gemini-embedding-001', 'text', 'jobs/1');
         expect(batches.create).toHaveBeenCalledWith(expect.objectContaining({ model: 'gemini-embedding-001' }));
-        expect(batches.cancel).toHaveBeenCalledWith({ name: 'jobs/1' });
-        expect(batches.get).toHaveBeenCalledWith({ name: 'jobs/1' });
-        expect(batches.delete).toHaveBeenCalledWith({ name: 'jobs/1' });
+        const request = { name: 'jobs/1', config: { httpOptions: { apiVersion: 'v1' } } };
+        expect(batches.cancel).toHaveBeenCalledWith(request);
+        expect(batches.get).toHaveBeenCalledWith(request);
+        expect(batches.delete).toHaveBeenCalledWith(request);
+        expect(batches.list).toHaveBeenCalledWith({
+            config: { filter: 'displayName="stable-name"', pageSize: 10, httpOptions: { apiVersion: 'v1' } },
+        });
+    });
+
+    it('treats partial provider success as terminal so successful rows can be applied', async () => {
+        const get = vi.fn().mockResolvedValue({
+            name: 'jobs/1',
+            state: 'JOB_STATE_PARTIALLY_SUCCEEDED',
+            model: 'gemini-embedding-2',
+        });
+        const driver = { getGoogleGenAIClient: vi.fn(() => ({ batches: { get } })) } as unknown as VertexAIDriver;
+        await expect(getVertexEmbeddingBatch(driver, 'gemini-embedding-2', 'image', 'jobs/1')).resolves.toMatchObject({
+            state: 'failed',
+        });
+    });
+
+    it('passes legacy dimensions as job model parameters through the SDK request body', async () => {
+        const create = vi.fn().mockResolvedValue({ name: 'jobs/1', model: 'text-embedding-005' });
+        const batches = {
+            create,
+            list: vi.fn().mockResolvedValue({ async *[Symbol.asyncIterator]() {} }),
+        };
+        const driver = { getGoogleGenAIClient: vi.fn(() => ({ batches })) } as unknown as VertexAIDriver;
+        await createVertexEmbeddingBatch(driver, {
+            model: 'text-embedding-005',
+            modality: 'text',
+            dimensions: 256,
+            displayName: 'stable-name',
+            inputUri: 'gs://bucket/input.jsonl',
+            outputUri: 'gs://bucket/output/',
+        });
+        expect(create).toHaveBeenCalledWith({
+            model: 'text-embedding-005',
+            src: { gcsUri: ['gs://bucket/input.jsonl'], format: 'jsonl' },
+            config: {
+                displayName: 'stable-name',
+                dest: { gcsUri: 'gs://bucket/output/', format: 'jsonl' },
+                httpOptions: { apiVersion: 'v1', extraBody: { modelParameters: { outputDimensionality: 256 } } },
+            },
+        });
+    });
+
+    it('does not adopt a listed job with a different display name', async () => {
+        const create = vi.fn().mockResolvedValue({ name: 'jobs/new', model: 'gemini-embedding-2' });
+        const batches = {
+            create,
+            list: vi.fn().mockResolvedValue({
+                async *[Symbol.asyncIterator]() {
+                    yield {
+                        name: 'jobs/old',
+                        displayName: 'other-name',
+                        model: 'gemini-embedding-2',
+                        src: { gcsUri: ['gs://bucket/input.jsonl'] },
+                        dest: { gcsUri: 'gs://bucket/output/' },
+                    };
+                },
+            }),
+        };
+        const driver = { getGoogleGenAIClient: vi.fn(() => ({ batches })) } as unknown as VertexAIDriver;
+        await expect(
+            createVertexEmbeddingBatch(driver, {
+                model: 'gemini-embedding-2',
+                modality: 'text',
+                displayName: 'stable-name',
+                inputUri: 'gs://bucket/input.jsonl',
+                outputUri: 'gs://bucket/output/',
+            }),
+        ).resolves.toMatchObject({ name: 'jobs/new' });
+        expect(create).toHaveBeenCalledOnce();
     });
 
     it('rejects a provider job that belongs to a different model', async () => {
@@ -189,7 +260,6 @@ describe('Vertex embedding batch rows', () => {
         ).resolves.toEqual({
             key: 'properties:1:etag',
             content: '{"name":"Ada"}',
-            outputDimensionality: 768,
         });
     });
 

--- a/drivers/src/vertexai/embeddings/batch.test.ts
+++ b/drivers/src/vertexai/embeddings/batch.test.ts
@@ -112,31 +112,34 @@ describe('Vertex embedding batch lifecycle', () => {
         });
     });
 
-    it('passes legacy dimensions as job model parameters through the SDK request body', async () => {
-        const create = vi.fn().mockResolvedValue({ name: 'jobs/1', model: 'text-embedding-005' });
-        const batches = {
-            create,
-            list: vi.fn().mockResolvedValue({ async *[Symbol.asyncIterator]() {} }),
-        };
-        const driver = { getGoogleGenAIClient: vi.fn(() => ({ batches })) } as unknown as VertexAIDriver;
-        await createVertexEmbeddingBatch(driver, {
-            model: 'text-embedding-005',
-            modality: 'text',
-            dimensions: 256,
-            displayName: 'stable-name',
-            inputUri: 'gs://bucket/input.jsonl',
-            outputUri: 'gs://bucket/output/',
-        });
-        expect(create).toHaveBeenCalledWith({
-            model: 'text-embedding-005',
-            src: { gcsUri: ['gs://bucket/input.jsonl'], format: 'jsonl' },
-            config: {
+    it.each(['text-embedding-004', 'text-embedding-005'])(
+        'passes %s dimensions as integer strings for the legacy batch backend',
+        async (model) => {
+            const create = vi.fn().mockResolvedValue({ name: 'jobs/1', model });
+            const batches = {
+                create,
+                list: vi.fn().mockResolvedValue({ async *[Symbol.asyncIterator]() {} }),
+            };
+            const driver = { getGoogleGenAIClient: vi.fn(() => ({ batches })) } as unknown as VertexAIDriver;
+            await createVertexEmbeddingBatch(driver, {
+                model,
+                modality: 'text',
+                dimensions: 256,
                 displayName: 'stable-name',
-                dest: { gcsUri: 'gs://bucket/output/', format: 'jsonl' },
-                httpOptions: { apiVersion: 'v1', extraBody: { modelParameters: { outputDimensionality: 256 } } },
-            },
-        });
-    });
+                inputUri: 'gs://bucket/input.jsonl',
+                outputUri: 'gs://bucket/output/',
+            });
+            expect(create).toHaveBeenCalledWith({
+                model,
+                src: { gcsUri: ['gs://bucket/input.jsonl'], format: 'jsonl' },
+                config: {
+                    displayName: 'stable-name',
+                    dest: { gcsUri: 'gs://bucket/output/', format: 'jsonl' },
+                    httpOptions: { apiVersion: 'v1', extraBody: { modelParameters: { outputDimensionality: '256' } } },
+                },
+            });
+        },
+    );
 
     it('does not adopt a listed job with a different display name', async () => {
         const create = vi.fn().mockResolvedValue({ name: 'jobs/new', model: 'gemini-embedding-2' });

--- a/drivers/src/vertexai/embeddings/batch.test.ts
+++ b/drivers/src/vertexai/embeddings/batch.test.ts
@@ -9,8 +9,8 @@ import {
     getVertexEmbeddingBatch,
     getVertexEmbeddingBatchCapability,
     normalizeVertexEmbeddingModelId,
-    vertexBatchTextForParity,
 } from './batch.js';
+import { buildVertexEmbeddingText } from './format.js';
 
 describe('Vertex embedding batch capabilities', () => {
     it('uses an explicit model and modality matrix', () => {
@@ -223,7 +223,7 @@ describe('Vertex embedding batch rows', () => {
                 embed_content_config: { output_dimensionality: 1024 },
             },
         });
-        expect(vertexBatchTextForParity(input, 'gemini-embedding-2')).toBe('title: none | text: hello');
+        expect(buildVertexEmbeddingText(input, true)).toBe('title: none | text: hello');
     });
 
     it('formats Gemini 2 images as GCS file data', async () => {

--- a/drivers/src/vertexai/embeddings/batch.ts
+++ b/drivers/src/vertexai/embeddings/batch.ts
@@ -78,11 +78,13 @@ export interface FormatVertexEmbeddingBatchRowOptions {
 
 type GeminiEmbeddingBatchRow = {
     key: string;
-    request: { content: { parts: NonNullable<Awaited<ReturnType<typeof vertexEmbeddingInputToContent>>['parts']> } };
-    embed_content_config: {
-        output_dimensionality: number;
-        task_type?: string;
-        title?: string;
+    request: {
+        content: { parts: NonNullable<Awaited<ReturnType<typeof vertexEmbeddingInputToContent>>['parts']> };
+        embed_content_config: {
+            output_dimensionality: number;
+            task_type?: string;
+            title?: string;
+        };
     };
 };
 
@@ -119,7 +121,7 @@ export async function formatVertexEmbeddingBatchRow(
 
     const viaPrefix = capability.model === 'gemini-embedding-2';
     const content = await vertexEmbeddingInputToContent(options.input, viaPrefix);
-    const config: GeminiEmbeddingBatchRow['embed_content_config'] = {
+    const config: GeminiEmbeddingBatchRow['request']['embed_content_config'] = {
         output_dimensionality: options.dimensions,
     };
     if (options.input.type === 'text' && !viaPrefix) {
@@ -129,8 +131,7 @@ export async function formatVertexEmbeddingBatchRow(
     }
     return {
         key: options.key,
-        request: { content: { parts: content.parts ?? [] } },
-        embed_content_config: config,
+        request: { content: { parts: content.parts ?? [] }, embed_content_config: config },
     };
 }
 

--- a/drivers/src/vertexai/embeddings/batch.ts
+++ b/drivers/src/vertexai/embeddings/batch.ts
@@ -1,0 +1,279 @@
+import type { BatchJob, JobState } from '@google/genai';
+import type { EmbeddingInput, EmbeddingTaskType, TextEmbeddingInput } from '@llumiverse/core';
+import type { VertexAIDriver } from '../index.js';
+import { buildVertexEmbeddingText, toGoogleTaskType, vertexEmbeddingInputToContent } from './format.js';
+
+export type VertexEmbeddingBatchSchema = 'gemini' | 'legacy';
+export type VertexEmbeddingBatchModality = 'text' | 'image';
+
+export interface VertexEmbeddingBatchCapability {
+    model: string;
+    schema: VertexEmbeddingBatchSchema;
+    modalities: readonly VertexEmbeddingBatchModality[];
+    maxRows: number;
+    location: 'environment' | 'global';
+}
+
+const CAPABILITIES = new Map<string, VertexEmbeddingBatchCapability>([
+    [
+        'gemini-embedding-2',
+        {
+            model: 'gemini-embedding-2',
+            schema: 'gemini',
+            modalities: ['text', 'image'],
+            maxRows: 1_000_000,
+            location: 'global',
+        },
+    ],
+    [
+        'gemini-embedding-001',
+        {
+            model: 'gemini-embedding-001',
+            schema: 'gemini',
+            modalities: ['text'],
+            maxRows: 1_000_000,
+            location: 'environment',
+        },
+    ],
+    [
+        'text-embedding-004',
+        {
+            model: 'text-embedding-004',
+            schema: 'legacy',
+            modalities: ['text'],
+            maxRows: 30_000,
+            location: 'environment',
+        },
+    ],
+    [
+        'text-embedding-005',
+        {
+            model: 'text-embedding-005',
+            schema: 'legacy',
+            modalities: ['text'],
+            maxRows: 30_000,
+            location: 'environment',
+        },
+    ],
+]);
+
+export function normalizeVertexEmbeddingModelId(model: string): string {
+    return model.split('/').at(-1) ?? model;
+}
+
+export function getVertexEmbeddingBatchCapability(
+    model: string,
+    modality: VertexEmbeddingBatchModality,
+): VertexEmbeddingBatchCapability | undefined {
+    const capability = CAPABILITIES.get(normalizeVertexEmbeddingModelId(model));
+    return capability?.modalities.includes(modality) ? capability : undefined;
+}
+
+export interface FormatVertexEmbeddingBatchRowOptions {
+    key: string;
+    model: string;
+    input: EmbeddingInput;
+    dimensions: number;
+}
+
+type GeminiEmbeddingBatchRow = {
+    key: string;
+    request: { content: { parts: NonNullable<Awaited<ReturnType<typeof vertexEmbeddingInputToContent>>['parts']> } };
+    embed_content_config: {
+        output_dimensionality: number;
+        task_type?: string;
+        title?: string;
+    };
+};
+
+type LegacyEmbeddingBatchRow = {
+    key: string;
+    content: string;
+    outputDimensionality: number;
+    task_type?: string;
+    title?: string;
+};
+
+export async function formatVertexEmbeddingBatchRow(
+    options: FormatVertexEmbeddingBatchRowOptions,
+): Promise<GeminiEmbeddingBatchRow | LegacyEmbeddingBatchRow> {
+    const modality: VertexEmbeddingBatchModality = options.input.type === 'text' ? 'text' : 'image';
+    const capability = getVertexEmbeddingBatchCapability(options.model, modality);
+    if (!capability) {
+        throw new Error(`Vertex embedding model ${options.model} does not support batch ${modality} inputs`);
+    }
+
+    if (capability.schema === 'legacy') {
+        if (options.input.type !== 'text') {
+            throw new Error(`Legacy Vertex embedding batches do not support ${options.input.type} inputs`);
+        }
+        const taskType = toGoogleTaskType(options.input.task_type);
+        return {
+            key: options.key,
+            content: options.input.text,
+            outputDimensionality: options.dimensions,
+            ...(taskType ? { task_type: taskType } : {}),
+            ...(options.input.title ? { title: options.input.title } : {}),
+        };
+    }
+
+    const viaPrefix = capability.model === 'gemini-embedding-2';
+    const content = await vertexEmbeddingInputToContent(options.input, viaPrefix);
+    const config: GeminiEmbeddingBatchRow['embed_content_config'] = {
+        output_dimensionality: options.dimensions,
+    };
+    if (options.input.type === 'text' && !viaPrefix) {
+        const taskType = toGoogleTaskType(options.input.task_type);
+        if (taskType) config.task_type = taskType;
+        if (options.input.title) config.title = options.input.title;
+    }
+    return {
+        key: options.key,
+        request: { content: { parts: content.parts ?? [] } },
+        embed_content_config: config,
+    };
+}
+
+export interface CreateVertexEmbeddingBatchOptions {
+    model: string;
+    modality: VertexEmbeddingBatchModality;
+    inputUri: string;
+    outputUri: string;
+    displayName: string;
+}
+
+export type VertexEmbeddingBatchState = 'pending' | 'running' | 'succeeded' | 'failed' | 'cancelled' | 'paused';
+
+export interface VertexEmbeddingBatchJob {
+    name: string;
+    displayName?: string;
+    state: VertexEmbeddingBatchState;
+    model?: string;
+    inputUri?: string;
+    outputUri?: string;
+    error?: string;
+}
+
+function normalizedJobState(state: JobState | undefined): VertexEmbeddingBatchState {
+    switch (state as string | undefined) {
+        case 'JOB_STATE_SUCCEEDED':
+            return 'succeeded';
+        case 'JOB_STATE_FAILED':
+        case 'JOB_STATE_EXPIRED':
+            return 'failed';
+        case 'JOB_STATE_CANCELLED':
+            return 'cancelled';
+        case 'JOB_STATE_PAUSED':
+            return 'paused';
+        case 'JOB_STATE_RUNNING':
+        case 'JOB_STATE_UPDATING':
+        case 'JOB_STATE_CANCELLING':
+            return 'running';
+        default:
+            return 'pending';
+    }
+}
+
+function firstGcsUri(value: unknown): string | undefined {
+    if (typeof value === 'string') return value;
+    if (Array.isArray(value)) return value.find((item): item is string => typeof item === 'string');
+    if (value && typeof value === 'object' && 'gcsUri' in value) {
+        return firstGcsUri((value as { gcsUri?: unknown }).gcsUri);
+    }
+    return undefined;
+}
+
+function toBatchJob(job: BatchJob): VertexEmbeddingBatchJob {
+    if (!job.name) throw new Error('Vertex AI batch job response did not contain a resource name');
+    return {
+        name: job.name,
+        displayName: job.displayName,
+        state: normalizedJobState(job.state),
+        model: job.model,
+        inputUri: firstGcsUri(job.src),
+        outputUri: firstGcsUri(job.dest),
+        error: job.error?.message,
+    };
+}
+
+function batchClient(driver: VertexAIDriver, capability: VertexEmbeddingBatchCapability) {
+    return driver.getGoogleGenAIClient(capability.location === 'global' ? 'global' : undefined);
+}
+
+export async function createVertexEmbeddingBatch(
+    driver: VertexAIDriver,
+    options: CreateVertexEmbeddingBatchOptions,
+): Promise<VertexEmbeddingBatchJob> {
+    const capability = getVertexEmbeddingBatchCapability(options.model, options.modality);
+    if (!capability) throw new Error(`Vertex embedding model ${options.model} is not batch capable`);
+    const client = batchClient(driver, capability);
+
+    const existing = await client.batches.list({
+        config: { filter: `displayName="${options.displayName}"`, pageSize: 10 },
+    });
+    for await (const candidate of existing) {
+        const job = toBatchJob(candidate);
+        if (
+            normalizeVertexEmbeddingModelId(job.model ?? '') === normalizeVertexEmbeddingModelId(options.model) &&
+            job.inputUri === options.inputUri &&
+            job.outputUri === options.outputUri
+        ) {
+            return job;
+        }
+    }
+
+    const created = await client.batches.create({
+        model: options.model,
+        src: { gcsUri: [options.inputUri], format: 'jsonl' },
+        config: {
+            displayName: options.displayName,
+            dest: { gcsUri: options.outputUri, format: 'jsonl' },
+            httpOptions: { apiVersion: 'v1' },
+        },
+    });
+    return toBatchJob(created);
+}
+
+export async function getVertexEmbeddingBatch(
+    driver: VertexAIDriver,
+    model: string,
+    modality: VertexEmbeddingBatchModality,
+    name: string,
+): Promise<VertexEmbeddingBatchJob> {
+    const capability = getVertexEmbeddingBatchCapability(model, modality);
+    if (!capability) throw new Error(`Vertex embedding model ${model} is not batch capable`);
+    return toBatchJob(await batchClient(driver, capability).batches.get({ name }));
+}
+
+export async function cancelVertexEmbeddingBatch(
+    driver: VertexAIDriver,
+    model: string,
+    modality: VertexEmbeddingBatchModality,
+    name: string,
+): Promise<VertexEmbeddingBatchJob> {
+    const capability = getVertexEmbeddingBatchCapability(model, modality);
+    if (!capability) throw new Error(`Vertex embedding model ${model} is not batch capable`);
+    await batchClient(driver, capability).batches.cancel({ name });
+    return getVertexEmbeddingBatch(driver, model, modality, name);
+}
+
+export async function deleteVertexEmbeddingBatch(
+    driver: VertexAIDriver,
+    model: string,
+    modality: VertexEmbeddingBatchModality,
+    name: string,
+): Promise<VertexEmbeddingBatchJob> {
+    const capability = getVertexEmbeddingBatchCapability(model, modality);
+    if (!capability) throw new Error(`Vertex embedding model ${model} is not batch capable`);
+    await batchClient(driver, capability).batches.delete({ name });
+    return { name, state: 'cancelled' };
+}
+
+export function vertexBatchTextForParity(input: TextEmbeddingInput, model: string): string {
+    const capability = getVertexEmbeddingBatchCapability(model, 'text');
+    return buildVertexEmbeddingText(input, capability?.model === 'gemini-embedding-2');
+}
+
+export function vertexBatchTaskTypeForParity(taskType: EmbeddingTaskType | undefined): string | undefined {
+    return toGoogleTaskType(taskType);
+}

--- a/drivers/src/vertexai/embeddings/batch.ts
+++ b/drivers/src/vertexai/embeddings/batch.ts
@@ -12,6 +12,8 @@ export interface VertexEmbeddingBatchCapability {
     modalities: readonly VertexEmbeddingBatchModality[];
     maxRows: number;
     location: 'environment' | 'global';
+    taskEncoding: 'config' | 'prefix';
+    maxSynchronousInputs?: number;
 }
 
 const CAPABILITIES = new Map<string, VertexEmbeddingBatchCapability>([
@@ -23,6 +25,8 @@ const CAPABILITIES = new Map<string, VertexEmbeddingBatchCapability>([
             modalities: ['text', 'image'],
             maxRows: 1_000_000,
             location: 'global',
+            taskEncoding: 'prefix',
+            maxSynchronousInputs: 1,
         },
     ],
     [
@@ -33,6 +37,8 @@ const CAPABILITIES = new Map<string, VertexEmbeddingBatchCapability>([
             modalities: ['text'],
             maxRows: 1_000_000,
             location: 'environment',
+            taskEncoding: 'config',
+            maxSynchronousInputs: 1,
         },
     ],
     [
@@ -43,6 +49,7 @@ const CAPABILITIES = new Map<string, VertexEmbeddingBatchCapability>([
             modalities: ['text'],
             maxRows: 30_000,
             location: 'environment',
+            taskEncoding: 'config',
         },
     ],
     [
@@ -53,6 +60,7 @@ const CAPABILITIES = new Map<string, VertexEmbeddingBatchCapability>([
             modalities: ['text'],
             maxRows: 30_000,
             location: 'environment',
+            taskEncoding: 'config',
         },
     ],
 ]);
@@ -74,6 +82,7 @@ export interface FormatVertexEmbeddingBatchRowOptions {
     model: string;
     input: EmbeddingInput;
     dimensions: number;
+    schema?: VertexEmbeddingBatchSchema;
 }
 
 type GeminiEmbeddingBatchRow = {
@@ -104,6 +113,11 @@ export async function formatVertexEmbeddingBatchRow(
     if (!capability) {
         throw new Error(`Vertex embedding model ${options.model} does not support batch ${modality} inputs`);
     }
+    if (options.schema && options.schema !== capability.schema) {
+        throw new Error(
+            `Vertex embedding model ${options.model} uses ${capability.schema} batch rows, not ${options.schema}`,
+        );
+    }
 
     if (capability.schema === 'legacy') {
         if (options.input.type !== 'text') {
@@ -119,7 +133,7 @@ export async function formatVertexEmbeddingBatchRow(
         };
     }
 
-    const viaPrefix = capability.model === 'gemini-embedding-2';
+    const viaPrefix = capability.taskEncoding === 'prefix';
     const content = await vertexEmbeddingInputToContent(options.input, viaPrefix);
     const config: GeminiEmbeddingBatchRow['request']['embed_content_config'] = {
         output_dimensionality: options.dimensions,
@@ -197,6 +211,13 @@ function toBatchJob(job: BatchJob): VertexEmbeddingBatchJob {
     };
 }
 
+function assertExpectedModel(job: VertexEmbeddingBatchJob, expectedModel: string): VertexEmbeddingBatchJob {
+    if (job.model && normalizeVertexEmbeddingModelId(job.model) !== normalizeVertexEmbeddingModelId(expectedModel)) {
+        throw new Error(`Vertex AI batch job ${job.name} belongs to model ${job.model}, not ${expectedModel}`);
+    }
+    return job;
+}
+
 function batchClient(driver: VertexAIDriver, capability: VertexEmbeddingBatchCapability) {
     return driver.getGoogleGenAIClient(capability.location === 'global' ? 'global' : undefined);
 }
@@ -232,7 +253,7 @@ export async function createVertexEmbeddingBatch(
             httpOptions: { apiVersion: 'v1' },
         },
     });
-    return toBatchJob(created);
+    return assertExpectedModel(toBatchJob(created), options.model);
 }
 
 export async function getVertexEmbeddingBatch(
@@ -243,7 +264,7 @@ export async function getVertexEmbeddingBatch(
 ): Promise<VertexEmbeddingBatchJob> {
     const capability = getVertexEmbeddingBatchCapability(model, modality);
     if (!capability) throw new Error(`Vertex embedding model ${model} is not batch capable`);
-    return toBatchJob(await batchClient(driver, capability).batches.get({ name }));
+    return assertExpectedModel(toBatchJob(await batchClient(driver, capability).batches.get({ name })), model);
 }
 
 export async function cancelVertexEmbeddingBatch(
@@ -272,7 +293,7 @@ export async function deleteVertexEmbeddingBatch(
 
 export function vertexBatchTextForParity(input: TextEmbeddingInput, model: string): string {
     const capability = getVertexEmbeddingBatchCapability(model, 'text');
-    return buildVertexEmbeddingText(input, capability?.model === 'gemini-embedding-2');
+    return buildVertexEmbeddingText(input, capability?.taskEncoding === 'prefix');
 }
 
 export function vertexBatchTaskTypeForParity(taskType: EmbeddingTaskType | undefined): string | undefined {

--- a/drivers/src/vertexai/embeddings/batch.ts
+++ b/drivers/src/vertexai/embeddings/batch.ts
@@ -1,8 +1,8 @@
 import { createHash } from 'node:crypto';
 import type { BatchJob, JobState } from '@google/genai';
-import type { EmbeddingInput, EmbeddingTaskType, TextEmbeddingInput } from '@llumiverse/core';
+import type { EmbeddingInput } from '@llumiverse/core';
 import type { VertexAIDriver } from '../index.js';
-import { buildVertexEmbeddingText, toGoogleTaskType, vertexEmbeddingInputToContent } from './format.js';
+import { toGoogleTaskType, vertexEmbeddingInputToContent } from './format.js';
 
 export interface ParsedVertexEmbeddingBatchResult {
     key?: string;
@@ -241,15 +241,6 @@ function normalizedJobState(state: JobState | undefined): VertexEmbeddingBatchSt
     }
 }
 
-function firstGcsUri(value: unknown): string | undefined {
-    if (typeof value === 'string') return value;
-    if (Array.isArray(value)) return value.find((item): item is string => typeof item === 'string');
-    if (value && typeof value === 'object' && 'gcsUri' in value) {
-        return firstGcsUri((value as { gcsUri?: unknown }).gcsUri);
-    }
-    return undefined;
-}
-
 function toBatchJob(job: BatchJob): VertexEmbeddingBatchJob {
     if (!job.name) throw new Error('Vertex AI batch job response did not contain a resource name');
     return {
@@ -257,8 +248,8 @@ function toBatchJob(job: BatchJob): VertexEmbeddingBatchJob {
         displayName: job.displayName,
         state: normalizedJobState(job.state),
         model: job.model,
-        inputUri: firstGcsUri(job.src),
-        outputUri: firstGcsUri(job.dest),
+        inputUri: job.src?.gcsUri?.[0],
+        outputUri: job.dest?.gcsUri,
         error: job.error?.message,
     };
 }
@@ -357,13 +348,4 @@ export async function deleteVertexEmbeddingBatch(
     if (!capability) throw new Error(`Vertex embedding model ${model} is not batch capable`);
     await batchClient(driver, capability).batches.delete({ name, config: { httpOptions: { apiVersion: 'v1' } } });
     return { name, state: 'cancelled' };
-}
-
-export function vertexBatchTextForParity(input: TextEmbeddingInput, model: string): string {
-    const capability = getVertexEmbeddingBatchCapability(model, 'text');
-    return buildVertexEmbeddingText(input, capability?.taskEncoding === 'prefix');
-}
-
-export function vertexBatchTaskTypeForParity(taskType: EmbeddingTaskType | undefined): string | undefined {
-    return toGoogleTaskType(taskType);
 }

--- a/drivers/src/vertexai/embeddings/batch.ts
+++ b/drivers/src/vertexai/embeddings/batch.ts
@@ -100,7 +100,6 @@ type GeminiEmbeddingBatchRow = {
 type LegacyEmbeddingBatchRow = {
     key: string;
     content: string;
-    outputDimensionality: number;
     task_type?: string;
     title?: string;
 };
@@ -127,7 +126,6 @@ export async function formatVertexEmbeddingBatchRow(
         return {
             key: options.key,
             content: options.input.text,
-            outputDimensionality: options.dimensions,
             ...(taskType ? { task_type: taskType } : {}),
             ...(options.input.title ? { title: options.input.title } : {}),
         };
@@ -152,6 +150,8 @@ export async function formatVertexEmbeddingBatchRow(
 export interface CreateVertexEmbeddingBatchOptions {
     model: string;
     modality: VertexEmbeddingBatchModality;
+    /** Legacy models accept dimensionality as a job parameter, rather than per row. */
+    dimensions?: number;
     inputUri: string;
     outputUri: string;
     displayName: string;
@@ -175,6 +175,8 @@ function normalizedJobState(state: JobState | undefined): VertexEmbeddingBatchSt
             return 'succeeded';
         case 'JOB_STATE_FAILED':
         case 'JOB_STATE_EXPIRED':
+        // Terminal partial results must reach application, including successful rows.
+        case 'JOB_STATE_PARTIALLY_SUCCEEDED':
             return 'failed';
         case 'JOB_STATE_CANCELLED':
             return 'cancelled';
@@ -231,11 +233,16 @@ export async function createVertexEmbeddingBatch(
     const client = batchClient(driver, capability);
 
     const existing = await client.batches.list({
-        config: { filter: `displayName="${options.displayName}"`, pageSize: 10 },
+        config: {
+            filter: `displayName=${JSON.stringify(options.displayName)}`,
+            pageSize: 10,
+            httpOptions: { apiVersion: 'v1' },
+        },
     });
     for await (const candidate of existing) {
         const job = toBatchJob(candidate);
         if (
+            job.displayName === options.displayName &&
             normalizeVertexEmbeddingModelId(job.model ?? '') === normalizeVertexEmbeddingModelId(options.model) &&
             job.inputUri === options.inputUri &&
             job.outputUri === options.outputUri
@@ -250,7 +257,12 @@ export async function createVertexEmbeddingBatch(
         config: {
             displayName: options.displayName,
             dest: { gcsUri: options.outputUri, format: 'jsonl' },
-            httpOptions: { apiVersion: 'v1' },
+            httpOptions: {
+                apiVersion: 'v1',
+                ...(capability.schema === 'legacy' && options.dimensions !== undefined
+                    ? { extraBody: { modelParameters: { outputDimensionality: options.dimensions } } }
+                    : {}),
+            },
         },
     });
     return assertExpectedModel(toBatchJob(created), options.model);
@@ -264,7 +276,12 @@ export async function getVertexEmbeddingBatch(
 ): Promise<VertexEmbeddingBatchJob> {
     const capability = getVertexEmbeddingBatchCapability(model, modality);
     if (!capability) throw new Error(`Vertex embedding model ${model} is not batch capable`);
-    return assertExpectedModel(toBatchJob(await batchClient(driver, capability).batches.get({ name })), model);
+    return assertExpectedModel(
+        toBatchJob(
+            await batchClient(driver, capability).batches.get({ name, config: { httpOptions: { apiVersion: 'v1' } } }),
+        ),
+        model,
+    );
 }
 
 export async function cancelVertexEmbeddingBatch(
@@ -275,7 +292,7 @@ export async function cancelVertexEmbeddingBatch(
 ): Promise<VertexEmbeddingBatchJob> {
     const capability = getVertexEmbeddingBatchCapability(model, modality);
     if (!capability) throw new Error(`Vertex embedding model ${model} is not batch capable`);
-    await batchClient(driver, capability).batches.cancel({ name });
+    await batchClient(driver, capability).batches.cancel({ name, config: { httpOptions: { apiVersion: 'v1' } } });
     return getVertexEmbeddingBatch(driver, model, modality, name);
 }
 
@@ -287,7 +304,7 @@ export async function deleteVertexEmbeddingBatch(
 ): Promise<VertexEmbeddingBatchJob> {
     const capability = getVertexEmbeddingBatchCapability(model, modality);
     if (!capability) throw new Error(`Vertex embedding model ${model} is not batch capable`);
-    await batchClient(driver, capability).batches.delete({ name });
+    await batchClient(driver, capability).batches.delete({ name, config: { httpOptions: { apiVersion: 'v1' } } });
     return { name, state: 'cancelled' };
 }
 

--- a/drivers/src/vertexai/embeddings/batch.ts
+++ b/drivers/src/vertexai/embeddings/batch.ts
@@ -3,6 +3,42 @@ import type { EmbeddingInput, EmbeddingTaskType, TextEmbeddingInput } from '@llu
 import type { VertexAIDriver } from '../index.js';
 import { buildVertexEmbeddingText, toGoogleTaskType, vertexEmbeddingInputToContent } from './format.js';
 
+export interface ParsedVertexEmbeddingBatchResult {
+    key?: string;
+    vector?: number[];
+    providerError: boolean;
+    failureCategory?: string;
+}
+
+/** Normalize Gemini and legacy output rows without retaining input content or provider error messages. */
+export function parseVertexEmbeddingBatchResult(record: Record<string, unknown>): ParsedVertexEmbeddingBatchResult {
+    // Gemini JSONL encodes google.rpc.Status as a JSON string; legacy rows may use an object.
+    let status = record.status;
+    if (typeof status === 'string' && status.trim()) {
+        try {
+            status = JSON.parse(status);
+        } catch {
+            status = { code: -1 };
+        }
+    }
+    const code = status && typeof status === 'object' && 'code' in status ? status.code : undefined;
+    const statusError = code !== undefined && code !== 0;
+    const response = record.response as Record<string, unknown> | undefined;
+    const predictions = record.predictions as Array<Record<string, unknown>> | undefined;
+    const embeddings = (response?.embedding ?? response?.embeddings ?? predictions?.[0]?.embeddings) as
+        | Array<Record<string, unknown>>
+        | Record<string, unknown>
+        | undefined;
+    const candidate = Array.isArray(embeddings) ? embeddings[0]?.values : embeddings?.values;
+    const key = record.key ?? (record.instance as Record<string, unknown> | undefined)?.key;
+    return {
+        key: typeof key === 'string' ? key : undefined,
+        vector: Array.isArray(candidate) ? (candidate as number[]) : undefined,
+        providerError: statusError || !!record.error || !!response?.error,
+        ...(statusError ? { failureCategory: code === 7 ? 'provider_permission_denied' : 'provider_row_error' } : {}),
+    };
+}
+
 export type VertexEmbeddingBatchSchema = 'gemini' | 'legacy';
 export type VertexEmbeddingBatchModality = 'text' | 'image';
 

--- a/drivers/src/vertexai/embeddings/batch.ts
+++ b/drivers/src/vertexai/embeddings/batch.ts
@@ -1,15 +1,16 @@
 import { createHash } from 'node:crypto';
 import type { BatchJob, JobState } from '@google/genai';
-import type { EmbeddingInput } from '@llumiverse/core';
+import type {
+    EmbeddingBatchCreateOptions,
+    EmbeddingBatchJob,
+    EmbeddingBatchState,
+    EmbeddingInput,
+    ParsedEmbeddingBatchResult,
+} from '@llumiverse/core';
 import type { VertexAIDriver } from '../index.js';
 import { toGoogleTaskType, vertexEmbeddingInputToContent } from './format.js';
 
-export interface ParsedVertexEmbeddingBatchResult {
-    key?: string;
-    vector?: number[];
-    providerError: boolean;
-    failureCategory?: string;
-}
+export type ParsedVertexEmbeddingBatchResult = ParsedEmbeddingBatchResult;
 
 /** Legacy batches echo only model input fields, dropping custom keys (including instanceConfig.keyField). */
 export function vertexEmbeddingBatchCorrelationKey(row: Record<string, unknown>): string | undefined {
@@ -167,6 +168,10 @@ export async function formatVertexEmbeddingBatchRow(
             `Vertex embedding model ${options.model} uses ${capability.schema} batch rows, not ${options.schema}`,
         );
     }
+    // Batch media is referenced in place. Do not let synchronous inline/download fallback copy source media.
+    if (options.input.type === 'image' && !(await options.input.source.getURL()).startsWith('gs://')) {
+        throw new Error('Vertex embedding batch images require a gs:// source URI');
+    }
 
     if (capability.schema === 'legacy') {
         if (options.input.type !== 'text') {
@@ -197,27 +202,9 @@ export async function formatVertexEmbeddingBatchRow(
     };
 }
 
-export interface CreateVertexEmbeddingBatchOptions {
-    model: string;
-    modality: VertexEmbeddingBatchModality;
-    /** Legacy models accept dimensionality as a job parameter, rather than per row. */
-    dimensions?: number;
-    inputUri: string;
-    outputUri: string;
-    displayName: string;
-}
-
-export type VertexEmbeddingBatchState = 'pending' | 'running' | 'succeeded' | 'failed' | 'cancelled' | 'paused';
-
-export interface VertexEmbeddingBatchJob {
-    name: string;
-    displayName?: string;
-    state: VertexEmbeddingBatchState;
-    model?: string;
-    inputUri?: string;
-    outputUri?: string;
-    error?: string;
-}
+export type CreateVertexEmbeddingBatchOptions = EmbeddingBatchCreateOptions;
+export type VertexEmbeddingBatchState = EmbeddingBatchState;
+export type VertexEmbeddingBatchJob = EmbeddingBatchJob;
 
 function normalizedJobState(state: JobState | undefined): VertexEmbeddingBatchState {
     switch (state as string | undefined) {

--- a/drivers/src/vertexai/embeddings/batch.ts
+++ b/drivers/src/vertexai/embeddings/batch.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import type { BatchJob, JobState } from '@google/genai';
 import type { EmbeddingInput, EmbeddingTaskType, TextEmbeddingInput } from '@llumiverse/core';
 import type { VertexAIDriver } from '../index.js';
@@ -8,6 +9,18 @@ export interface ParsedVertexEmbeddingBatchResult {
     vector?: number[];
     providerError: boolean;
     failureCategory?: string;
+}
+
+/** Legacy batches echo only model input fields, dropping custom keys (including instanceConfig.keyField). */
+export function vertexEmbeddingBatchCorrelationKey(row: Record<string, unknown>): string | undefined {
+    if (typeof row.content === 'string') {
+        if (row.task_type != null && typeof row.task_type !== 'string') return undefined;
+        if (row.title != null && typeof row.title !== 'string') return undefined;
+        return `input:${createHash('sha256')
+            .update(JSON.stringify([row.content, row.task_type ?? null, row.title ?? null]))
+            .digest('hex')}`;
+    }
+    return typeof row.key === 'string' ? row.key : undefined;
 }
 
 /** Normalize Gemini and legacy output rows without retaining input content or provider error messages. */
@@ -30,7 +43,8 @@ export function parseVertexEmbeddingBatchResult(record: Record<string, unknown>)
         | Record<string, unknown>
         | undefined;
     const candidate = Array.isArray(embeddings) ? embeddings[0]?.values : embeddings?.values;
-    const key = record.key ?? (record.instance as Record<string, unknown> | undefined)?.key;
+    const instance = record.instance as Record<string, unknown> | undefined;
+    const key = record.key ?? (instance ? vertexEmbeddingBatchCorrelationKey(instance) : undefined);
     return {
         key: typeof key === 'string' ? key : undefined,
         vector: Array.isArray(candidate) ? (candidate as number[]) : undefined,
@@ -296,7 +310,8 @@ export async function createVertexEmbeddingBatch(
             httpOptions: {
                 apiVersion: 'v1',
                 ...(capability.schema === 'legacy' && options.dimensions !== undefined
-                    ? { extraBody: { modelParameters: { outputDimensionality: options.dimensions } } }
+                    ? // The legacy batch backend reads numeric JSON parameters as FLOAT64, not INT64.
+                      { extraBody: { modelParameters: { outputDimensionality: String(options.dimensions) } } }
                     : {}),
             },
         },

--- a/drivers/src/vertexai/embeddings/embed.ts
+++ b/drivers/src/vertexai/embeddings/embed.ts
@@ -1,21 +1,21 @@
-import type { Content, EmbedContentConfig, Part } from '@google/genai';
+import type { EmbedContentConfig } from '@google/genai';
 import { VERTEX_DEFAULT_EMBEDDING_MODEL, VERTEX_MULTIMODAL_EMBEDDING_MODEL } from '@llumiverse/common';
 import {
     buildEmbeddingsResult,
-    type DataSource,
     type EmbeddingInput,
     type EmbeddingResultItem,
     type EmbeddingsOptions,
     type EmbeddingsResult,
     type EmbeddingsTokenUsage,
-    type EmbeddingTaskType,
     LlumiverseError,
     normalizeEmbeddingsOptions,
     type TextEmbeddingInput,
 } from '@llumiverse/core';
 import type { VertexAIDriver } from '../index.js';
 import { generateLegacyMultimodalEmbeddings } from './embed-legacy-multimodal.js';
-import { dataSourceToVertexSourceData } from './source-utils.js';
+import { toGoogleTaskType, vertexEmbeddingInputToContent } from './format.js';
+
+export { buildVertexEmbeddingText, toGoogleTaskType, vertexEmbeddingInputToContent } from './format.js';
 
 /**
  * Models that do not accept task_type as an API parameter and instead expect
@@ -30,30 +30,6 @@ const TASK_TYPE_PREFIX_MODELS = new Set<string>(['gemini-embedding-2']);
  *   query    → "task: search result | query: {text}"
  *   document → "title: {title} | text: {text}"  (uses "none" when title is absent)
  */
-function buildPrefixText(input: TextEmbeddingInput): string {
-    if (!input.task_type) return input.text;
-    if (input.task_type === 'query') {
-        return `task: search result | query: ${input.text}`;
-    }
-    // document
-    const title = input.title ?? 'none';
-    return `title: ${title} | text: ${input.text}`;
-}
-
-/** Maps llumiverse task types to Google's embedContent taskType strings. */
-type GoogleEmbedTaskType = 'RETRIEVAL_QUERY' | 'RETRIEVAL_DOCUMENT';
-
-function toGoogleTaskType(taskType: EmbeddingTaskType | undefined): GoogleEmbedTaskType | undefined {
-    switch (taskType) {
-        case 'query':
-            return 'RETRIEVAL_QUERY';
-        case 'document':
-            return 'RETRIEVAL_DOCUMENT';
-        default:
-            return undefined;
-    }
-}
-
 /**
  * Models only available in the Vertex "global" location.
  */
@@ -63,19 +39,6 @@ const GLOBAL_ONLY_MODELS = new Set<string>(['gemini-embedding-2']);
  * Models that only support one input content per embedContent request.
  */
 const NON_GROUPING_MODELS = new Set<string>(['gemini-embedding-001', 'gemini-embedding-2']);
-
-async function dataSourceToPart(ds: DataSource): Promise<Part> {
-    const source = await dataSourceToVertexSourceData(ds);
-    if (source.gcsUri) {
-        return { fileData: { fileUri: source.gcsUri, mimeType: ds.mime_type } };
-    }
-
-    if (!source.bytesBase64Encoded) {
-        throw new Error('Data source conversion produced neither GCS URI nor inline bytes');
-    }
-
-    return { inlineData: { data: source.bytesBase64Encoded, mimeType: ds.mime_type } };
-}
 
 type TextConfig = Pick<EmbedContentConfig, 'taskType' | 'title'>;
 
@@ -89,14 +52,6 @@ function textConfig(input: TextEmbeddingInput, viaPrefix: boolean): TextConfig {
 function configSignature(input: EmbeddingInput, viaPrefix: boolean): string {
     if (input.type !== 'text') return '{}';
     return JSON.stringify(textConfig(input, viaPrefix));
-}
-
-async function inputToContent(input: EmbeddingInput, viaPrefix: boolean): Promise<Content> {
-    if (input.type === 'text') {
-        const text = viaPrefix ? buildPrefixText(input) : input.text;
-        return { role: 'user', parts: [{ text }] };
-    }
-    return { role: 'user', parts: [await dataSourceToPart(input.source)] };
 }
 
 function configForGroup(
@@ -162,7 +117,7 @@ export async function generateVertexAiEmbeddings(
     const usage: EmbeddingsTokenUsage = {};
 
     for (const group of groups.values()) {
-        const contents = await Promise.all(group.map((entry) => inputToContent(entry.input, viaPrefix)));
+        const contents = await Promise.all(group.map((entry) => vertexEmbeddingInputToContent(entry.input, viaPrefix)));
         const config = configForGroup(group[0].input, viaPrefix, normalized);
 
         try {

--- a/drivers/src/vertexai/embeddings/embed.ts
+++ b/drivers/src/vertexai/embeddings/embed.ts
@@ -12,33 +12,11 @@ import {
     type TextEmbeddingInput,
 } from '@llumiverse/core';
 import type { VertexAIDriver } from '../index.js';
+import { getVertexEmbeddingBatchCapability } from './batch.js';
 import { generateLegacyMultimodalEmbeddings } from './embed-legacy-multimodal.js';
 import { toGoogleTaskType, vertexEmbeddingInputToContent } from './format.js';
 
 export { buildVertexEmbeddingText, toGoogleTaskType, vertexEmbeddingInputToContent } from './format.js';
-
-/**
- * Models that do not accept task_type as an API parameter and instead expect
- * the task to be conveyed by a documented prompt prefix.
- */
-const TASK_TYPE_PREFIX_MODELS = new Set<string>(['gemini-embedding-2']);
-
-/**
- * Apply the documented prompt prefix for gemini-embedding-2 (prefix-only model).
- *
- * Prefixes per Google docs:
- *   query    → "task: search result | query: {text}"
- *   document → "title: {title} | text: {text}"  (uses "none" when title is absent)
- */
-/**
- * Models only available in the Vertex "global" location.
- */
-const GLOBAL_ONLY_MODELS = new Set<string>(['gemini-embedding-2']);
-
-/**
- * Models that only support one input content per embedContent request.
- */
-const NON_GROUPING_MODELS = new Set<string>(['gemini-embedding-001', 'gemini-embedding-2']);
 
 type TextConfig = Pick<EmbedContentConfig, 'taskType' | 'title'>;
 
@@ -97,9 +75,12 @@ export async function generateVertexAiEmbeddings(
         return generateLegacyMultimodalEmbeddings(driver, normalized);
     }
 
-    const viaPrefix = TASK_TYPE_PREFIX_MODELS.has(model);
-    const region = GLOBAL_ONLY_MODELS.has(model) ? 'global' : undefined;
-    const disableGrouping = NON_GROUPING_MODELS.has(model);
+    const textCapability = getVertexEmbeddingBatchCapability(model, 'text');
+    const imageCapability = getVertexEmbeddingBatchCapability(model, 'image');
+    const profile = textCapability ?? imageCapability;
+    const viaPrefix = profile?.taskEncoding === 'prefix';
+    const region = profile?.location === 'global' ? 'global' : undefined;
+    const disableGrouping = profile?.maxSynchronousInputs === 1;
 
     const groups = new Map<string, { index: number; input: EmbeddingInput }[]>();
     normalized.inputs.forEach((input, index) => {

--- a/drivers/src/vertexai/embeddings/format.ts
+++ b/drivers/src/vertexai/embeddings/format.ts
@@ -1,0 +1,30 @@
+import type { Content, Part } from '@google/genai';
+import type { DataSource, EmbeddingInput, EmbeddingTaskType, TextEmbeddingInput } from '@llumiverse/core';
+import { dataSourceToVertexSourceData } from './source-utils.js';
+
+export function buildVertexEmbeddingText(input: TextEmbeddingInput, viaPrefix: boolean): string {
+    if (!viaPrefix) return input.text;
+    if (!input.task_type) return input.text;
+    if (input.task_type === 'query') return `task: search result | query: ${input.text}`;
+    return `title: ${input.title ?? 'none'} | text: ${input.text}`;
+}
+
+export function toGoogleTaskType(
+    taskType: EmbeddingTaskType | undefined,
+): 'RETRIEVAL_QUERY' | 'RETRIEVAL_DOCUMENT' | undefined {
+    if (taskType === 'query') return 'RETRIEVAL_QUERY';
+    if (taskType === 'document') return 'RETRIEVAL_DOCUMENT';
+    return undefined;
+}
+
+async function dataSourceToPart(ds: DataSource): Promise<Part> {
+    const source = await dataSourceToVertexSourceData(ds);
+    if (source.gcsUri) return { fileData: { fileUri: source.gcsUri, mimeType: ds.mime_type } };
+    if (!source.bytesBase64Encoded) throw new Error('Data source conversion produced neither GCS URI nor inline bytes');
+    return { inlineData: { data: source.bytesBase64Encoded, mimeType: ds.mime_type } };
+}
+
+export async function vertexEmbeddingInputToContent(input: EmbeddingInput, viaPrefix: boolean): Promise<Content> {
+    if (input.type === 'text') return { role: 'user', parts: [{ text: buildVertexEmbeddingText(input, viaPrefix) }] };
+    return { role: 'user', parts: [await dataSourceToPart(input.source)] };
+}

--- a/drivers/src/vertexai/index.ts
+++ b/drivers/src/vertexai/index.ts
@@ -33,6 +33,9 @@ import {
 import { type ClaudePrompt, formatClaudeDebugPrompt, isClaudePromptCacheEnabled } from '../shared/claude-messages.js';
 import { resolveModelListingMetadata } from '../shared/model-listing.js';
 import { generateVertexAiEmbeddings } from './embeddings/embed.js';
+
+export * from './embeddings/batch.js';
+
 import { ANTHROPIC_REGIONS, NON_GLOBAL_ANTHROPIC_MODELS } from './models/claude.js';
 import { formatGeminiDebugPrompt } from './models/gemini.js';
 import {


### PR DESCRIPTION
## Summary

- Add provider-neutral batch adapter types in `@llumiverse/core` and the `@llumiverse/drivers/embedding-batch` resolver. Vertex is the first implementation; no other provider is enabled.
- Explicit capability profiles for Gemini embedding 2, Gemini embedding 001, and stable text embedding 004/005. Preserve synchronous behavior for unsupported models.
- Share synchronous/batch formatting for prompt prefixes, task semantics, MIME types, dimensions, and model locations.
- Use authenticated Vertex v1 generic batch lifecycle operations, deterministic-name submission recovery, and normalized terminal states.
- Keep model-specific request formatting and result parsing in the driver. Legacy batches use integer-string dimensionality and correlation digests over echoed inputs, never output order.

## Verification

- Drivers: `pnpm lint`, `pnpm typecheck:test`, and `pnpm test src/embedding-batch.test.ts src/vertexai/embeddings/batch.test.ts src/vertexai/embeddings/batch-result.test.ts` — passed, 32 non-live tests.
- Repository `pnpm build` passed during integration verification.
- Targeted legacy live probes verified default 768 dimensions, explicit 256 dimensions, and Unicode/newline/task/title correlation.
- Full `pnpm test` intentionally not run because it includes costly live model calls.
- Working-tree status and public diff reviewed. Targets release/1.5; forward-port to main after merge.

Reference: [Google batch embedding documentation](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/embeddings/batch-prediction-genai-embeddings).
