### PR TITLE
feat: adopt canonical conversations across text protocols

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -54,6 +54,7 @@
         "url": "git+ssh://git@github.com/vertesia/llumiverse.git"
     },
     "dependencies": {
+        "@llumiverse/conversation": "workspace:*",
         "zod": "^4.5.4"
     },
     "devDependencies": {

--- a/common/src/schemas/completion.ts
+++ b/common/src/schemas/completion.ts
@@ -91,6 +91,10 @@ export const PromptSegmentSchema = z
         role: PromptRoleSchema,
         content: z.string(),
         tool_use_id: z.string().meta({ description: 'The tool use id if the segment is a tool response' }).optional(),
+        tool_result_status: z
+            .enum(['success', 'error', 'cancelled', 'denied'])
+            .meta({ description: 'Terminal status of a tool response supplied by the application' })
+            .optional(),
         thought_signature: z
             .string()
             .meta({

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -1,4 +1,8 @@
+import type { ConversationRuntimeContext } from '@llumiverse/conversation';
 import type { z } from 'zod';
+
+export type { ConversationRuntimeContext } from '@llumiverse/conversation';
+
 import type {
     ExecutionTokenUsageSchema,
     PromptCacheDiagnosticSchema,
@@ -691,6 +695,11 @@ export interface ExecutionOptions extends ExecutionOptionsBase {
      */
     conversation?: unknown | null;
     /**
+     * Stable canonical request identity for adapters that have adopted `@llumiverse/conversation`.
+     * Remaining legacy-native drivers ignore this field until their adapter migration.
+     */
+    conversation_runtime?: ConversationRuntimeContext;
+    /**
      * Labels for billing attribution and cost tracking.
      * Passed through to provider APIs that support request-level labels (e.g. Vertex AI).
      * Keys and values must be lowercase, max 64 characters, containing only letters, numbers, underscores, and dashes.
@@ -846,6 +855,8 @@ export interface PromptSegment {
      * The tool use id if the segment is a tool response
      */
     tool_use_id?: string;
+    /** Terminal status of a tool response supplied by the application. */
+    tool_result_status?: 'success' | 'error' | 'cancelled' | 'denied';
     /**
      * Gemini thinking models require thought_signature to be passed back with tool results.
      * This should be copied from the ToolUse.thought_signature when sending tool responses.

--- a/common/tsconfig.json
+++ b/common/tsconfig.json
@@ -25,5 +25,6 @@
         "useUnknownInCatchVariables": true
     },
     "include": ["src"],
-    "exclude": ["node_modules", "**/*.test.ts", "lib", "test"]
+    "exclude": ["node_modules", "**/*.test.ts", "lib", "test"],
+    "references": [{ "path": "../conversation" }]
 }

--- a/conversation/.gitignore
+++ b/conversation/.gitignore
@@ -1,0 +1,3 @@
+# generated files
+lib/
+.verify/

--- a/conversation/README.md
+++ b/conversation/README.md
@@ -1,0 +1,52 @@
+# @llumiverse/conversation
+
+Experimental schema-first conversation records for Llumiverse. This package currently defines schema
+version `0` with the exact `experimental_revision` exported as `CONVERSATION_EXPERIMENTAL_REVISION`.
+Version `0` is not a stable compatibility promise.
+
+The foundation revision supports fully materialized conversation documents. It includes strict Zod
+schemas and inferred TypeScript types for turns, content, tools, media assets, generations, accounting,
+receipts, context selection, compaction records, processing configuration, lineage, diagnostics, and
+basic inspection. It also provides bounded JSON preflight, full-document shape and semantic validation,
+JSON serialization, builders, type guards, and deterministic Draft 2020-12 JSON Schema exports.
+
+```ts
+import {
+    conversationDocumentFromJson,
+    conversationDocumentToJson,
+    createConversationDocument,
+    inspectConversation,
+} from '@llumiverse/conversation';
+
+const empty = createConversationDocument({
+    id: 'conversation-1',
+    created_at: '2026-09-11T00:00:00.000Z',
+});
+
+const restored = conversationDocumentFromJson(conversationDocumentToJson(empty));
+console.log(inspectConversation(restored));
+```
+
+Import runtime schemas from `@llumiverse/conversation/schemas` and generated schemas from
+`@llumiverse/conversation/json-schema`. Ordinary `import type` use of the package is erased by
+TypeScript and does not load Zod.
+
+Always use `validateConversationDocument()`, `parseConversationDocument()`, or the JSON helpers for
+untrusted input. Calling a leaf Zod schema directly performs shape validation without the bounded
+preflight or document-wide reference checks. In Zod 4, recursive record parsing skips an own
+`__proto__` key. The public preflight therefore rejects that key in this experimental revision rather
+than accepting and rewriting it. It also rejects negative zero because JSON serialization changes it
+to zero. Other valid names such as `constructor`, `toString`, and `hasOwnProperty` are preserved.
+Unknown measurements stay absent; builders do not invent usage, model, timestamp, or provenance data.
+
+Processing configurations and compaction records are inert persisted data in this revision. They do
+not imply that a processor ran or that a document is ready for another request. The exported
+`CONVERSATION_FOUNDATION_LIMITATIONS` lists unavailable contract areas. In particular, this revision
+does not implement manifests and segmented storage, partial working-set validation, fragments,
+mutation operations, processing jobs and readiness, delivery streams, provider adapters, or legacy
+migrations. It does not satisfy the stable schema-version-1, core-preview, migration, or npm
+publication gates.
+
+The package remains private while its experimental publication gate is reviewed. A future publication
+must freeze the intended experimental surface, verify generated-contract compatibility, and define a
+release path that does not include the package in the stable Llumiverse publication set by accident.

--- a/conversation/README.md
+++ b/conversation/README.md
@@ -1,14 +1,17 @@
 # @llumiverse/conversation
 
-Experimental schema-first conversation records for Llumiverse. This package currently defines schema
-version `0` with the exact `experimental_revision` exported as `CONVERSATION_EXPERIMENTAL_REVISION`.
-Version `0` is not a stable compatibility promise.
+`@llumiverse/conversation` is the experimental canonical conversation record package for Llumiverse.
+It currently defines schema version `0` with the exact revision `2026-09-11.ingestion.1`, also exported
+as `CONVERSATION_EXPERIMENTAL_REVISION`. Version `0` has no stable compatibility promise. The ingestion
+revision adds strict persisted receipts and accepted-record identities; documents from the earlier
+`foundation.1` revision require an explicit migration and are rejected rather than guessed.
 
-The foundation revision supports fully materialized conversation documents. It includes strict Zod
-schemas and inferred TypeScript types for turns, content, tools, media assets, generations, accounting,
-receipts, context selection, compaction records, processing configuration, lineage, diagnostics, and
-basic inspection. It also provides bounded JSON preflight, full-document shape and semantic validation,
-JSON serialization, builders, type guards, and deterministic Draft 2020-12 JSON Schema exports.
+The package supports fully materialized documents. Strict Zod schemas are authoritative for turns,
+content, tools, media assets, generations, accounting, receipts, context selection, compaction records,
+processing configuration, lineage, diagnostics, and ingestion batches. Public TypeScript types are
+inferred from those schemas. Bounded JSON preflight, document-wide structural and semantic validation,
+JSON round trips, builders, type guards, basic rendering and inspection, idempotent append-only ingestion,
+and deterministic Draft 2020-12 JSON Schema exports are included.
 
 ```ts
 import {
@@ -27,6 +30,19 @@ const restored = conversationDocumentFromJson(conversationDocumentToJson(empty))
 console.log(inspectConversation(restored));
 ```
 
+Native execution adapters live in `@llumiverse/drivers`. OpenAI Chat Completions and Claude Messages
+import native history once, render canonical context into provider requests, ingest native responses
+directly into canonical records, and can produce read-only legacy projections at an API compatibility
+boundary. Internal retries use persisted operation receipts and stable host-supplied identities. Other
+driver protocols remain on their native histories and reject canonical input so a provider switch cannot
+silently discard conversation state.
+
+```ts
+import { exportLegacyConversation, OPENAI_CHAT_COMPLETIONS_PROTOCOL } from '@llumiverse/drivers';
+
+const legacyView = exportLegacyConversation(restored, OPENAI_CHAT_COMPLETIONS_PROTOCOL);
+```
+
 Import runtime schemas from `@llumiverse/conversation/schemas` and generated schemas from
 `@llumiverse/conversation/json-schema`. Ordinary `import type` use of the package is erased by
 TypeScript and does not load Zod.
@@ -41,11 +57,11 @@ Unknown measurements stay absent; builders do not invent usage, model, timestamp
 
 Processing configurations and compaction records are inert persisted data in this revision. They do
 not imply that a processor ran or that a document is ready for another request. The exported
-`CONVERSATION_FOUNDATION_LIMITATIONS` lists unavailable contract areas. In particular, this revision
-does not implement manifests and segmented storage, partial working-set validation, fragments,
-mutation operations, processing jobs and readiness, delivery streams, provider adapters, or legacy
-migrations. It does not satisfy the stable schema-version-1, core-preview, migration, or npm
-publication gates.
+`CONVERSATION_FOUNDATION_LIMITATIONS` lists unavailable contract areas. This revision does not implement
+manifests and segmented storage, partial working-set validation, fragments, mutation operations,
+processing jobs and readiness, delivery streams, adapters for the remaining protocols, or persisted
+legacy-document migrations. It does not satisfy the stable schema-version-1, core-preview, full runtime
+retirement, migration, or npm publication gates.
 
 The package remains private while its experimental publication gate is reviewed. A future publication
 must freeze the intended experimental surface, verify generated-contract compatibility, and define a

--- a/conversation/package.json
+++ b/conversation/package.json
@@ -1,0 +1,56 @@
+{
+    "name": "@llumiverse/conversation",
+    "version": "0.0.0-experimental.0",
+    "private": true,
+    "type": "module",
+    "description": "Experimental schema-first canonical conversation data model for Llumiverse.",
+    "files": [
+        "lib",
+        "src",
+        "README.md"
+    ],
+    "sideEffects": false,
+    "main": "./lib/index.js",
+    "types": "./lib/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./lib/index.d.ts",
+            "default": "./lib/index.js"
+        },
+        "./schemas": {
+            "types": "./lib/schemas/index.d.ts",
+            "default": "./lib/schemas/index.js"
+        },
+        "./json-schema": {
+            "types": "./lib/json-schema.d.ts",
+            "default": "./lib/json-schema.js"
+        },
+        "./package.json": "./package.json"
+    },
+    "scripts": {
+        "lint": "biome lint src",
+        "test": "vitest run",
+        "typecheck:test": "tsc -p tsconfig.test.json --noEmit",
+        "build": "pnpm exec rimraf ./lib ./tsconfig.tsbuildinfo && tsc",
+        "clean": "rimraf ./lib ./tsconfig.tsbuildinfo ./.verify",
+        "verify:exports": "node ./scripts/verify-exports.mjs"
+    },
+    "author": "Llumiverse",
+    "license": "Apache-2.0",
+    "homepage": "https://github.com/vertesia/llumiverse",
+    "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/vertesia/llumiverse.git"
+    },
+    "dependencies": {
+        "zod": "^4.5.4"
+    },
+    "devDependencies": {
+        "@types/node": "catalog:",
+        "ajv": "^8.20.0",
+        "ajv-formats": "^3.0.1",
+        "rimraf": "^6.1.3",
+        "typescript": "catalog:",
+        "vitest": "^4.1.11"
+    }
+}

--- a/conversation/scripts/verify-exports.mjs
+++ b/conversation/scripts/verify-exports.mjs
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFile, rm } from 'node:fs/promises';
+
+const root = await import('@llumiverse/conversation');
+const schemas = await import('@llumiverse/conversation/schemas');
+const jsonSchemas = await import('@llumiverse/conversation/json-schema');
+
+assert.equal(typeof root.validateConversationDocument, 'function');
+assert.equal(typeof root.createConversationDocument, 'function');
+assert.equal(typeof schemas.ConversationDocumentSchema?.safeParse, 'function');
+assert.equal(jsonSchemas.ConversationDocumentJsonSchema.$schema, 'https://json-schema.org/draft/2020-12/schema');
+
+const compiler = spawnSync('pnpm', ['exec', 'tsc', '-p', 'test-fixtures/tsconfig.json'], {
+    cwd: new URL('..', import.meta.url),
+    encoding: 'utf8',
+});
+assert.equal(compiler.status, 0, compiler.stderr || compiler.stdout);
+
+const outputUrl = new URL('../.verify/type-only.js', import.meta.url);
+const output = await readFile(outputUrl, 'utf8');
+assert.doesNotMatch(output, /@llumiverse\/conversation|zod/);
+await rm(new URL('../.verify', import.meta.url), { recursive: true, force: true });

--- a/conversation/src/builders.ts
+++ b/conversation/src/builders.ts
@@ -1,0 +1,134 @@
+import type { z } from 'zod';
+import { ConversationValidationError } from './diagnostics.js';
+import { preflightJsonInput } from './json-preflight.js';
+import {
+    ContentBlockSchema,
+    ConversationTurnSchema,
+    GeneratedAgentTurnSchema,
+    ProgramTurnSchema,
+    TextBlockSchema,
+    ToolTurnSchema,
+    UserTurnSchema,
+} from './schemas/index.js';
+import {
+    CONVERSATION_EXPERIMENTAL_REVISION,
+    CONVERSATION_FORMAT,
+    CONVERSATION_SCHEMA_VERSION,
+} from './schemas/primitives.js';
+import type {
+    ContentBlock,
+    ConversationDocument,
+    ConversationMetadata,
+    ConversationTurn,
+    GeneratedAgentTurn,
+    ProgramTurn,
+    TextBlock,
+    ToolTurn,
+    UserTurn,
+} from './types.js';
+import { diagnosticsFromZodError, parseConversationDocument } from './validation.js';
+
+export type ConversationDocumentBuilderInput = Pick<ConversationDocument, 'id' | 'created_at'> &
+    Partial<Pick<ConversationDocument, 'revision' | 'updated_at'>> & {
+        metadata?: ConversationMetadata;
+    };
+
+export type TextBlockBuilderInput = Omit<TextBlock, 'type'>;
+export type UserTurnBuilderInput = Omit<UserTurn, 'kind'>;
+export type GeneratedAgentTurnBuilderInput = Omit<GeneratedAgentTurn, 'kind'>;
+export type ToolTurnBuilderInput = Omit<ToolTurn, 'kind'>;
+export type ProgramTurnBuilderInput = Omit<ProgramTurn, 'kind'>;
+
+function buildSchemaValue<T>(schema: z.ZodType<T>, input: unknown): T {
+    const preflight = preflightJsonInput(input);
+    if (!preflight.success) {
+        throw new ConversationValidationError('Conversation value failed JSON preflight', preflight.diagnostics);
+    }
+    const result = schema.safeParse(input);
+    if (!result.success) {
+        throw new ConversationValidationError(
+            'Conversation value failed schema validation',
+            diagnosticsFromZodError(result.error),
+        );
+    }
+    // The preflight and schema prove that the original value is JSON-safe and shape-valid. Clone the
+    // original to avoid Zod record reconstruction changing an accepted own-key representation.
+    return structuredClone(input) as T;
+}
+
+function assertJsonBuilderInput(input: unknown): void {
+    const preflight = preflightJsonInput(input);
+    if (!preflight.success) {
+        throw new ConversationValidationError(
+            'Conversation builder input failed JSON preflight',
+            preflight.diagnostics,
+        );
+    }
+}
+
+export function createConversationDocument(input: ConversationDocumentBuilderInput): ConversationDocument {
+    assertJsonBuilderInput(input);
+    const revision = input.revision ?? 0;
+    return parseConversationDocument({
+        format: CONVERSATION_FORMAT,
+        schema_version: CONVERSATION_SCHEMA_VERSION,
+        experimental_revision: CONVERSATION_EXPERIMENTAL_REVISION,
+        id: input.id,
+        revision,
+        created_at: input.created_at,
+        updated_at: input.updated_at ?? input.created_at,
+        turns: [],
+        generations: {},
+        operation_receipts: {},
+        execution_receipts: {},
+        assets: {},
+        tool_definitions: {},
+        context: {
+            revision,
+            entries: [],
+            active_tool_definition_ids: [],
+            protected_entry_ids: [],
+            retrieval_requirements: [],
+        },
+        compactions: {},
+        processing: {
+            enabled: false,
+            policy_revision: 0,
+            processors: [],
+        },
+        ...(input.metadata === undefined ? {} : { metadata: input.metadata }),
+    });
+}
+
+export function createTextBlock(input: TextBlockBuilderInput): TextBlock {
+    assertJsonBuilderInput(input);
+    return buildSchemaValue(TextBlockSchema, { ...input, type: 'text' });
+}
+
+export function createUserTurn(input: UserTurnBuilderInput): UserTurn {
+    assertJsonBuilderInput(input);
+    return buildSchemaValue(UserTurnSchema, { ...input, kind: 'user' });
+}
+
+export function createGeneratedAgentTurn(input: GeneratedAgentTurnBuilderInput): GeneratedAgentTurn {
+    assertJsonBuilderInput(input);
+    return buildSchemaValue(GeneratedAgentTurnSchema, { ...input, kind: 'agent' });
+}
+
+export function createToolTurn(input: ToolTurnBuilderInput): ToolTurn {
+    assertJsonBuilderInput(input);
+    return buildSchemaValue(ToolTurnSchema, { ...input, kind: 'tool' });
+}
+
+export function createProgramTurn(input: ProgramTurnBuilderInput): ProgramTurn {
+    assertJsonBuilderInput(input);
+    return buildSchemaValue(ProgramTurnSchema, { ...input, kind: 'program' });
+}
+
+export function buildConversationTurn(input: unknown): ConversationTurn {
+    return buildSchemaValue(ConversationTurnSchema, input);
+}
+
+export function buildContentBlock(input: unknown): ContentBlock {
+    return buildSchemaValue(ContentBlockSchema, input);
+}

--- a/conversation/src/diagnostics.ts
+++ b/conversation/src/diagnostics.ts
@@ -1,0 +1,103 @@
+import {
+    DIAGNOSTIC_MESSAGE_MAX_LENGTH,
+    DIAGNOSTIC_PATH_MAX_LENGTH,
+    DIAGNOSTIC_RECORD_ID_MAX_LENGTH,
+    DIAGNOSTIC_RELATED_PATHS_MAX_LENGTH,
+} from './schemas/diagnostics.js';
+import type { ConversationDiagnostic, JsonPreflightDiagnostic, SemanticConversationDiagnostic } from './types.js';
+
+const TRUNCATED_SUFFIX = '…';
+
+function truncate(value: string, maximumLength: number): string {
+    if (value.length <= maximumLength) {
+        return value;
+    }
+    return `${value.slice(0, maximumLength - TRUNCATED_SUFFIX.length)}${TRUNCATED_SUFFIX}`;
+}
+
+/** Bounds untrusted values before interpolating them into a diagnostic message. */
+export function diagnosticValue(value: string): string {
+    return truncate(value, 128);
+}
+
+function appendPointerSegment(pointer: string, segment: string): { pointer: string; truncated: boolean } {
+    let next = pointer;
+    for (let index = 0; index < segment.length; index += 1) {
+        const character = segment[index];
+        const encoded = character === '~' ? '~0' : character === '/' ? '~1' : character;
+        if (next.length + encoded.length > DIAGNOSTIC_PATH_MAX_LENGTH - TRUNCATED_SUFFIX.length) {
+            return {
+                pointer: `${next.slice(0, DIAGNOSTIC_PATH_MAX_LENGTH - TRUNCATED_SUFFIX.length)}${TRUNCATED_SUFFIX}`,
+                truncated: true,
+            };
+        }
+        next += encoded;
+    }
+    return { pointer: next, truncated: false };
+}
+
+/** Builds a bounded RFC 6901 pointer without first copying an untrusted full key. */
+export function diagnosticPointer(segments: readonly (string | number)[]): string {
+    let pointer = '';
+    for (const segment of segments) {
+        if (pointer.length + 1 > DIAGNOSTIC_PATH_MAX_LENGTH - TRUNCATED_SUFFIX.length) {
+            return `${pointer.slice(0, DIAGNOSTIC_PATH_MAX_LENGTH - TRUNCATED_SUFFIX.length)}${TRUNCATED_SUFFIX}`;
+        }
+        pointer += '/';
+        const appended = appendPointerSegment(pointer, String(segment));
+        pointer = appended.pointer;
+        if (appended.truncated) {
+            return pointer;
+        }
+    }
+    return truncate(pointer, DIAGNOSTIC_PATH_MAX_LENGTH);
+}
+
+/**
+ * Applies the public diagnostic payload limits without modifying the underlying conversation value.
+ * All validation stages use this final projection before returning diagnostics to a caller.
+ */
+export function boundConversationDiagnostic(diagnostic: JsonPreflightDiagnostic): JsonPreflightDiagnostic;
+export function boundConversationDiagnostic(diagnostic: SemanticConversationDiagnostic): SemanticConversationDiagnostic;
+export function boundConversationDiagnostic(diagnostic: ConversationDiagnostic): ConversationDiagnostic;
+export function boundConversationDiagnostic(diagnostic: ConversationDiagnostic): ConversationDiagnostic {
+    const relatedPaths = diagnostic.related_paths
+        ?.slice(0, DIAGNOSTIC_RELATED_PATHS_MAX_LENGTH)
+        .map((path) => truncate(path, DIAGNOSTIC_PATH_MAX_LENGTH));
+    return {
+        ...diagnostic,
+        path: truncate(diagnostic.path, DIAGNOSTIC_PATH_MAX_LENGTH),
+        message: truncate(diagnostic.message, DIAGNOSTIC_MESSAGE_MAX_LENGTH),
+        record_id:
+            diagnostic.record_id === undefined
+                ? undefined
+                : truncate(diagnostic.record_id, DIAGNOSTIC_RECORD_ID_MAX_LENGTH),
+        related_paths: relatedPaths,
+        limit: diagnostic.limit === undefined ? undefined : Math.min(diagnostic.limit, Number.MAX_SAFE_INTEGER),
+        observed:
+            diagnostic.observed === undefined ? undefined : Math.min(diagnostic.observed, Number.MAX_SAFE_INTEGER),
+    };
+}
+
+export interface ConversationValidationSuccess<T> {
+    success: true;
+    data: T;
+    diagnostics: [];
+}
+
+export interface ConversationValidationFailure {
+    success: false;
+    diagnostics: ConversationDiagnostic[];
+}
+
+export type ConversationValidationResult<T> = ConversationValidationSuccess<T> | ConversationValidationFailure;
+
+export class ConversationValidationError extends Error {
+    public readonly diagnostics: ConversationDiagnostic[];
+
+    public constructor(message: string, diagnostics: ConversationDiagnostic[], options?: ErrorOptions) {
+        super(message, options);
+        this.name = 'ConversationValidationError';
+        this.diagnostics = diagnostics;
+    }
+}

--- a/conversation/src/guards.ts
+++ b/conversation/src/guards.ts
@@ -1,3 +1,4 @@
+import { CONVERSATION_FORMAT } from './schemas/primitives.js';
 import type { AgentTurn, ConversationTurn, GeneratedAgentTurn, ProgramTurn, ToolTurn, UserTurn } from './types.js';
 
 export function isUserTurn(turn: ConversationTurn): turn is UserTurn {
@@ -18,4 +19,11 @@ export function isToolTurn(turn: ConversationTurn): turn is ToolTurn {
 
 export function isProgramTurn(turn: ConversationTurn): turn is ProgramTurn {
     return turn.kind === 'program';
+}
+
+/** Recognizes the envelope only. Parse before treating the value as a document. */
+export function isConversationDocumentFormat(value: unknown): boolean {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+    const descriptor = Object.getOwnPropertyDescriptor(value, 'format');
+    return descriptor !== undefined && 'value' in descriptor && descriptor.value === CONVERSATION_FORMAT;
 }

--- a/conversation/src/guards.ts
+++ b/conversation/src/guards.ts
@@ -1,0 +1,21 @@
+import type { AgentTurn, ConversationTurn, GeneratedAgentTurn, ProgramTurn, ToolTurn, UserTurn } from './types.js';
+
+export function isUserTurn(turn: ConversationTurn): turn is UserTurn {
+    return turn.kind === 'user';
+}
+
+export function isAgentTurn(turn: ConversationTurn): turn is AgentTurn {
+    return turn.kind === 'agent';
+}
+
+export function isGeneratedAgentTurn(turn: ConversationTurn): turn is GeneratedAgentTurn {
+    return turn.kind === 'agent' && turn.provenance.type === 'generated';
+}
+
+export function isToolTurn(turn: ConversationTurn): turn is ToolTurn {
+    return turn.kind === 'tool';
+}
+
+export function isProgramTurn(turn: ConversationTurn): turn is ProgramTurn {
+    return turn.kind === 'program';
+}

--- a/conversation/src/index.ts
+++ b/conversation/src/index.ts
@@ -3,6 +3,8 @@ export { ConversationValidationError } from './diagnostics.js';
 export * from './guards.js';
 export * from './inspection.js';
 export * from './json-preflight.js';
+export * from './rendering.js';
+export * from './runtime.js';
 export * from './schemas/index.js';
 export * from './scope.js';
 export * from './semantic-validation.js';

--- a/conversation/src/index.ts
+++ b/conversation/src/index.ts
@@ -1,0 +1,11 @@
+export * from './builders.js';
+export { ConversationValidationError } from './diagnostics.js';
+export * from './guards.js';
+export * from './inspection.js';
+export * from './json-preflight.js';
+export * from './schemas/index.js';
+export * from './scope.js';
+export * from './semantic-validation.js';
+export * from './serialization.js';
+export type * from './types.js';
+export * from './validation.js';

--- a/conversation/src/inspection.ts
+++ b/conversation/src/inspection.ts
@@ -1,0 +1,142 @@
+import type {
+    ConversationDocument,
+    ConversationInspection,
+    ConversationTurn,
+    Generation,
+    TurnKindCounts,
+} from './types.js';
+
+export interface ResolvedConversationTurn {
+    turn: ConversationTurn;
+    source: 'history' | 'compaction';
+    compaction_id?: string;
+    generation?: Generation;
+}
+
+function emptyKindCounts(): TurnKindCounts {
+    return { user: 0, agent: 0, tool: 0, program: 0 };
+}
+
+function findGeneration(document: ConversationDocument, turn: ConversationTurn): Generation | undefined {
+    if (turn.kind !== 'agent' || !('generation_id' in turn) || turn.generation_id === undefined) {
+        return undefined;
+    }
+    return Object.hasOwn(document.generations, turn.generation_id)
+        ? document.generations[turn.generation_id]
+        : undefined;
+}
+
+function indexConversationTurns(document: ConversationDocument): Map<string, ResolvedConversationTurn> {
+    const turns = new Map<string, ResolvedConversationTurn>();
+    for (const turn of document.turns) {
+        if (!turns.has(turn.id)) {
+            turns.set(turn.id, {
+                turn,
+                source: 'history',
+                generation: findGeneration(document, turn),
+            });
+        }
+    }
+    for (const compaction of Object.values(document.compactions)) {
+        for (const turn of compaction.replacement_turns) {
+            if (!turns.has(turn.id)) {
+                turns.set(turn.id, {
+                    turn,
+                    source: 'compaction',
+                    compaction_id: compaction.id,
+                    generation: findGeneration(document, turn),
+                });
+            }
+        }
+    }
+    return turns;
+}
+
+export function getConversationTurn(
+    document: ConversationDocument,
+    turnId: string,
+): ResolvedConversationTurn | undefined {
+    for (const turn of document.turns) {
+        if (turn.id === turnId) {
+            return {
+                turn,
+                source: 'history',
+                generation: findGeneration(document, turn),
+            };
+        }
+    }
+    for (const compaction of Object.values(document.compactions)) {
+        for (const turn of compaction.replacement_turns) {
+            if (turn.id === turnId) {
+                return {
+                    turn,
+                    source: 'compaction',
+                    compaction_id: compaction.id,
+                    generation: findGeneration(document, turn),
+                };
+            }
+        }
+    }
+    return undefined;
+}
+
+export function getPendingToolCallIds(document: ConversationDocument): string[] {
+    const resolved = new Set<string>();
+    for (const turn of document.turns) {
+        if (turn.kind === 'tool') {
+            resolved.add(turn.blocks[0].call_id);
+        }
+    }
+    for (const receipt of Object.values(document.execution_receipts)) {
+        resolved.add(receipt.call_id);
+    }
+
+    const pending: string[] = [];
+    const seen = new Set<string>();
+    for (const turn of document.turns) {
+        if (turn.kind !== 'agent') {
+            continue;
+        }
+        for (const block of turn.blocks) {
+            if (
+                block.type === 'tool_call' &&
+                block.executor === 'application' &&
+                !resolved.has(block.call_id) &&
+                !seen.has(block.call_id)
+            ) {
+                pending.push(block.call_id);
+                seen.add(block.call_id);
+            }
+        }
+    }
+    return pending;
+}
+
+export function inspectConversation(document: ConversationDocument): ConversationInspection {
+    const sourceTurnsByKind = emptyKindCounts();
+    for (const turn of document.turns) {
+        sourceTurnsByKind[turn.kind] += 1;
+    }
+
+    const turnsById = indexConversationTurns(document);
+    const contextTurns = new Map<string, ConversationTurn>();
+    for (const entry of document.context.entries) {
+        const resolved = turnsById.get(entry.turn_id);
+        if (resolved !== undefined && !contextTurns.has(entry.turn_id)) {
+            contextTurns.set(entry.turn_id, resolved.turn);
+        }
+    }
+    const contextTurnsByKind = emptyKindCounts();
+    for (const turn of contextTurns.values()) {
+        contextTurnsByKind[turn.kind] += 1;
+    }
+
+    return {
+        source_turn_count: document.turns.length,
+        context_turn_count: contextTurns.size,
+        source_turns_by_kind: sourceTurnsByKind,
+        context_turns_by_kind: contextTurnsByKind,
+        generation_count: Object.keys(document.generations).length,
+        pending_tool_call_ids: getPendingToolCallIds(document),
+    };
+}

--- a/conversation/src/json-preflight.ts
+++ b/conversation/src/json-preflight.ts
@@ -1,0 +1,480 @@
+import { boundConversationDiagnostic, diagnosticPointer } from './diagnostics.js';
+import type { JsonPreflightDiagnostic } from './types.js';
+
+export interface JsonInputLimits {
+    max_depth: number;
+    max_nodes: number;
+    max_bytes: number;
+    max_string_bytes: number;
+    max_array_length: number;
+    max_object_properties: number;
+    max_diagnostics: number;
+}
+
+export const DEFAULT_JSON_INPUT_LIMITS: Readonly<JsonInputLimits> = Object.freeze({
+    max_depth: 128,
+    max_nodes: 250_000,
+    max_bytes: 32 * 1024 * 1024,
+    max_string_bytes: 32 * 1024 * 1024,
+    max_array_length: 100_000,
+    max_object_properties: 100_000,
+    max_diagnostics: 32,
+});
+
+export interface JsonPreflightSuccess {
+    success: true;
+    diagnostics: [];
+    bytes: number;
+    nodes: number;
+}
+
+export interface JsonPreflightFailure {
+    success: false;
+    diagnostics: JsonPreflightDiagnostic[];
+    bytes: number;
+    nodes: number;
+}
+
+export type JsonPreflightResult = JsonPreflightSuccess | JsonPreflightFailure;
+
+type PathSegment = string | number;
+
+interface EnterFrame {
+    type: 'enter';
+    value: unknown;
+    path: PathSegment[];
+    depth: number;
+}
+
+interface ExitFrame {
+    type: 'exit';
+    value: object;
+}
+
+interface ArrayChildFrame {
+    type: 'array_child';
+    value: unknown[];
+    index: number;
+    path: PathSegment[];
+    depth: number;
+}
+
+interface ObjectChildFrame {
+    type: 'object_child';
+    value: Record<string, unknown>;
+    keys: string[];
+    index: number;
+    path: PathSegment[];
+    depth: number;
+}
+
+type TraversalFrame = EnterFrame | ExitFrame | ArrayChildFrame | ObjectChildFrame;
+
+function toPointer(path: PathSegment[]): string {
+    return diagnosticPointer(path);
+}
+
+function serializedStringBytes(value: string, stopAfter: number): number {
+    if (value.length + 2 > stopAfter) {
+        return stopAfter + 1;
+    }
+    let bytes = 2;
+    for (let index = 0; index < value.length; index += 1) {
+        const codeUnit = value.charCodeAt(index);
+        if (codeUnit === 0x22 || codeUnit === 0x5c || codeUnit === 0x08 || codeUnit === 0x09) {
+            bytes += 2;
+        } else if (codeUnit === 0x0a || codeUnit === 0x0c || codeUnit === 0x0d) {
+            bytes += 2;
+        } else if (codeUnit <= 0x1f) {
+            bytes += 6;
+        } else if (codeUnit <= 0x7f) {
+            bytes += 1;
+        } else if (codeUnit <= 0x7ff) {
+            bytes += 2;
+        } else if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+            const next = value.charCodeAt(index + 1);
+            if (next >= 0xdc00 && next <= 0xdfff) {
+                bytes += 4;
+                index += 1;
+            } else {
+                bytes += 6;
+            }
+        } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+            bytes += 6;
+        } else {
+            bytes += 3;
+        }
+        if (bytes > stopAfter) {
+            return stopAfter + 1;
+        }
+    }
+    return bytes;
+}
+
+function scalarBytes(value: number | boolean | null): number {
+    if (value === null) {
+        return 4;
+    }
+    if (typeof value === 'boolean') {
+        return value ? 4 : 5;
+    }
+    return String(value).length;
+}
+
+function isArrayIndex(key: string, length: number): boolean {
+    if (key === '') {
+        return false;
+    }
+    const index = Number(key);
+    return Number.isSafeInteger(index) && index >= 0 && index < length && String(index) === key;
+}
+
+function resolveLimits(overrides: Partial<JsonInputLimits>): JsonInputLimits {
+    const limits = { ...DEFAULT_JSON_INPUT_LIMITS, ...overrides };
+    for (const [name, value] of Object.entries(limits)) {
+        const allowsZero = name === 'max_depth';
+        if (!Number.isSafeInteger(value) || value < (allowsZero ? 0 : 1)) {
+            throw new RangeError(`${name} must be a ${allowsZero ? 'nonnegative' : 'positive'} safe integer`);
+        }
+    }
+    return limits;
+}
+
+export function preflightJsonInput(input: unknown, limitOverrides: Partial<JsonInputLimits> = {}): JsonPreflightResult {
+    const limits = resolveLimits(limitOverrides);
+    const diagnostics: JsonPreflightDiagnostic[] = [];
+    const activeObjects = new WeakMap<object, string>();
+    const stack: TraversalFrame[] = [{ type: 'enter', value: input, path: [], depth: 0 }];
+    let bytes = 0;
+    let nodes = 0;
+    let stopped = false;
+
+    const addDiagnostic = (diagnostic: JsonPreflightDiagnostic): void => {
+        if (diagnostics.length >= limits.max_diagnostics) {
+            stopped = true;
+            return;
+        }
+        diagnostics.push(boundConversationDiagnostic(diagnostic));
+        if (diagnostics.length >= limits.max_diagnostics) {
+            stopped = true;
+        }
+    };
+
+    const addBytes = (added: number, path: PathSegment[]): boolean => {
+        const exceedsLimit = added > limits.max_bytes - bytes;
+        bytes = Math.min(Number.MAX_SAFE_INTEGER, bytes + added);
+        if (!exceedsLimit) {
+            return true;
+        }
+        addDiagnostic({
+            code: 'JSON_MAX_BYTES',
+            stage: 'preflight',
+            path: toPointer(path),
+            message: 'Serialized JSON size exceeds the configured limit',
+            limit: limits.max_bytes,
+            observed: bytes,
+        });
+        stopped = true;
+        return false;
+    };
+
+    while (stack.length > 0 && !stopped) {
+        const frame = stack.pop();
+        if (frame === undefined) {
+            break;
+        }
+        if (frame.type === 'exit') {
+            activeObjects.delete(frame.value);
+            continue;
+        }
+        if (frame.type === 'array_child') {
+            if (frame.index >= frame.value.length) {
+                continue;
+            }
+            stack.push({ ...frame, index: frame.index + 1 });
+            const descriptor = Object.getOwnPropertyDescriptor(frame.value, String(frame.index));
+            const childPath = [...frame.path, frame.index];
+            if (descriptor === undefined) {
+                addDiagnostic({
+                    code: 'JSON_SPARSE_ARRAY',
+                    stage: 'preflight',
+                    path: toPointer(childPath),
+                    message: 'JSON arrays cannot contain holes',
+                });
+            } else if ('get' in descriptor || 'set' in descriptor) {
+                addDiagnostic({
+                    code: 'JSON_ACCESSOR_PROPERTY',
+                    stage: 'preflight',
+                    path: toPointer(childPath),
+                    message: 'JSON input cannot contain accessor properties',
+                });
+            } else if (!descriptor.enumerable) {
+                addDiagnostic({
+                    code: 'JSON_NON_ENUMERABLE_PROPERTY',
+                    stage: 'preflight',
+                    path: toPointer(childPath),
+                    message: 'JSON input cannot contain non-enumerable data properties',
+                });
+            } else {
+                stack.push({ type: 'enter', value: descriptor.value, path: childPath, depth: frame.depth + 1 });
+            }
+            continue;
+        }
+        if (frame.type === 'object_child') {
+            if (frame.index >= frame.keys.length) {
+                continue;
+            }
+            stack.push({ ...frame, index: frame.index + 1 });
+            const key = frame.keys[frame.index];
+            const childPath = [...frame.path, key];
+            const remainingBytes = Math.max(0, limits.max_bytes - bytes);
+            const keyBytes = serializedStringBytes(key, Math.min(limits.max_string_bytes, remainingBytes));
+            if (keyBytes > limits.max_string_bytes) {
+                addDiagnostic({
+                    code: 'JSON_MAX_STRING_BYTES',
+                    stage: 'preflight',
+                    path: toPointer(childPath),
+                    message: 'Serialized JSON property name exceeds the configured per-string limit',
+                    limit: limits.max_string_bytes,
+                    observed: keyBytes,
+                });
+            }
+            if (stopped || !addBytes(keyBytes, childPath)) {
+                continue;
+            }
+            const descriptor = Object.getOwnPropertyDescriptor(frame.value, key);
+            if (descriptor === undefined) {
+                continue;
+            }
+            if ('get' in descriptor || 'set' in descriptor) {
+                addDiagnostic({
+                    code: 'JSON_ACCESSOR_PROPERTY',
+                    stage: 'preflight',
+                    path: toPointer(childPath),
+                    message: 'JSON input cannot contain accessor properties',
+                });
+            } else if (!descriptor.enumerable) {
+                addDiagnostic({
+                    code: 'JSON_NON_ENUMERABLE_PROPERTY',
+                    stage: 'preflight',
+                    path: toPointer(childPath),
+                    message: 'JSON input cannot contain non-enumerable data properties',
+                });
+            } else {
+                stack.push({ type: 'enter', value: descriptor.value, path: childPath, depth: frame.depth + 1 });
+            }
+            continue;
+        }
+
+        const { value, path, depth } = frame;
+        const pointer = toPointer(path);
+        nodes += 1;
+        if (nodes > limits.max_nodes) {
+            addDiagnostic({
+                code: 'JSON_MAX_NODES',
+                stage: 'preflight',
+                path: pointer,
+                message: 'JSON node count exceeds the configured limit',
+                limit: limits.max_nodes,
+                observed: nodes,
+            });
+            stopped = true;
+            continue;
+        }
+        if (depth > limits.max_depth) {
+            addDiagnostic({
+                code: 'JSON_MAX_DEPTH',
+                stage: 'preflight',
+                path: pointer,
+                message: 'JSON nesting depth exceeds the configured limit',
+                limit: limits.max_depth,
+                observed: depth,
+            });
+            continue;
+        }
+
+        if (value === null || typeof value === 'boolean') {
+            addBytes(scalarBytes(value), path);
+            continue;
+        }
+        if (typeof value === 'string') {
+            const remainingBytes = Math.max(0, limits.max_bytes - bytes);
+            const valueBytes = serializedStringBytes(value, Math.min(limits.max_string_bytes, remainingBytes));
+            if (valueBytes > limits.max_string_bytes) {
+                addDiagnostic({
+                    code: 'JSON_MAX_STRING_BYTES',
+                    stage: 'preflight',
+                    path: pointer,
+                    message: 'Serialized JSON string exceeds the configured per-string limit',
+                    limit: limits.max_string_bytes,
+                    observed: valueBytes,
+                });
+            }
+            if (!stopped) {
+                addBytes(valueBytes, path);
+            }
+            continue;
+        }
+        if (typeof value === 'number') {
+            if (!Number.isFinite(value)) {
+                addDiagnostic({
+                    code: 'JSON_NON_FINITE_NUMBER',
+                    stage: 'preflight',
+                    path: pointer,
+                    message: 'JSON numbers must be finite',
+                });
+            } else if (Object.is(value, -0)) {
+                addDiagnostic({
+                    code: 'JSON_NEGATIVE_ZERO',
+                    stage: 'preflight',
+                    path: pointer,
+                    message: 'Negative zero is rejected because JSON serialization normalizes it to zero',
+                });
+            } else {
+                addBytes(scalarBytes(value), path);
+            }
+            continue;
+        }
+        if (typeof value !== 'object') {
+            addDiagnostic({
+                code: 'JSON_UNSUPPORTED_TYPE',
+                stage: 'preflight',
+                path: pointer,
+                message: `JSON does not support values of type ${typeof value}`,
+            });
+            continue;
+        }
+
+        const priorPath = activeObjects.get(value);
+        if (priorPath !== undefined) {
+            addDiagnostic({
+                code: 'JSON_CYCLE',
+                stage: 'preflight',
+                path: pointer,
+                related_paths: [priorPath],
+                message: 'JSON input contains a cycle',
+            });
+            continue;
+        }
+
+        const isArray = Array.isArray(value);
+        const prototype = Object.getPrototypeOf(value);
+        if (
+            (isArray && prototype !== Array.prototype) ||
+            (!isArray && prototype !== Object.prototype && prototype !== null)
+        ) {
+            addDiagnostic({
+                code: 'JSON_NON_PLAIN_OBJECT',
+                stage: 'preflight',
+                path: pointer,
+                message: `JSON ${isArray ? 'arrays' : 'objects'} must have a plain prototype`,
+            });
+            continue;
+        }
+
+        if (isArray && value.length > limits.max_array_length) {
+            addDiagnostic({
+                code: 'JSON_MAX_ARRAY_LENGTH',
+                stage: 'preflight',
+                path: pointer,
+                message: 'JSON array length exceeds the configured limit',
+                limit: limits.max_array_length,
+                observed: value.length,
+            });
+            continue;
+        }
+
+        const ownKeys = Reflect.ownKeys(value);
+        const maximumKeys = isArray ? limits.max_array_length + 1 : limits.max_object_properties;
+        if (ownKeys.length > maximumKeys) {
+            addDiagnostic({
+                code: isArray ? 'JSON_MAX_ARRAY_LENGTH' : 'JSON_MAX_OBJECT_PROPERTIES',
+                stage: 'preflight',
+                path: pointer,
+                message: `JSON ${isArray ? 'array' : 'object'} own-key count exceeds the configured limit`,
+                limit: isArray ? limits.max_array_length : limits.max_object_properties,
+                observed: ownKeys.length - (isArray ? 1 : 0),
+            });
+            continue;
+        }
+
+        const dataKeys: string[] = [];
+        for (const key of ownKeys) {
+            if (stopped || (isArray && key === 'length')) {
+                continue;
+            }
+            if (typeof key === 'symbol') {
+                addDiagnostic({
+                    code: 'JSON_SYMBOL_KEY',
+                    stage: 'preflight',
+                    path: pointer,
+                    message: 'JSON objects and arrays cannot contain symbol keys',
+                });
+            } else if (key === '__proto__') {
+                addDiagnostic({
+                    code: 'JSON_RESERVED_PROPERTY_KEY',
+                    stage: 'preflight',
+                    path: toPointer([...path, key]),
+                    message:
+                        'The experimental revision rejects __proto__ because Zod 4 does not validate that record key',
+                });
+            } else {
+                dataKeys.push(key);
+            }
+        }
+        if (stopped) {
+            continue;
+        }
+
+        if (isArray) {
+            if (dataKeys.some((key) => !isArrayIndex(key, value.length))) {
+                addDiagnostic({
+                    code: 'JSON_ARRAY_PROPERTY',
+                    stage: 'preflight',
+                    path: pointer,
+                    message: 'JSON arrays cannot contain named own properties',
+                });
+                continue;
+            }
+            if (dataKeys.length !== value.length) {
+                addDiagnostic({
+                    code: 'JSON_SPARSE_ARRAY',
+                    stage: 'preflight',
+                    path: pointer,
+                    message: 'JSON arrays cannot contain holes',
+                });
+                continue;
+            }
+            if (!addBytes(2 + Math.max(0, value.length - 1), path)) {
+                continue;
+            }
+            activeObjects.set(value, pointer);
+            stack.push({ type: 'exit', value });
+            if (value.length > 0) {
+                stack.push({ type: 'array_child', value, index: 0, path, depth });
+            }
+            continue;
+        }
+
+        if (!addBytes(2 + Math.max(0, dataKeys.length - 1) + dataKeys.length, path)) {
+            continue;
+        }
+        activeObjects.set(value, pointer);
+        stack.push({ type: 'exit', value });
+        if (dataKeys.length > 0) {
+            stack.push({
+                type: 'object_child',
+                value: value as Record<string, unknown>,
+                keys: dataKeys,
+                index: 0,
+                path,
+                depth,
+            });
+        }
+    }
+
+    if (diagnostics.length === 0) {
+        return { success: true, diagnostics: [], bytes, nodes };
+    }
+    return { success: false, diagnostics, bytes, nodes };
+}

--- a/conversation/src/json-schema.ts
+++ b/conversation/src/json-schema.ts
@@ -1,0 +1,71 @@
+import type { z } from 'zod';
+import {
+    ContentBlockSchema,
+    ConversationDiagnosticSchema,
+    ConversationDocumentSchema,
+    ConversationInspectionSchema,
+    ConversationTurnSchema,
+    GenerationSchema,
+} from './schemas/index.js';
+import { CONVERSATION_EXPERIMENTAL_REVISION } from './schemas/primitives.js';
+
+export type GeneratedConversationJsonSchema = Readonly<Record<string, unknown>>;
+
+const JSON_SCHEMA_OPTIONS = {
+    target: 'draft-2020-12',
+    io: 'input',
+    cycles: 'ref',
+    reused: 'ref',
+    unrepresentable: 'throw',
+} as const;
+
+function sortJsonValue<T>(value: T): T {
+    if (Array.isArray(value)) {
+        return value.map((item) => sortJsonValue(item)) as T;
+    }
+    if (value !== null && typeof value === 'object') {
+        const sorted = Object.fromEntries(
+            Object.entries(value)
+                .sort(([first], [second]) => (first < second ? -1 : first > second ? 1 : 0))
+                .map(([key, item]) => [key, sortJsonValue(item)]),
+        );
+        return sorted as T;
+    }
+    return value;
+}
+
+function deepFreeze<T>(value: T): Readonly<T> {
+    if (value !== null && typeof value === 'object' && !Object.isFrozen(value)) {
+        for (const child of Object.values(value)) {
+            deepFreeze(child);
+        }
+        Object.freeze(value);
+    }
+    return value;
+}
+
+function emitJsonSchema(schema: z.ZodType, name: string): GeneratedConversationJsonSchema {
+    const generated = schema.toJSONSchema(JSON_SCHEMA_OPTIONS);
+    return deepFreeze(
+        sortJsonValue({
+            ...generated,
+            $id: `urn:llumiverse:conversation:${CONVERSATION_EXPERIMENTAL_REVISION}:${name}`,
+        }),
+    );
+}
+
+export const ConversationDocumentJsonSchema = emitJsonSchema(ConversationDocumentSchema, 'document');
+export const ConversationTurnJsonSchema = emitJsonSchema(ConversationTurnSchema, 'turn');
+export const ConversationContentBlockJsonSchema = emitJsonSchema(ContentBlockSchema, 'content-block');
+export const ConversationGenerationJsonSchema = emitJsonSchema(GenerationSchema, 'generation');
+export const ConversationDiagnosticJsonSchema = emitJsonSchema(ConversationDiagnosticSchema, 'diagnostic');
+export const ConversationInspectionJsonSchema = emitJsonSchema(ConversationInspectionSchema, 'inspection');
+
+export const CONVERSATION_JSON_SCHEMAS = Object.freeze({
+    content_block: ConversationContentBlockJsonSchema,
+    diagnostic: ConversationDiagnosticJsonSchema,
+    document: ConversationDocumentJsonSchema,
+    generation: ConversationGenerationJsonSchema,
+    inspection: ConversationInspectionJsonSchema,
+    turn: ConversationTurnJsonSchema,
+});

--- a/conversation/src/json-schema.ts
+++ b/conversation/src/json-schema.ts
@@ -1,10 +1,14 @@
 import type { z } from 'zod';
 import {
+    AppendConversationRecordsOptionsSchema,
+    AppendConversationRecordsResultSchema,
     ContentBlockSchema,
     ConversationDiagnosticSchema,
     ConversationDocumentSchema,
     ConversationInspectionSchema,
+    ConversationRecordBatchSchema,
     ConversationTurnSchema,
+    DecodedConversationResponseSchema,
     GenerationSchema,
 } from './schemas/index.js';
 import { CONVERSATION_EXPERIMENTAL_REVISION } from './schemas/primitives.js';
@@ -60,12 +64,29 @@ export const ConversationContentBlockJsonSchema = emitJsonSchema(ContentBlockSch
 export const ConversationGenerationJsonSchema = emitJsonSchema(GenerationSchema, 'generation');
 export const ConversationDiagnosticJsonSchema = emitJsonSchema(ConversationDiagnosticSchema, 'diagnostic');
 export const ConversationInspectionJsonSchema = emitJsonSchema(ConversationInspectionSchema, 'inspection');
+export const ConversationRecordBatchJsonSchema = emitJsonSchema(ConversationRecordBatchSchema, 'record-batch');
+export const AppendConversationRecordsOptionsJsonSchema = emitJsonSchema(
+    AppendConversationRecordsOptionsSchema,
+    'append-options',
+);
+export const AppendConversationRecordsResultJsonSchema = emitJsonSchema(
+    AppendConversationRecordsResultSchema,
+    'append-result',
+);
+export const DecodedConversationResponseJsonSchema = emitJsonSchema(
+    DecodedConversationResponseSchema,
+    'decoded-response',
+);
 
 export const CONVERSATION_JSON_SCHEMAS = Object.freeze({
+    append_options: AppendConversationRecordsOptionsJsonSchema,
+    append_result: AppendConversationRecordsResultJsonSchema,
     content_block: ConversationContentBlockJsonSchema,
     diagnostic: ConversationDiagnosticJsonSchema,
+    decoded_response: DecodedConversationResponseJsonSchema,
     document: ConversationDocumentJsonSchema,
     generation: ConversationGenerationJsonSchema,
     inspection: ConversationInspectionJsonSchema,
+    record_batch: ConversationRecordBatchJsonSchema,
     turn: ConversationTurnJsonSchema,
 });

--- a/conversation/src/rendering.ts
+++ b/conversation/src/rendering.ts
@@ -1,0 +1,41 @@
+import type { ContentBlock, ConversationDocument } from './types.js';
+
+/** Human-readable projection; never hydrates assets or exposes opaque replay bytes. */
+export function renderContentBlockText(block: ContentBlock): string {
+    switch (block.type) {
+        case 'text':
+        case 'reasoning':
+            return block.text;
+        case 'json':
+            return JSON.stringify(block.value);
+        case 'image':
+            return '[Image]';
+        case 'document':
+            return '[Document]';
+        case 'audio':
+            return '[Audio]';
+        case 'video':
+            return '[Video]';
+        case 'tool_call':
+            return `[TOOL CALL]: ${block.tool_name}(...)`;
+        case 'tool_result':
+            return `[TOOL RESULT]: ${block.call_id} → ${block.content.map(renderContentBlockText).filter(Boolean).join(' ')}`;
+        case 'external_reference':
+            return block.preview ?? `[External content: ${block.description}]`;
+        case 'native_replay':
+        case 'extension':
+            return '';
+    }
+}
+
+/** Renders source history, preserving order independently of the current model-context selection. */
+export function renderConversationText(document: ConversationDocument): string {
+    const lines: string[] = [];
+    for (const turn of document.turns) {
+        const text = turn.blocks.map(renderContentBlockText).filter(Boolean).join(' ');
+        if (!text) continue;
+        const role = turn.kind === 'agent' ? 'ASSISTANT' : turn.kind.toUpperCase();
+        lines.push(`[${role}]: ${text}`);
+    }
+    return lines.join('\n\n');
+}

--- a/conversation/src/runtime.ts
+++ b/conversation/src/runtime.ts
@@ -1,0 +1,384 @@
+import { ConversationValidationError } from './diagnostics.js';
+import { preflightJsonInput } from './json-preflight.js';
+import {
+    AppendConversationRecordsOptionsSchema,
+    AppendConversationRecordsResultSchema,
+    ConversationRecordBatchSchema,
+    DecodedConversationResponseSchema,
+} from './schemas/index.js';
+import type {
+    AppendConversationRecordsOptions,
+    AppendConversationRecordsResult,
+    ConversationDiagnostic,
+    ConversationDocument,
+    ConversationRecordBatch,
+    DecodedConversationResponse,
+    OperationReceipt,
+    RequestReceipt,
+} from './types.js';
+import { parseConversationDocument } from './validation.js';
+
+export interface PreparedConversationRequest<NativePayload> {
+    document: ConversationDocument;
+    payload: NativePayload;
+    receipt: RequestReceipt;
+    generation_id: string;
+    response_turn_id: string;
+    diagnostics: ConversationDiagnostic[];
+}
+
+export interface NativeConversationAdapter<
+    NativeHistory,
+    NativePayload,
+    NativeResponse,
+    PrepareOptions,
+    DecodeOptions,
+> {
+    readonly protocol: string;
+    readonly adapter_version: string;
+    importConversation(history: NativeHistory, options: PrepareOptions): Promise<ConversationDocument>;
+    prepare(
+        conversation: ConversationDocument | NativeHistory | undefined | null,
+        options: PrepareOptions,
+    ): Promise<PreparedConversationRequest<NativePayload>>;
+    decodeResponse(
+        response: NativeResponse,
+        prepared: PreparedConversationRequest<NativePayload>,
+        options: DecodeOptions,
+    ): Promise<DecodedConversationResponse>;
+}
+
+function checkedNextRevision(revision: number): number {
+    const next = revision + 1;
+    if (!Number.isSafeInteger(next)) {
+        throw new RangeError('Conversation revision exceeds Number.MAX_SAFE_INTEGER');
+    }
+    return next;
+}
+
+function recordById<T extends { id: string }>(values: readonly T[] | undefined): Record<string, T> {
+    const entries: Array<[string, T]> = [];
+    const ids = new Set<string>();
+    for (const value of values ?? []) {
+        if (ids.has(value.id)) throw new Error(`Conversation batch contains duplicate record ID ${value.id}`);
+        ids.add(value.id);
+        entries.push([value.id, value]);
+    }
+    return Object.fromEntries(entries);
+}
+
+function acceptedIds<T extends { id: string }>(values: readonly T[] | undefined): string[] {
+    return (values ?? []).map((value) => value.id);
+}
+
+function assertAcceptedIds(
+    kind: string,
+    incoming: readonly string[],
+    accepted: readonly string[] | undefined,
+    retained: (id: string) => boolean,
+): string[] {
+    const authoritative = accepted === undefined ? [...incoming] : [...accepted];
+    if (stableJson(incoming) !== stableJson(authoritative)) {
+        throw new Error(`Conversation operation retry does not identify its accepted ${kind}`);
+    }
+    const missing = authoritative.find((id) => !retained(id));
+    if (missing !== undefined)
+        throw new Error(`Conversation operation retry cannot resolve accepted ${kind} ${missing}`);
+    return authoritative;
+}
+
+function retryComparableRecord(value: unknown): unknown {
+    if (value === null || typeof value !== 'object') return value;
+    if (Array.isArray(value)) return value.map(retryComparableRecord);
+    const comparable: Record<string, unknown> = {};
+    for (const [key, child] of Object.entries(value)) {
+        // Retrying an accepted input operation may allocate a fresh host attempt and timestamps.
+        // Those observations are not semantic prompt content. All other persisted fields remain
+        // byte-for-byte accountable to the accepted records.
+        if (key === 'timestamps' || key === 'created_at' || key === 'recorded_at') continue;
+        comparable[key] = retryComparableRecord(child);
+    }
+    return comparable;
+}
+
+function assertAcceptedRecords<T extends { id: string }>(
+    kind: string,
+    incoming: readonly T[] | undefined,
+    retained: (id: string) => T | undefined,
+): void {
+    for (const record of incoming ?? []) {
+        const accepted = retained(record.id);
+        if (
+            accepted === undefined ||
+            stableJson(retryComparableRecord(record)) !== stableJson(retryComparableRecord(accepted))
+        ) {
+            throw new Error(`Conversation operation retry changes accepted ${kind} ${record.id}`);
+        }
+    }
+}
+
+function assertExactRetry(
+    document: ConversationDocument,
+    batch: ConversationRecordBatch,
+    receipt: OperationReceipt,
+): { turn_ids: string[]; generation_ids: string[] } {
+    const turnIds = assertAcceptedIds('turns', acceptedIds(batch.turns), receipt.accepted_turn_ids, (id) =>
+        document.turns.some((turn) => turn.id === id),
+    );
+    const generationIds = assertAcceptedIds(
+        'generations',
+        acceptedIds(batch.generations),
+        receipt.accepted_generation_ids,
+        (id) => Object.hasOwn(document.generations, id),
+    );
+    assertAcceptedIds('assets', acceptedIds(batch.assets), receipt.accepted_asset_ids, (id) =>
+        Object.hasOwn(document.assets, id),
+    );
+    assertAcceptedIds(
+        'tool definitions',
+        acceptedIds(batch.tool_definitions),
+        receipt.accepted_tool_definition_ids,
+        (id) => Object.hasOwn(document.tool_definitions, id),
+    );
+    assertAcceptedIds(
+        'execution receipts',
+        acceptedIds(batch.execution_receipts),
+        receipt.accepted_execution_receipt_ids,
+        (id) => Object.hasOwn(document.execution_receipts, id),
+    );
+    assertAcceptedIds('context entries', acceptedIds(batch.context_entries), receipt.accepted_context_entry_ids, (id) =>
+        document.context.entries.some((entry) => entry.id === id),
+    );
+    assertAcceptedRecords('turn', batch.turns, (id) => document.turns.find((turn) => turn.id === id));
+    assertAcceptedRecords('generation', batch.generations, (id) =>
+        Object.hasOwn(document.generations, id) ? document.generations[id] : undefined,
+    );
+    assertAcceptedRecords('asset', batch.assets, (id) =>
+        Object.hasOwn(document.assets, id) ? document.assets[id] : undefined,
+    );
+    assertAcceptedRecords('tool definition', batch.tool_definitions, (id) =>
+        Object.hasOwn(document.tool_definitions, id) ? document.tool_definitions[id] : undefined,
+    );
+    assertAcceptedRecords('execution receipt', batch.execution_receipts, (id) =>
+        Object.hasOwn(document.execution_receipts, id) ? document.execution_receipts[id] : undefined,
+    );
+    assertAcceptedRecords('context entry', batch.context_entries, (id) =>
+        document.context.entries.find((entry) => entry.id === id),
+    );
+    return { turn_ids: turnIds, generation_ids: generationIds };
+}
+
+/**
+ * Append already-decoded canonical records to a materialized document.
+ *
+ * This is the narrow ingestion primitive used by native adapters. It does not edit, compact, or
+ * process existing content. Operation receipts make exact retry delivery idempotent; conflicting
+ * payloads under the same operation identity are rejected.
+ */
+export function appendConversationRecords(
+    input: ConversationDocument,
+    batchInput: ConversationRecordBatch,
+    optionsInput: AppendConversationRecordsOptions,
+): AppendConversationRecordsResult {
+    const batchPreflight = preflightJsonInput(batchInput);
+    if (!batchPreflight.success) {
+        throw new ConversationValidationError(
+            'Conversation record batch failed JSON preflight',
+            batchPreflight.diagnostics,
+        );
+    }
+    const optionsPreflight = preflightJsonInput(optionsInput);
+    if (!optionsPreflight.success) {
+        throw new ConversationValidationError(
+            'Conversation append options failed JSON preflight',
+            optionsPreflight.diagnostics,
+        );
+    }
+    const batch = ConversationRecordBatchSchema.parse(batchInput);
+    const options = AppendConversationRecordsOptionsSchema.parse(optionsInput);
+    const document = parseConversationDocument(input);
+    const priorReceipt = Object.hasOwn(document.operation_receipts, options.operation_id)
+        ? document.operation_receipts[options.operation_id]
+        : undefined;
+    if (priorReceipt !== undefined) {
+        if (priorReceipt.payload_fingerprint !== options.payload_fingerprint) {
+            throw new Error(`Conversation operation ${options.operation_id} was already used with a different payload`);
+        }
+        const accepted = assertExactRetry(document, batch, priorReceipt);
+        return AppendConversationRecordsResultSchema.parse({
+            document,
+            applied: false,
+            accepted_turn_ids: accepted.turn_ids,
+            accepted_generation_ids: accepted.generation_ids,
+        });
+    }
+    if (options.expected_revision !== document.revision) {
+        throw new Error(
+            `Conversation revision conflict: expected ${options.expected_revision}, received ${document.revision}`,
+        );
+    }
+
+    const generationRecords = recordById(batch.generations);
+    const assetRecords = recordById(batch.assets);
+    const definitionRecords = recordById(batch.tool_definitions);
+    const executionRecords = recordById(batch.execution_receipts);
+    for (const id of Object.keys(generationRecords)) {
+        if (Object.hasOwn(document.generations, id)) throw new Error(`Generation ${id} already exists`);
+    }
+    for (const id of Object.keys(assetRecords)) {
+        if (Object.hasOwn(document.assets, id)) throw new Error(`Asset ${id} already exists`);
+    }
+    for (const id of Object.keys(executionRecords)) {
+        if (Object.hasOwn(document.execution_receipts, id)) throw new Error(`Execution receipt ${id} already exists`);
+    }
+    for (const [id, definition] of Object.entries(definitionRecords)) {
+        const retained = Object.hasOwn(document.tool_definitions, id) ? document.tool_definitions[id] : undefined;
+        if (retained !== undefined && stableJson(retained) !== stableJson(definition)) {
+            throw new Error(`Tool definition ${id} conflicts with the retained definition`);
+        }
+    }
+
+    const resultRevision = checkedNextRevision(document.revision);
+    const operationReceipt = {
+        id: options.operation_id,
+        conversation_id: document.id,
+        payload_fingerprint: options.payload_fingerprint,
+        base_revision: document.revision,
+        result_revision: resultRevision,
+        recorded_at: options.recorded_at,
+        accepted_turn_ids: acceptedIds(batch.turns),
+        accepted_generation_ids: acceptedIds(batch.generations),
+        accepted_asset_ids: acceptedIds(batch.assets),
+        accepted_tool_definition_ids: acceptedIds(batch.tool_definitions),
+        accepted_execution_receipt_ids: acceptedIds(batch.execution_receipts),
+        accepted_context_entry_ids: acceptedIds(batch.context_entries),
+    } as const;
+
+    const updated = {
+        ...document,
+        revision: resultRevision,
+        updated_at: options.recorded_at,
+        turns: [...document.turns, ...(batch.turns ?? [])],
+        generations: { ...document.generations, ...generationRecords },
+        operation_receipts: {
+            ...document.operation_receipts,
+            [operationReceipt.id]: operationReceipt,
+        },
+        execution_receipts: {
+            ...document.execution_receipts,
+            ...executionRecords,
+        },
+        assets: { ...document.assets, ...assetRecords },
+        tool_definitions: { ...document.tool_definitions, ...definitionRecords },
+        context: {
+            ...document.context,
+            revision: resultRevision,
+            entries: [...document.context.entries, ...(batch.context_entries ?? [])],
+            active_tool_definition_ids:
+                batch.active_tool_definition_ids === undefined
+                    ? document.context.active_tool_definition_ids
+                    : [...batch.active_tool_definition_ids],
+        },
+    };
+
+    return AppendConversationRecordsResultSchema.parse({
+        document: parseConversationDocument(updated),
+        applied: true,
+        accepted_turn_ids: acceptedIds(batch.turns),
+        accepted_generation_ids: acceptedIds(batch.generations),
+    });
+}
+
+export function appendDecodedConversationResponse<NativePayload>(
+    prepared: PreparedConversationRequest<NativePayload>,
+    decodedInput: DecodedConversationResponse,
+    optionsInput: Omit<AppendConversationRecordsOptions, 'expected_revision' | 'payload_fingerprint'>,
+): AppendConversationRecordsResult {
+    const optionsPreflight = preflightJsonInput(optionsInput);
+    if (!optionsPreflight.success) {
+        throw new ConversationValidationError(
+            'Conversation response append options failed JSON preflight',
+            optionsPreflight.diagnostics,
+        );
+    }
+    const decodedPreflight = preflightJsonInput(decodedInput);
+    if (!decodedPreflight.success) {
+        throw new ConversationValidationError(
+            'Decoded conversation response failed JSON preflight',
+            decodedPreflight.diagnostics,
+        );
+    }
+    const decoded = DecodedConversationResponseSchema.parse(decodedInput);
+    const options = AppendConversationRecordsOptionsSchema.parse({
+        ...optionsInput,
+        expected_revision: prepared.document.revision,
+        payload_fingerprint: decoded.payload_fingerprint,
+    });
+    if (
+        decoded.generation.id !== prepared.generation_id ||
+        decoded.generation.request_id !== prepared.receipt.request_id ||
+        decoded.generation.attempt_id !== prepared.receipt.attempt_id ||
+        decoded.generation.source.conversation_id !== prepared.receipt.source.conversation_id ||
+        decoded.generation.source.revision !== prepared.receipt.source.revision ||
+        decoded.generation.requested_model !== prepared.receipt.target.model ||
+        decoded.generation.provider !== prepared.receipt.target.provider ||
+        decoded.generation.protocol !== prepared.receipt.target.protocol ||
+        decoded.generation.adapter_version !== prepared.receipt.target.adapter_version ||
+        stableJson(decoded.generation.request_receipt) !== stableJson(prepared.receipt)
+    ) {
+        throw new Error('Decoded generation request receipt does not match the prepared request');
+    }
+    if (
+        decoded.turns.length !== 1 ||
+        decoded.turns[0].id !== prepared.response_turn_id ||
+        decoded.turns.some(
+            (turn) =>
+                turn.kind !== 'agent' || !('generation_id' in turn) || turn.generation_id !== prepared.generation_id,
+        )
+    ) {
+        throw new Error('Decoded response turns do not match the prepared response identity');
+    }
+    const batch: ConversationRecordBatch = {
+        turns: decoded.turns,
+        generations: [decoded.generation],
+        context_entries: decoded.turns.map((turn, index) => ({
+            id: `${options.operation_id}:context:${index}`,
+            type: 'source_turn' as const,
+            turn_id: turn.id,
+        })),
+        ...(decoded.assets === undefined ? {} : { assets: decoded.assets }),
+        ...(decoded.execution_receipts === undefined ? {} : { execution_receipts: decoded.execution_receipts }),
+    };
+    return appendConversationRecords(prepared.document, batch, options);
+}
+
+function stableJson(value: unknown): string {
+    if (value === null || typeof value !== 'object') {
+        return JSON.stringify(value);
+    }
+    if (Array.isArray(value)) {
+        return `[${value.map(stableJson).join(',')}]`;
+    }
+    return `{${Object.keys(value as object)
+        .sort()
+        .map((key) => `${JSON.stringify(key)}:${stableJson((value as Record<string, unknown>)[key])}`)
+        .join(',')}}`;
+}
+
+/** Produce a browser-safe SHA-256 fingerprint for JSON-safe canonical or native data. */
+export async function fingerprintJson(value: unknown): Promise<string> {
+    const preflight = preflightJsonInput(value);
+    if (!preflight.success) {
+        throw new ConversationValidationError('Fingerprint input failed JSON preflight', preflight.diagnostics);
+    }
+    const bytes = new TextEncoder().encode(stableJson(value));
+    const digest = await globalThis.crypto.subtle.digest('SHA-256', bytes);
+    const hex = Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('');
+    return `sha256:${hex}`;
+}
+
+/** Derive a compact deterministic entity ID from a stable request/import identity. */
+export async function deriveConversationId(kind: string, ...identity: string[]): Promise<string> {
+    const fingerprint = await fingerprintJson([kind, ...identity]);
+    return `${kind}_${fingerprint.slice('sha256:'.length, 'sha256:'.length + 32)}`;
+}

--- a/conversation/src/schemas/content.ts
+++ b/conversation/src/schemas/content.ts
@@ -1,0 +1,586 @@
+import { z } from 'zod';
+import {
+    AuthoritySchema,
+    Base64Schema,
+    ContentHashSchema,
+    IdentifierSchema,
+    JsonObjectSchema,
+    JsonValueSchema,
+    MetadataSchema,
+    ModelVisibilitySchema,
+    NonnegativeSafeIntegerSchema,
+    PositiveSafeIntegerSchema,
+    TimestampSchema,
+    TurnStatusSchema,
+    TurnTimestampsSchema,
+} from './primitives.js';
+
+export const NativeIdentitySchema = z
+    .strictObject({
+        protocol: IdentifierSchema,
+        scope: IdentifierSchema,
+        value: z.string().min(1),
+    })
+    .meta({ id: 'ConversationNativeIdentity' });
+
+export const ImageRegionSchema = z
+    .strictObject({
+        type: z.literal('image_region'),
+        coordinate_space: z.enum(['pixels', 'normalized']),
+        x: z.number().nonnegative(),
+        y: z.number().nonnegative(),
+        width: z.number().positive(),
+        height: z.number().positive(),
+    })
+    .meta({ id: 'ConversationImageRegion' });
+
+export const PageRangeSchema = z
+    .strictObject({
+        type: z.literal('page_range'),
+        from_page: PositiveSafeIntegerSchema,
+        through_page: PositiveSafeIntegerSchema,
+    })
+    .meta({ id: 'ConversationPageRange' });
+
+export const TimeRangeSchema = z
+    .strictObject({
+        type: z.literal('time_range'),
+        start_seconds: z.number().nonnegative(),
+        end_seconds: z.number().positive(),
+    })
+    .meta({ id: 'ConversationTimeRange' });
+
+export const AssetKindSchema = z
+    .enum(['text', 'json', 'binary', 'image', 'document', 'audio', 'video', 'other'])
+    .meta({ id: 'ConversationAssetKind' });
+
+export const InlineTextAssetStorageSchema = z
+    .strictObject({
+        type: z.literal('inline_text'),
+        text: z.string(),
+    })
+    .meta({ id: 'ConversationInlineTextAssetStorage' });
+
+export const InlineJsonAssetStorageSchema = z
+    .strictObject({
+        type: z.literal('inline_json'),
+        value: JsonValueSchema,
+    })
+    .meta({ id: 'ConversationInlineJsonAssetStorage' });
+
+export const InlineBase64AssetStorageSchema = z
+    .strictObject({
+        type: z.literal('inline_base64'),
+        data: Base64Schema,
+    })
+    .meta({ id: 'ConversationInlineBase64AssetStorage' });
+
+export const ExternalAssetStorageSchema = z
+    .strictObject({
+        type: z.literal('external'),
+        resolver: IdentifierSchema,
+        locator: JsonObjectSchema,
+    })
+    .meta({ id: 'ConversationExternalAssetStorage' });
+
+export const AssetStorageSchema = z
+    .discriminatedUnion('type', [
+        InlineTextAssetStorageSchema,
+        InlineJsonAssetStorageSchema,
+        InlineBase64AssetStorageSchema,
+        ExternalAssetStorageSchema,
+    ])
+    .meta({ id: 'ConversationAssetStorage' });
+
+export const ReceivedAssetProvenanceSchema = z
+    .strictObject({
+        type: z.literal('received'),
+        source_turn_id: IdentifierSchema.optional(),
+    })
+    .meta({ id: 'ConversationReceivedAssetProvenance' });
+
+export const GeneratedAssetProvenanceSchema = z
+    .strictObject({
+        type: z.literal('generated'),
+        generation_id: IdentifierSchema,
+        source_turn_id: IdentifierSchema.optional(),
+    })
+    .meta({ id: 'ConversationGeneratedAssetProvenance' });
+
+export const ImportedAssetProvenanceSchema = z
+    .strictObject({
+        type: z.literal('imported'),
+        source: IdentifierSchema,
+        native_id: NativeIdentitySchema.optional(),
+    })
+    .meta({ id: 'ConversationImportedAssetProvenance' });
+
+export const DerivedAssetProvenanceSchema = z
+    .strictObject({
+        type: z.literal('derived'),
+        source_asset_id: IdentifierSchema,
+        transform_id: IdentifierSchema,
+        transform_version: IdentifierSchema,
+        configuration: JsonObjectSchema.optional(),
+    })
+    .meta({ id: 'ConversationDerivedAssetProvenance' });
+
+export const AssetProvenanceSchema = z
+    .discriminatedUnion('type', [
+        ReceivedAssetProvenanceSchema,
+        GeneratedAssetProvenanceSchema,
+        ImportedAssetProvenanceSchema,
+        DerivedAssetProvenanceSchema,
+    ])
+    .meta({ id: 'ConversationAssetProvenance' });
+
+export const AssetMediaMetadataSchema = z
+    .strictObject({
+        width: PositiveSafeIntegerSchema.optional(),
+        height: PositiveSafeIntegerSchema.optional(),
+        duration_seconds: z.number().positive().optional(),
+        page_count: PositiveSafeIntegerSchema.optional(),
+    })
+    .meta({ id: 'ConversationAssetMediaMetadata' });
+
+export const AssetSchema = z
+    .strictObject({
+        id: IdentifierSchema,
+        kind: AssetKindSchema,
+        mime_type: z.string().min(1),
+        storage: AssetStorageSchema,
+        provenance: AssetProvenanceSchema,
+        byte_length: NonnegativeSafeIntegerSchema.optional(),
+        content_hash: ContentHashSchema.optional(),
+        media: AssetMediaMetadataSchema.optional(),
+        created_at: TimestampSchema,
+        metadata: MetadataSchema.optional(),
+    })
+    .meta({ id: 'ConversationAsset' });
+
+export const ToolResultCapabilitySchema = z
+    .enum(['text', 'json', 'image', 'document', 'audio', 'video'])
+    .meta({ id: 'ConversationToolResultCapability' });
+
+export const ToolInputSchemaSchema = z
+    .union([JsonObjectSchema, z.boolean()])
+    .meta({ id: 'ConversationToolInputSchema' });
+
+export const ToolDefinitionSchema = z
+    .strictObject({
+        id: IdentifierSchema,
+        name: IdentifierSchema,
+        version: IdentifierSchema,
+        description: z.string().optional(),
+        input_schema: ToolInputSchemaSchema,
+        result_capabilities: z.array(ToolResultCapabilitySchema).optional(),
+        metadata: MetadataSchema.optional(),
+    })
+    .meta({ id: 'ConversationToolDefinition' });
+
+export const TextBlockSchema = z
+    .strictObject({
+        id: IdentifierSchema,
+        type: z.literal('text'),
+        text: z.string(),
+        format: z.enum(['plain', 'markdown', 'code']),
+        language: z.string().min(1).optional(),
+    })
+    .meta({ id: 'ConversationTextBlock' });
+
+export const JsonBlockSchema = z
+    .strictObject({
+        id: IdentifierSchema,
+        type: z.literal('json'),
+        value: JsonValueSchema,
+    })
+    .meta({ id: 'ConversationJsonBlock' });
+
+export const ImageBlockSchema = z
+    .strictObject({
+        id: IdentifierSchema,
+        type: z.literal('image'),
+        asset_id: IdentifierSchema,
+        caption: z.string().optional(),
+        selection: ImageRegionSchema.optional(),
+    })
+    .meta({ id: 'ConversationImageBlock' });
+
+export const DocumentBlockSchema = z
+    .strictObject({
+        id: IdentifierSchema,
+        type: z.literal('document'),
+        asset_id: IdentifierSchema,
+        caption: z.string().optional(),
+        selection: PageRangeSchema.optional(),
+    })
+    .meta({ id: 'ConversationDocumentBlock' });
+
+export const AudioBlockSchema = z
+    .strictObject({
+        id: IdentifierSchema,
+        type: z.literal('audio'),
+        asset_id: IdentifierSchema,
+        caption: z.string().optional(),
+        selection: TimeRangeSchema.optional(),
+    })
+    .meta({ id: 'ConversationAudioBlock' });
+
+export const VideoBlockSchema = z
+    .strictObject({
+        id: IdentifierSchema,
+        type: z.literal('video'),
+        asset_id: IdentifierSchema,
+        caption: z.string().optional(),
+        selection: TimeRangeSchema.optional(),
+    })
+    .meta({ id: 'ConversationVideoBlock' });
+
+export const StructuredToolArgumentsSchema = z
+    .strictObject({
+        type: z.literal('json'),
+        value: JsonValueSchema,
+    })
+    .meta({ id: 'ConversationStructuredToolArguments' });
+
+export const InvalidToolArgumentsSchema = z
+    .strictObject({
+        type: z.literal('invalid'),
+        raw: z.string(),
+        error: z.string().optional(),
+    })
+    .meta({ id: 'ConversationInvalidToolArguments' });
+
+export const ToolArgumentsSchema = z
+    .discriminatedUnion('type', [StructuredToolArgumentsSchema, InvalidToolArgumentsSchema])
+    .meta({ id: 'ConversationToolArguments' });
+
+export const ToolCallBlockSchema = z
+    .strictObject({
+        id: IdentifierSchema,
+        type: z.literal('tool_call'),
+        call_id: IdentifierSchema,
+        tool_name: IdentifierSchema,
+        definition_id: IdentifierSchema.optional(),
+        executor: z.enum(['application', 'provider']),
+        arguments: ToolArgumentsSchema,
+        native_id: NativeIdentitySchema.optional(),
+    })
+    .meta({ id: 'ConversationToolCallBlock' });
+
+export const RetrievalCapabilitySchema = z
+    .strictObject({
+        capability: IdentifierSchema,
+        version: PositiveSafeIntegerSchema,
+        arguments: JsonObjectSchema,
+        tool_definition_id: IdentifierSchema.optional(),
+    })
+    .meta({ id: 'ConversationRetrievalCapability' });
+
+export const ExternalReferenceBlockSchema = z
+    .strictObject({
+        id: IdentifierSchema,
+        type: z.literal('external_reference'),
+        asset_id: IdentifierSchema,
+        original_type: z.enum([
+            'text',
+            'json',
+            'image',
+            'document',
+            'audio',
+            'video',
+            'tool_call',
+            'tool_result',
+            'reasoning',
+            'native_replay',
+            'extension',
+        ]),
+        description: z.string().min(1),
+        content_hash: ContentHashSchema.optional(),
+        preview: z.string().optional(),
+        retrieval: RetrievalCapabilitySchema,
+    })
+    .meta({ id: 'ConversationExternalReferenceBlock' });
+
+export const ReasoningBlockSchema = z
+    .strictObject({
+        id: IdentifierSchema,
+        type: z.literal('reasoning'),
+        text: z.string(),
+        representation: z.enum(['text', 'summary']),
+    })
+    .meta({ id: 'ConversationReasoningBlock' });
+
+export const ReplayCompatibilityScopeSchema = z
+    .strictObject({
+        provider: IdentifierSchema,
+        protocol: IdentifierSchema,
+        model: IdentifierSchema.optional(),
+        adapter_version: IdentifierSchema,
+    })
+    .meta({ id: 'ConversationReplayCompatibilityScope' });
+
+export const ReplayDependenciesSchema = z
+    .strictObject({
+        turn_ids: z.array(IdentifierSchema),
+        block_ids: z.array(IdentifierSchema),
+        call_ids: z.array(IdentifierSchema),
+        request_ids: z.array(IdentifierSchema),
+    })
+    .meta({ id: 'ConversationReplayDependencies' });
+
+export const NativeReplayBlockSchema = z
+    .strictObject({
+        id: IdentifierSchema,
+        type: z.literal('native_replay'),
+        adapter: IdentifierSchema,
+        protocol: IdentifierSchema,
+        compatibility_scope: ReplayCompatibilityScopeSchema,
+        payload: JsonValueSchema,
+        dependencies: ReplayDependenciesSchema,
+        content_hash: ContentHashSchema.optional(),
+    })
+    .meta({ id: 'ConversationNativeReplayBlock' });
+
+export const ExtensionBlockSchema = z
+    .strictObject({
+        id: IdentifierSchema,
+        type: z.literal('extension'),
+        namespace: IdentifierSchema,
+        version: IdentifierSchema,
+        payload: JsonValueSchema,
+        model_projection: z.enum(['excluded', 'registered']).optional(),
+    })
+    .meta({ id: 'ConversationExtensionBlock' });
+
+export const NestedToolResultContentBlockSchema = z
+    .discriminatedUnion('type', [
+        TextBlockSchema,
+        JsonBlockSchema,
+        ImageBlockSchema,
+        DocumentBlockSchema,
+        AudioBlockSchema,
+        VideoBlockSchema,
+        ExternalReferenceBlockSchema,
+        ReasoningBlockSchema,
+        NativeReplayBlockSchema,
+        ExtensionBlockSchema,
+    ])
+    .meta({ id: 'ConversationNestedToolResultContentBlock' });
+
+export const ToolResultBlockSchema = z
+    .strictObject({
+        id: IdentifierSchema,
+        type: z.literal('tool_result'),
+        call_id: IdentifierSchema,
+        status: z.enum(['success', 'error', 'cancelled', 'denied']),
+        content: z.array(NestedToolResultContentBlockSchema),
+        native_id: NativeIdentitySchema.optional(),
+    })
+    .meta({ id: 'ConversationToolResultBlock' });
+
+export const ContentBlockSchema = z
+    .discriminatedUnion('type', [
+        TextBlockSchema,
+        JsonBlockSchema,
+        ImageBlockSchema,
+        DocumentBlockSchema,
+        AudioBlockSchema,
+        VideoBlockSchema,
+        ToolCallBlockSchema,
+        ToolResultBlockSchema,
+        ExternalReferenceBlockSchema,
+        ReasoningBlockSchema,
+        NativeReplayBlockSchema,
+        ExtensionBlockSchema,
+    ])
+    .meta({ id: 'ConversationContentBlock' });
+
+export const UserContentBlockSchema = z
+    .discriminatedUnion('type', [
+        TextBlockSchema,
+        JsonBlockSchema,
+        ImageBlockSchema,
+        DocumentBlockSchema,
+        AudioBlockSchema,
+        VideoBlockSchema,
+        ExternalReferenceBlockSchema,
+        ExtensionBlockSchema,
+    ])
+    .meta({ id: 'ConversationUserContentBlock' });
+
+export const AgentContentBlockSchema = z
+    .discriminatedUnion('type', [
+        TextBlockSchema,
+        JsonBlockSchema,
+        ImageBlockSchema,
+        DocumentBlockSchema,
+        AudioBlockSchema,
+        VideoBlockSchema,
+        ToolCallBlockSchema,
+        ExternalReferenceBlockSchema,
+        ReasoningBlockSchema,
+        NativeReplayBlockSchema,
+        ExtensionBlockSchema,
+    ])
+    .meta({ id: 'ConversationAgentContentBlock' });
+
+export const ProgramContentBlockSchema = z
+    .discriminatedUnion('type', [
+        TextBlockSchema,
+        JsonBlockSchema,
+        ImageBlockSchema,
+        DocumentBlockSchema,
+        AudioBlockSchema,
+        VideoBlockSchema,
+        ExternalReferenceBlockSchema,
+        ReasoningBlockSchema,
+        NativeReplayBlockSchema,
+        ExtensionBlockSchema,
+    ])
+    .meta({ id: 'ConversationProgramContentBlock' });
+
+export const ReceivedTurnProvenanceSchema = z
+    .strictObject({ type: z.literal('received') })
+    .meta({ id: 'ConversationReceivedTurnProvenance' });
+
+export const InsertedTurnProvenanceSchema = z
+    .strictObject({
+        type: z.literal('inserted'),
+        operation_id: IdentifierSchema.optional(),
+    })
+    .meta({ id: 'ConversationInsertedTurnProvenance' });
+
+export const GeneratedTurnProvenanceSchema = z
+    .strictObject({ type: z.literal('generated') })
+    .meta({ id: 'ConversationGeneratedTurnProvenance' });
+
+export const ImportedTurnProvenanceSchema = z
+    .strictObject({
+        type: z.literal('imported'),
+        source: IdentifierSchema,
+        native_id: NativeIdentitySchema.optional(),
+        missing_metadata: z
+            .array(
+                z.enum(['actor_id', 'authority', 'generation', 'timestamps', 'usage', 'exchange', 'tool_definition']),
+            )
+            .optional(),
+    })
+    .meta({ id: 'ConversationImportedTurnProvenance' });
+
+export const DerivedTurnProvenanceSchema = z
+    .strictObject({
+        type: z.literal('derived'),
+        derivation_id: IdentifierSchema,
+        source_turn_ids: z.array(IdentifierSchema).min(1),
+        source_block_ids: z.array(IdentifierSchema).min(1).optional(),
+        source_hash: ContentHashSchema,
+    })
+    .meta({ id: 'ConversationDerivedTurnProvenance' });
+
+export const NonGeneratedTurnProvenanceSchema = z
+    .discriminatedUnion('type', [
+        ReceivedTurnProvenanceSchema,
+        InsertedTurnProvenanceSchema,
+        ImportedTurnProvenanceSchema,
+        DerivedTurnProvenanceSchema,
+    ])
+    .meta({ id: 'ConversationNonGeneratedTurnProvenance' });
+
+export const AgentTurnProvenanceSchema = z
+    .discriminatedUnion('type', [
+        ReceivedTurnProvenanceSchema,
+        InsertedTurnProvenanceSchema,
+        GeneratedTurnProvenanceSchema,
+        ImportedTurnProvenanceSchema,
+        DerivedTurnProvenanceSchema,
+    ])
+    .meta({ id: 'ConversationAgentTurnProvenance' });
+
+const commonTurnShape = {
+    id: IdentifierSchema,
+    actor_id: IdentifierSchema.optional(),
+    status: TurnStatusSchema,
+    timestamps: TurnTimestampsSchema,
+    execution_id: IdentifierSchema.optional(),
+    exchange_id: IdentifierSchema.optional(),
+    parent_turn_id: IdentifierSchema.optional(),
+    model_visibility: ModelVisibilitySchema,
+    metadata: MetadataSchema.optional(),
+};
+
+export const UserTurnSchema = z
+    .strictObject({
+        ...commonTurnShape,
+        kind: z.literal('user'),
+        authority: AuthoritySchema,
+        blocks: z.array(UserContentBlockSchema),
+        provenance: NonGeneratedTurnProvenanceSchema,
+    })
+    .meta({ id: 'ConversationUserTurn' });
+
+const commonAgentTurnShape = {
+    ...commonTurnShape,
+    kind: z.literal('agent'),
+    authority: AuthoritySchema,
+    blocks: z.array(AgentContentBlockSchema),
+};
+
+export const GeneratedAgentTurnSchema = z
+    .strictObject({
+        ...commonAgentTurnShape,
+        provenance: GeneratedTurnProvenanceSchema,
+        generation_id: IdentifierSchema,
+    })
+    .meta({ id: 'ConversationGeneratedAgentTurn' });
+
+export const ImportedAgentTurnSchema = z
+    .strictObject({
+        ...commonAgentTurnShape,
+        provenance: ImportedTurnProvenanceSchema,
+        generation_id: IdentifierSchema.optional(),
+    })
+    .meta({ id: 'ConversationImportedAgentTurn' });
+
+export const DerivedAgentTurnSchema = z
+    .strictObject({
+        ...commonAgentTurnShape,
+        provenance: DerivedTurnProvenanceSchema,
+        generation_id: IdentifierSchema.optional(),
+    })
+    .meta({ id: 'ConversationDerivedAgentTurn' });
+
+export const NongeneratedAgentTurnSchema = z
+    .strictObject({
+        ...commonAgentTurnShape,
+        provenance: z.discriminatedUnion('type', [ReceivedTurnProvenanceSchema, InsertedTurnProvenanceSchema]),
+    })
+    .meta({ id: 'ConversationNongeneratedAgentTurn' });
+
+export const AgentTurnSchema = z
+    .union([GeneratedAgentTurnSchema, ImportedAgentTurnSchema, DerivedAgentTurnSchema, NongeneratedAgentTurnSchema])
+    .meta({ id: 'ConversationAgentTurn' });
+
+export const ToolTurnSchema = z
+    .strictObject({
+        ...commonTurnShape,
+        kind: z.literal('tool'),
+        authority: z.literal('ordinary'),
+        blocks: z.array(ToolResultBlockSchema).length(1),
+        provenance: NonGeneratedTurnProvenanceSchema,
+    })
+    .meta({ id: 'ConversationToolTurn' });
+
+export const ProgramTurnSchema = z
+    .strictObject({
+        ...commonTurnShape,
+        kind: z.literal('program'),
+        authority: AuthoritySchema,
+        blocks: z.array(ProgramContentBlockSchema),
+        provenance: NonGeneratedTurnProvenanceSchema,
+    })
+    .meta({ id: 'ConversationProgramTurn' });
+
+export const ConversationTurnSchema = z
+    .union([UserTurnSchema, AgentTurnSchema, ToolTurnSchema, ProgramTurnSchema])
+    .meta({ id: 'ConversationTurn' });

--- a/conversation/src/schemas/content.ts
+++ b/conversation/src/schemas/content.ts
@@ -373,7 +373,9 @@ export const ToolResultBlockSchema = z
         id: IdentifierSchema,
         type: z.literal('tool_result'),
         call_id: IdentifierSchema,
-        status: z.enum(['success', 'error', 'cancelled', 'denied']),
+        // Some native histories and older hosts do not persist execution status. New application
+        // input records the explicit terminal status supplied through PromptSegment.
+        status: z.enum(['success', 'error', 'cancelled', 'denied', 'unknown']),
         content: z.array(NestedToolResultContentBlockSchema),
         native_id: NativeIdentitySchema.optional(),
     })
@@ -460,6 +462,7 @@ export const ImportedTurnProvenanceSchema = z
         type: z.literal('imported'),
         source: IdentifierSchema,
         native_id: NativeIdentitySchema.optional(),
+        source_history_turn_number: NonnegativeSafeIntegerSchema.optional(),
         missing_metadata: z
             .array(
                 z.enum(['actor_id', 'authority', 'generation', 'timestamps', 'usage', 'exchange', 'tool_definition']),

--- a/conversation/src/schemas/diagnostics.ts
+++ b/conversation/src/schemas/diagnostics.ts
@@ -1,0 +1,116 @@
+import { z } from 'zod';
+import { NonnegativeSafeIntegerSchema } from './primitives.js';
+
+export const DIAGNOSTIC_PATH_MAX_LENGTH = 512 as const;
+export const DIAGNOSTIC_MESSAGE_MAX_LENGTH = 1_024 as const;
+export const DIAGNOSTIC_RECORD_ID_MAX_LENGTH = 512 as const;
+export const DIAGNOSTIC_RELATED_PATHS_MAX_LENGTH = 8 as const;
+
+export const JsonPreflightDiagnosticCodeSchema = z
+    .enum([
+        'JSON_ACCESSOR_PROPERTY',
+        'JSON_ARRAY_PROPERTY',
+        'JSON_CYCLE',
+        'JSON_MAX_ARRAY_LENGTH',
+        'JSON_MAX_BYTES',
+        'JSON_MAX_DEPTH',
+        'JSON_MAX_NODES',
+        'JSON_MAX_OBJECT_PROPERTIES',
+        'JSON_MAX_STRING_BYTES',
+        'JSON_NEGATIVE_ZERO',
+        'JSON_NON_ENUMERABLE_PROPERTY',
+        'JSON_NON_FINITE_NUMBER',
+        'JSON_NON_PLAIN_OBJECT',
+        'JSON_RESERVED_PROPERTY_KEY',
+        'JSON_SPARSE_ARRAY',
+        'JSON_SYMBOL_KEY',
+        'JSON_UNSUPPORTED_TYPE',
+    ])
+    .meta({ id: 'ConversationJsonPreflightDiagnosticCode' });
+
+export const SemanticConversationDiagnosticCodeSchema = z
+    .enum([
+        'ACCOUNTING_PROVENANCE_MISMATCH',
+        'ASSET_KIND_MISMATCH',
+        'CONTEXT_BLOCK_ORDER_INVALID',
+        'CONTEXT_DIRECT_REPLACEMENT_OVERLAP',
+        'CONTEXT_REVISION_INVALID',
+        'CONTEXT_SELECTION_OVERLAP',
+        'DERIVED_AUTHORITY_MIXED',
+        'DERIVED_AUTHORITY_PROMOTED',
+        'DERIVED_PROVENANCE_CYCLE',
+        'DERIVED_PROVENANCE_MISMATCH',
+        'DUPLICATE_ID',
+        'DUPLICATE_TERMINAL_RESULT',
+        'GENERATION_REQUEST_MISMATCH',
+        'GENERATION_SOURCE_INVALID',
+        'GENERATION_USAGE_EMPTY',
+        'INPUT_PARTITION_INVALID',
+        'MAP_KEY_ID_MISMATCH',
+        'PARENT_TURN_CYCLE',
+        'REFERENCE_NOT_FOUND',
+        'REQUEST_MAPPING_INVALID',
+        'SELECTION_RANGE_INVALID',
+        'SEMANTIC_DIAGNOSTIC_LIMIT',
+        'SUPERSEDES_CYCLE',
+        'TIMESTAMP_ORDER_INVALID',
+        'TOOL_DEFINITION_MISMATCH',
+        'TOOL_RECEIPT_MISMATCH',
+        'TOOL_RESULT_UNRESOLVED',
+        'USAGE_BREAKDOWN_INVALID',
+        'USAGE_OVERFLOW',
+        'USAGE_TOTAL_INVALID',
+    ])
+    .meta({ id: 'ConversationSemanticDiagnosticCode' });
+
+export const ConversationDiagnosticStageSchema = z
+    .enum(['preflight', 'schema', 'semantic'])
+    .meta({ id: 'ConversationDiagnosticStage' });
+
+export const ConversationDiagnosticCodeSchema = z
+    .union([JsonPreflightDiagnosticCodeSchema, z.literal('SCHEMA_INVALID'), SemanticConversationDiagnosticCodeSchema])
+    .meta({ id: 'ConversationDiagnosticCode' });
+
+const diagnosticDetailShape = {
+    path: z.string().max(DIAGNOSTIC_PATH_MAX_LENGTH),
+    message: z.string().max(DIAGNOSTIC_MESSAGE_MAX_LENGTH),
+    record_id: z.string().max(DIAGNOSTIC_RECORD_ID_MAX_LENGTH).optional(),
+    related_paths: z
+        .array(z.string().max(DIAGNOSTIC_PATH_MAX_LENGTH))
+        .max(DIAGNOSTIC_RELATED_PATHS_MAX_LENGTH)
+        .optional(),
+    limit: NonnegativeSafeIntegerSchema.optional(),
+    observed: NonnegativeSafeIntegerSchema.optional(),
+};
+
+export const JsonPreflightDiagnosticSchema = z
+    .strictObject({
+        code: JsonPreflightDiagnosticCodeSchema,
+        stage: z.literal(ConversationDiagnosticStageSchema.enum.preflight),
+        ...diagnosticDetailShape,
+    })
+    .meta({ id: 'ConversationJsonPreflightDiagnostic' });
+
+export const ConversationSchemaDiagnosticSchema = z
+    .strictObject({
+        code: z.literal('SCHEMA_INVALID'),
+        stage: z.literal(ConversationDiagnosticStageSchema.enum.schema),
+        ...diagnosticDetailShape,
+    })
+    .meta({ id: 'ConversationSchemaDiagnostic' });
+
+export const SemanticConversationDiagnosticSchema = z
+    .strictObject({
+        code: SemanticConversationDiagnosticCodeSchema,
+        stage: z.literal(ConversationDiagnosticStageSchema.enum.semantic),
+        ...diagnosticDetailShape,
+    })
+    .meta({ id: 'ConversationSemanticDiagnostic' });
+
+export const ConversationDiagnosticSchema = z
+    .discriminatedUnion('stage', [
+        JsonPreflightDiagnosticSchema,
+        ConversationSchemaDiagnosticSchema,
+        SemanticConversationDiagnosticSchema,
+    ])
+    .meta({ id: 'ConversationDiagnostic' });

--- a/conversation/src/schemas/document.ts
+++ b/conversation/src/schemas/document.ts
@@ -1,0 +1,156 @@
+import { z } from 'zod';
+import { AssetSchema, ConversationTurnSchema, RetrievalCapabilitySchema, ToolDefinitionSchema } from './content.js';
+import { ExecutionReceiptSchema, GenerationSchema, OperationReceiptSchema } from './execution.js';
+import {
+    CONVERSATION_EXPERIMENTAL_REVISION,
+    CONVERSATION_FORMAT,
+    CONVERSATION_SCHEMA_VERSION,
+    ContentHashSchema,
+    ConversationRefSchema,
+    IdentifierSchema,
+    JsonObjectSchema,
+    MetadataSchema,
+    NonnegativeSafeIntegerSchema,
+    PositiveSafeIntegerSchema,
+    TimestampSchema,
+} from './primitives.js';
+
+export const SourceTurnContextEntrySchema = z
+    .strictObject({
+        id: IdentifierSchema,
+        type: z.literal('source_turn'),
+        turn_id: IdentifierSchema,
+        block_ids: z.array(IdentifierSchema).min(1).optional(),
+    })
+    .meta({ id: 'ConversationSourceTurnContextEntry' });
+
+export const ReplacementTurnContextEntrySchema = z
+    .strictObject({
+        id: IdentifierSchema,
+        type: z.literal('replacement_turn'),
+        compaction_id: IdentifierSchema,
+        turn_id: IdentifierSchema,
+        block_ids: z.array(IdentifierSchema).min(1).optional(),
+    })
+    .meta({ id: 'ConversationReplacementTurnContextEntry' });
+
+export const ContextEntrySchema = z
+    .discriminatedUnion('type', [SourceTurnContextEntrySchema, ReplacementTurnContextEntrySchema])
+    .meta({ id: 'ConversationContextEntry' });
+
+export const ContextRetrievalRequirementSchema = z
+    .strictObject({
+        id: IdentifierSchema,
+        asset_id: IdentifierSchema,
+        retrieval: RetrievalCapabilitySchema,
+    })
+    .meta({ id: 'ConversationContextRetrievalRequirement' });
+
+export const CacheIntentSchema = z
+    .strictObject({
+        namespace: IdentifierSchema,
+        mode: z.enum(['auto', 'off', 'required']),
+        stable_through_entry_id: IdentifierSchema.optional(),
+        ttl_seconds: PositiveSafeIntegerSchema.optional(),
+    })
+    .meta({ id: 'ConversationCacheIntent' });
+
+export const ConversationContextSchema = z
+    .strictObject({
+        revision: NonnegativeSafeIntegerSchema,
+        entries: z.array(ContextEntrySchema),
+        active_tool_definition_ids: z.array(IdentifierSchema),
+        protected_entry_ids: z.array(IdentifierSchema),
+        retrieval_requirements: z.array(ContextRetrievalRequirementSchema),
+        cache_intent: CacheIntentSchema.optional(),
+    })
+    .meta({ id: 'ConversationContext' });
+
+export const CompactionStrategySchema = z
+    .strictObject({
+        id: IdentifierSchema,
+        version: IdentifierSchema,
+        configuration_fingerprint: ContentHashSchema,
+    })
+    .meta({ id: 'ConversationCompactionStrategy' });
+
+export const CompactionSourceSchema = z
+    .strictObject({
+        turn_ids: z.array(IdentifierSchema).min(1),
+        block_ids: z.array(IdentifierSchema).min(1).optional(),
+        source_fingerprint: ContentHashSchema,
+    })
+    .meta({ id: 'ConversationCompactionSource' });
+
+export const CompactionRecordSchema = z
+    .strictObject({
+        id: IdentifierSchema,
+        operation_id: IdentifierSchema,
+        strategy: CompactionStrategySchema,
+        source: CompactionSourceSchema,
+        replacement_turns: z.array(ConversationTurnSchema).min(1),
+        fidelity: z.enum(['value_preserving', 'reversible_representation', 'heuristic', 'semantic', 'retrievable']),
+        retained_asset_ids: z.array(IdentifierSchema),
+        generation_ids: z.array(IdentifierSchema),
+        supersedes_compaction_id: IdentifierSchema.optional(),
+        created_at: TimestampSchema,
+        metadata: MetadataSchema.optional(),
+    })
+    .meta({ id: 'ConversationCompactionRecord' });
+
+export const ProcessorConfigurationSchema = z
+    .strictObject({
+        id: IdentifierSchema,
+        version: IdentifierSchema,
+        scope: z.enum(['on_append', 'on_budget', 'manual']),
+        config: JsonObjectSchema,
+        required: z.boolean(),
+        failure_behavior: z.enum(['block', 'skip_with_diagnostic']),
+    })
+    .meta({ id: 'ConversationProcessorConfiguration' });
+
+// This record is inert persisted configuration in the foundation revision. It deliberately has no
+// readiness boolean, job runner, callback, or executable plugin instance.
+export const ProcessingStateSchema = z
+    .strictObject({
+        enabled: z.boolean(),
+        policy_revision: NonnegativeSafeIntegerSchema,
+        processors: z.array(ProcessorConfigurationSchema),
+    })
+    .meta({ id: 'ConversationProcessingState' });
+
+export const ConversationLineageParentSchema = z
+    .strictObject({
+        relation: z.enum(['fork', 'merge']),
+        source: ConversationRefSchema,
+    })
+    .meta({ id: 'ConversationLineageParent' });
+
+export const ConversationLineageSchema = z
+    .strictObject({
+        parents: z.array(ConversationLineageParentSchema).min(1),
+    })
+    .meta({ id: 'ConversationLineage' });
+
+export const ConversationDocumentSchema = z
+    .strictObject({
+        format: z.literal(CONVERSATION_FORMAT),
+        schema_version: z.literal(CONVERSATION_SCHEMA_VERSION),
+        experimental_revision: z.literal(CONVERSATION_EXPERIMENTAL_REVISION),
+        id: IdentifierSchema,
+        revision: NonnegativeSafeIntegerSchema,
+        created_at: TimestampSchema,
+        updated_at: TimestampSchema,
+        turns: z.array(ConversationTurnSchema),
+        generations: z.record(IdentifierSchema, GenerationSchema),
+        operation_receipts: z.record(IdentifierSchema, OperationReceiptSchema),
+        execution_receipts: z.record(IdentifierSchema, ExecutionReceiptSchema),
+        assets: z.record(IdentifierSchema, AssetSchema),
+        tool_definitions: z.record(IdentifierSchema, ToolDefinitionSchema),
+        context: ConversationContextSchema,
+        compactions: z.record(IdentifierSchema, CompactionRecordSchema),
+        processing: ProcessingStateSchema,
+        lineage: ConversationLineageSchema.optional(),
+        metadata: MetadataSchema.optional(),
+    })
+    .meta({ id: 'ConversationDocumentV0' });

--- a/conversation/src/schemas/execution.ts
+++ b/conversation/src/schemas/execution.ts
@@ -1,0 +1,258 @@
+import { z } from 'zod';
+import {
+    ContentHashSchema,
+    ConversationRefSchema,
+    IdentifierSchema,
+    JsonObjectSchema,
+    JsonValueSchema,
+    MetadataSchema,
+    NonnegativeSafeIntegerSchema,
+    TimestampSchema,
+} from './primitives.js';
+
+export const UsageMetricSchema = z
+    .enum([
+        'input_tokens',
+        'output_tokens',
+        'total_tokens',
+        'reasoning_tokens',
+        'cache_read_tokens',
+        'cache_write_tokens',
+        'input_new_tokens',
+    ])
+    .meta({ id: 'ConversationUsageMetric' });
+
+export const AccountingProvenanceSchema = z
+    .strictObject({
+        method: z.enum(['reported', 'derived']),
+        accounting_basis: IdentifierSchema,
+        source: IdentifierSchema.optional(),
+    })
+    .meta({ id: 'ConversationAccountingProvenance' });
+
+export const UsageAccountingProvenanceSchema = z
+    .strictObject({
+        input_tokens: AccountingProvenanceSchema.optional(),
+        output_tokens: AccountingProvenanceSchema.optional(),
+        total_tokens: AccountingProvenanceSchema.optional(),
+        reasoning_tokens: AccountingProvenanceSchema.optional(),
+        cache_read_tokens: AccountingProvenanceSchema.optional(),
+        cache_write_tokens: AccountingProvenanceSchema.optional(),
+        input_new_tokens: AccountingProvenanceSchema.optional(),
+    })
+    .meta({ id: 'ConversationUsageAccountingProvenance' });
+
+export const ReportedUsageSchema = z
+    .strictObject({
+        source: z.enum(['provider', 'legacy', 'host']),
+        protocol: IdentifierSchema.optional(),
+        version: IdentifierSchema.optional(),
+        accounting_basis: IdentifierSchema.optional(),
+        payload: JsonValueSchema,
+    })
+    .meta({ id: 'ConversationReportedUsage' });
+
+export const CompleteInputPartitionSchema = z
+    .strictObject({
+        type: z.literal('complete_disjoint'),
+        cache_write_bucket: z.enum(['included', 'inapplicable']),
+    })
+    .meta({ id: 'ConversationCompleteInputPartition' });
+
+export const GenerationCostSchema = z
+    .strictObject({
+        amount: z.string().regex(/^(?:0|[1-9]\d*)(?:\.\d+)?$/),
+        currency: z.string().regex(/^[A-Z]{3}$/),
+        provenance: z.enum(['reported', 'estimated']),
+        price_source: IdentifierSchema.optional(),
+        price_version: IdentifierSchema.optional(),
+    })
+    .meta({ id: 'ConversationGenerationCost' });
+
+export const GenerationUsageSchema = z
+    .strictObject({
+        input_tokens: NonnegativeSafeIntegerSchema.optional(),
+        output_tokens: NonnegativeSafeIntegerSchema.optional(),
+        total_tokens: NonnegativeSafeIntegerSchema.optional(),
+        reasoning_tokens: NonnegativeSafeIntegerSchema.optional(),
+        cache_read_tokens: NonnegativeSafeIntegerSchema.optional(),
+        cache_write_tokens: NonnegativeSafeIntegerSchema.optional(),
+        input_new_tokens: NonnegativeSafeIntegerSchema.optional(),
+        accounting_provenance: UsageAccountingProvenanceSchema.optional(),
+        input_partition: CompleteInputPartitionSchema.optional(),
+        reported_usage: z.array(ReportedUsageSchema).min(1).optional(),
+        cost: GenerationCostSchema.optional(),
+    })
+    .meta({ id: 'ConversationGenerationUsage' });
+
+export const ContextMeasurementSchema = z
+    .strictObject({
+        input_tokens: NonnegativeSafeIntegerSchema,
+        method: z.enum(['exact', 'estimated', 'provider_counted']),
+        tokenizer: IdentifierSchema,
+        tokenizer_version: IdentifierSchema.optional(),
+        adapter: IdentifierSchema,
+        adapter_version: IdentifierSchema,
+        source_fingerprint: ContentHashSchema,
+        target_model: IdentifierSchema,
+        measured_at: TimestampSchema,
+    })
+    .meta({ id: 'ConversationContextMeasurement' });
+
+export const ModelTargetSchema = z
+    .strictObject({
+        provider: IdentifierSchema,
+        protocol: IdentifierSchema,
+        model: IdentifierSchema,
+        adapter_version: IdentifierSchema,
+        options: JsonObjectSchema.optional(),
+    })
+    .meta({ id: 'ConversationModelTarget' });
+
+export const AssetVersionBindingSchema = z
+    .strictObject({
+        asset_id: IdentifierSchema,
+        content_hash: ContentHashSchema,
+    })
+    .meta({ id: 'ConversationAssetVersionBinding' });
+
+export const NativeItemMappingSchema = z
+    .strictObject({
+        canonical_id: IdentifierSchema,
+        native_id: z.string().min(1),
+        kind: z.enum(['turn', 'block', 'call']),
+    })
+    .meta({ id: 'ConversationNativeItemMapping' });
+
+export const RequestReceiptSchema = z
+    .strictObject({
+        id: IdentifierSchema,
+        request_id: IdentifierSchema,
+        attempt_id: IdentifierSchema,
+        source: ConversationRefSchema,
+        source_tail_turn_id: IdentifierSchema.optional(),
+        context_fingerprint: ContentHashSchema,
+        tool_set_fingerprint: ContentHashSchema,
+        request_fingerprint: ContentHashSchema,
+        target: ModelTargetSchema,
+        tool_definition_ids: z.array(IdentifierSchema),
+        asset_versions: z.array(AssetVersionBindingSchema),
+        item_mappings: z.array(NativeItemMappingSchema),
+        measurement: ContextMeasurementSchema.optional(),
+        recorded_at: TimestampSchema,
+        metadata: MetadataSchema.optional(),
+    })
+    .meta({ id: 'ConversationRequestReceipt' });
+
+export const GenerationTimestampsSchema = z
+    .strictObject({
+        recorded_at: TimestampSchema,
+        started_at: TimestampSchema.optional(),
+        completed_at: TimestampSchema.optional(),
+        provider_duration_ms: z.number().nonnegative().optional(),
+    })
+    .meta({ id: 'ConversationGenerationTimestamps' });
+
+const commonGenerationShape = {
+    id: IdentifierSchema,
+    request_id: IdentifierSchema,
+    attempt_id: IdentifierSchema,
+    provider_response_id: z.string().min(1).optional(),
+    purpose: IdentifierSchema,
+    requested_model: IdentifierSchema,
+    resolved_model: IdentifierSchema.optional(),
+    provider: IdentifierSchema,
+    protocol: IdentifierSchema,
+    model_options: JsonObjectSchema.optional(),
+    adapter_version: IdentifierSchema,
+    status: z.enum(['completed', 'failed', 'cancelled']),
+    finish_reason: z.string().optional(),
+    timestamps: GenerationTimestampsSchema,
+    source: ConversationRefSchema,
+    context_fingerprint: ContentHashSchema.optional(),
+    tool_set_fingerprint: ContentHashSchema.optional(),
+    usage: GenerationUsageSchema.optional(),
+    metadata: MetadataSchema.optional(),
+};
+
+export const ExecutedGenerationSchema = z
+    .strictObject({
+        ...commonGenerationShape,
+        record_source: z.literal('executed'),
+        request_receipt: RequestReceiptSchema,
+    })
+    .meta({ id: 'ConversationExecutedGeneration' });
+
+export const ImportedGenerationSchema = z
+    .strictObject({
+        id: IdentifierSchema,
+        record_source: z.literal('imported'),
+        request_id: IdentifierSchema.optional(),
+        attempt_id: IdentifierSchema.optional(),
+        provider_response_id: z.string().min(1).optional(),
+        purpose: IdentifierSchema.optional(),
+        requested_model: IdentifierSchema.optional(),
+        resolved_model: IdentifierSchema.optional(),
+        provider: IdentifierSchema.optional(),
+        protocol: IdentifierSchema.optional(),
+        model_options: JsonObjectSchema.optional(),
+        adapter_version: IdentifierSchema.optional(),
+        status: z.enum(['completed', 'failed', 'cancelled']),
+        finish_reason: z.string().optional(),
+        timestamps: GenerationTimestampsSchema,
+        source: ConversationRefSchema,
+        context_fingerprint: ContentHashSchema.optional(),
+        tool_set_fingerprint: ContentHashSchema.optional(),
+        usage: GenerationUsageSchema.optional(),
+        metadata: MetadataSchema.optional(),
+        request_receipt: RequestReceiptSchema.optional(),
+        missing_metadata: z
+            .array(
+                z.enum([
+                    'request_receipt',
+                    'request_id',
+                    'attempt_id',
+                    'timestamps',
+                    'usage',
+                    'purpose',
+                    'requested_model',
+                    'resolved_model',
+                    'provider',
+                    'protocol',
+                    'adapter_version',
+                    'provider_response_id',
+                    'finish_reason',
+                ]),
+            )
+            .optional(),
+    })
+    .meta({ id: 'ConversationImportedGeneration' });
+
+export const GenerationSchema = z
+    .discriminatedUnion('record_source', [ExecutedGenerationSchema, ImportedGenerationSchema])
+    .meta({ id: 'ConversationGeneration' });
+
+export const OperationReceiptSchema = z
+    .strictObject({
+        id: IdentifierSchema,
+        conversation_id: IdentifierSchema,
+        payload_fingerprint: ContentHashSchema,
+        base_revision: NonnegativeSafeIntegerSchema,
+        result_revision: NonnegativeSafeIntegerSchema,
+        recorded_at: TimestampSchema,
+    })
+    .meta({ id: 'ConversationOperationReceipt' });
+
+export const ExecutionReceiptSchema = z
+    .strictObject({
+        id: IdentifierSchema,
+        call_id: IdentifierSchema,
+        executor: z.enum(['application', 'provider']),
+        host_execution_id: IdentifierSchema.optional(),
+        attempt_id: IdentifierSchema.optional(),
+        status: z.enum(['success', 'error', 'cancelled', 'denied']),
+        result_turn_id: IdentifierSchema.optional(),
+        result_fingerprint: ContentHashSchema,
+        recorded_at: TimestampSchema,
+    })
+    .meta({ id: 'ConversationExecutionReceipt' });

--- a/conversation/src/schemas/execution.ts
+++ b/conversation/src/schemas/execution.ts
@@ -10,6 +10,20 @@ import {
     TimestampSchema,
 } from './primitives.js';
 
+export const ConversationRuntimeContextSchema = z
+    .strictObject({
+        conversation_id: IdentifierSchema.optional(),
+        request_id: IdentifierSchema,
+        attempt_id: IdentifierSchema,
+        input_operation_id: IdentifierSchema,
+        response_operation_id: IdentifierSchema,
+        recorded_at: TimestampSchema,
+        started_at: TimestampSchema.optional(),
+        completed_at: TimestampSchema.optional(),
+        purpose: IdentifierSchema.optional(),
+    })
+    .meta({ id: 'ConversationRuntimeContext' });
+
 export const UsageMetricSchema = z
     .enum([
         'input_tokens',
@@ -240,6 +254,12 @@ export const OperationReceiptSchema = z
         base_revision: NonnegativeSafeIntegerSchema,
         result_revision: NonnegativeSafeIntegerSchema,
         recorded_at: TimestampSchema,
+        accepted_turn_ids: z.array(IdentifierSchema).optional(),
+        accepted_generation_ids: z.array(IdentifierSchema).optional(),
+        accepted_asset_ids: z.array(IdentifierSchema).optional(),
+        accepted_tool_definition_ids: z.array(IdentifierSchema).optional(),
+        accepted_execution_receipt_ids: z.array(IdentifierSchema).optional(),
+        accepted_context_entry_ids: z.array(IdentifierSchema).optional(),
     })
     .meta({ id: 'ConversationOperationReceipt' });
 

--- a/conversation/src/schemas/index.ts
+++ b/conversation/src/schemas/index.ts
@@ -1,0 +1,6 @@
+export * from './content.js';
+export * from './diagnostics.js';
+export * from './document.js';
+export * from './execution.js';
+export * from './inspection.js';
+export * from './primitives.js';

--- a/conversation/src/schemas/index.ts
+++ b/conversation/src/schemas/index.ts
@@ -2,5 +2,6 @@ export * from './content.js';
 export * from './diagnostics.js';
 export * from './document.js';
 export * from './execution.js';
+export * from './ingestion.js';
 export * from './inspection.js';
 export * from './primitives.js';

--- a/conversation/src/schemas/ingestion.ts
+++ b/conversation/src/schemas/ingestion.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod';
+import { AssetSchema, ConversationTurnSchema, ToolDefinitionSchema } from './content.js';
+import { ConversationDiagnosticSchema } from './diagnostics.js';
+import { ContextEntrySchema, ConversationDocumentSchema } from './document.js';
+import { ExecutedGenerationSchema, ExecutionReceiptSchema, GenerationSchema } from './execution.js';
+import { ContentHashSchema, IdentifierSchema, NonnegativeSafeIntegerSchema, TimestampSchema } from './primitives.js';
+
+/** Concrete JSON additions; cross-record integrity is checked against the resulting document. */
+export const ConversationRecordBatchSchema = z
+    .strictObject({
+        turns: z.array(ConversationTurnSchema).readonly().optional(),
+        generations: z.array(GenerationSchema).readonly().optional(),
+        assets: z.array(AssetSchema).readonly().optional(),
+        tool_definitions: z.array(ToolDefinitionSchema).readonly().optional(),
+        execution_receipts: z.array(ExecutionReceiptSchema).readonly().optional(),
+        context_entries: z.array(ContextEntrySchema).readonly().optional(),
+        active_tool_definition_ids: z.array(IdentifierSchema).readonly().optional(),
+    })
+    .meta({ id: 'ConversationRecordBatch' });
+
+export const AppendConversationRecordsOptionsSchema = z
+    .strictObject({
+        expected_revision: NonnegativeSafeIntegerSchema,
+        operation_id: IdentifierSchema,
+        payload_fingerprint: ContentHashSchema,
+        recorded_at: TimestampSchema,
+    })
+    .meta({ id: 'AppendConversationRecordsOptions' });
+
+export const AppendConversationRecordsResultSchema = z
+    .strictObject({
+        document: ConversationDocumentSchema,
+        applied: z.boolean(),
+        accepted_turn_ids: z.array(IdentifierSchema),
+        accepted_generation_ids: z.array(IdentifierSchema),
+    })
+    .meta({ id: 'AppendConversationRecordsResult' });
+
+/** Completed decoder output, before the request/response identity and dependency checks. */
+export const DecodedConversationResponseSchema = z
+    .strictObject({
+        turns: z.array(ConversationTurnSchema).readonly(),
+        generation: ExecutedGenerationSchema,
+        assets: z.array(AssetSchema).readonly().optional(),
+        execution_receipts: z.array(ExecutionReceiptSchema).readonly().optional(),
+        diagnostics: z.array(ConversationDiagnosticSchema),
+        payload_fingerprint: ContentHashSchema,
+    })
+    .meta({ id: 'DecodedConversationResponse' });

--- a/conversation/src/schemas/inspection.ts
+++ b/conversation/src/schemas/inspection.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+import { IdentifierSchema, NonnegativeSafeIntegerSchema } from './primitives.js';
+
+export const TurnKindCountsSchema = z
+    .strictObject({
+        user: NonnegativeSafeIntegerSchema,
+        agent: NonnegativeSafeIntegerSchema,
+        tool: NonnegativeSafeIntegerSchema,
+        program: NonnegativeSafeIntegerSchema,
+    })
+    .meta({ id: 'ConversationTurnKindCounts' });
+
+export const ConversationInspectionSchema = z
+    .strictObject({
+        source_turn_count: NonnegativeSafeIntegerSchema,
+        context_turn_count: NonnegativeSafeIntegerSchema,
+        source_turns_by_kind: TurnKindCountsSchema,
+        context_turns_by_kind: TurnKindCountsSchema,
+        generation_count: NonnegativeSafeIntegerSchema,
+        pending_tool_call_ids: z.array(IdentifierSchema),
+    })
+    .meta({ id: 'ConversationInspection' });

--- a/conversation/src/schemas/primitives.ts
+++ b/conversation/src/schemas/primitives.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 export const CONVERSATION_FORMAT = 'llumiverse.conversation' as const;
 export const CONVERSATION_SCHEMA_VERSION = 0 as const;
-export const CONVERSATION_EXPERIMENTAL_REVISION = '2026-09-11.foundation.1' as const;
+export const CONVERSATION_EXPERIMENTAL_REVISION = '2026-09-11.ingestion.1' as const;
 
 export const IdentifierSchema = z.string().min(1).meta({ id: 'ConversationIdentifier' });
 

--- a/conversation/src/schemas/primitives.ts
+++ b/conversation/src/schemas/primitives.ts
@@ -1,0 +1,62 @@
+import { z } from 'zod';
+
+export const CONVERSATION_FORMAT = 'llumiverse.conversation' as const;
+export const CONVERSATION_SCHEMA_VERSION = 0 as const;
+export const CONVERSATION_EXPERIMENTAL_REVISION = '2026-09-11.foundation.1' as const;
+
+export const IdentifierSchema = z.string().min(1).meta({ id: 'ConversationIdentifier' });
+
+export const NonnegativeSafeIntegerSchema = z
+    .number()
+    .int()
+    .nonnegative()
+    .max(Number.MAX_SAFE_INTEGER)
+    .meta({ id: 'ConversationNonnegativeSafeInteger' });
+
+export const PositiveSafeIntegerSchema = z
+    .number()
+    .int()
+    .positive()
+    .max(Number.MAX_SAFE_INTEGER)
+    .meta({ id: 'ConversationPositiveSafeInteger' });
+
+export const TimestampSchema = z.iso.datetime({ offset: false }).meta({ id: 'ConversationTimestamp' });
+
+export const ContentHashSchema = z.string().min(1).meta({ id: 'ConversationContentHash' });
+
+export const Base64Schema = z
+    .string()
+    .regex(/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/)
+    .meta({ id: 'ConversationBase64' });
+
+// Zod 4's built-in recursive JSON schema provides both a real recursive runtime validator and a
+// recursive draft-2020-12 schema. Public parsing runs the bounded preflight first; callers should
+// use that boundary when they need preservation rather than Zod's reconstructed output value.
+export const JsonValueSchema = z.json().meta({ id: 'ConversationJsonValue' });
+
+export const JsonObjectSchema = z.record(z.string(), JsonValueSchema).meta({ id: 'ConversationJsonObject' });
+
+export const MetadataSchema = z.record(z.string().min(1), JsonValueSchema).meta({ id: 'ConversationMetadata' });
+
+export const ModelVisibilitySchema = z.enum(['include', 'exclude']).meta({ id: 'ConversationModelVisibility' });
+
+export const AuthoritySchema = z.enum(['system', 'developer', 'ordinary']).meta({ id: 'ConversationAuthority' });
+
+export const TurnKindSchema = z.enum(['user', 'agent', 'tool', 'program']).meta({ id: 'ConversationTurnKind' });
+
+export const TurnStatusSchema = z.enum(['completed', 'interrupted', 'failed']).meta({ id: 'ConversationTurnStatus' });
+
+export const TurnTimestampsSchema = z
+    .strictObject({
+        recorded_at: TimestampSchema,
+        started_at: TimestampSchema.optional(),
+        completed_at: TimestampSchema.optional(),
+    })
+    .meta({ id: 'ConversationTurnTimestamps' });
+
+export const ConversationRefSchema = z
+    .strictObject({
+        conversation_id: IdentifierSchema,
+        revision: NonnegativeSafeIntegerSchema,
+    })
+    .meta({ id: 'ConversationRef' });

--- a/conversation/src/schemas/primitives.ts
+++ b/conversation/src/schemas/primitives.ts
@@ -32,7 +32,8 @@ export const Base64Schema = z
 // Zod 4's built-in recursive JSON schema provides both a real recursive runtime validator and a
 // recursive draft-2020-12 schema. Public parsing runs the bounded preflight first; callers should
 // use that boundary when they need preservation rather than Zod's reconstructed output value.
-export const JsonValueSchema = z.json().meta({ id: 'ConversationJsonValue' });
+// Register the recursive instance itself: meta() clones it and leaves its recursion anonymously named.
+export const JsonValueSchema = z.json().register(z.globalRegistry, { id: 'ConversationJsonValue' });
 
 export const JsonObjectSchema = z.record(z.string(), JsonValueSchema).meta({ id: 'ConversationJsonObject' });
 

--- a/conversation/src/scope.ts
+++ b/conversation/src/scope.ts
@@ -1,0 +1,50 @@
+import { CONVERSATION_EXPERIMENTAL_REVISION, CONVERSATION_SCHEMA_VERSION } from './schemas/primitives.js';
+
+export const CONVERSATION_FOUNDATION_SCOPE = Object.freeze({
+    schema_version: CONVERSATION_SCHEMA_VERSION,
+    experimental_revision: CONVERSATION_EXPERIMENTAL_REVISION,
+    supported: Object.freeze([
+        'materialized_document_schema',
+        'bounded_json_preflight',
+        'full_document_shape_and_semantic_validation',
+        'materialized_json_round_trip',
+        'basic_builders_and_inspection',
+        'deterministic_json_schema',
+    ]),
+});
+
+export const CONVERSATION_FOUNDATION_LIMITATIONS = Object.freeze([
+    {
+        code: 'UNIMPLEMENTED_SCOPE',
+        feature: 'segmented_storage',
+        message:
+            'Manifest, segment, index-page, and bounded working-set contracts are not implemented in this revision.',
+    },
+    {
+        code: 'UNIMPLEMENTED_SCOPE',
+        feature: 'fragments',
+        message: 'Fragment validation and completeness descriptors are not implemented in this revision.',
+    },
+    {
+        code: 'UNIMPLEMENTED_SCOPE',
+        feature: 'changes_and_editing',
+        message: 'Change, editing, conflict, merge, and fork contracts are not implemented in this revision.',
+    },
+    {
+        code: 'UNIMPLEMENTED_SCOPE',
+        feature: 'processing_runtime',
+        message: 'Persisted processing and compaction data is inert and has no jobs, readiness, or execution.',
+    },
+    {
+        code: 'UNIMPLEMENTED_SCOPE',
+        feature: 'delivery_and_adapters',
+        message: 'Delivery, adapter, and migration contracts are not implemented in this revision.',
+    },
+    {
+        code: 'UNIMPLEMENTED_SCOPE',
+        feature: 'stable_publication',
+        message: 'Schema version 1, core-preview acceptance, and npm publication gates have not been completed.',
+    },
+] as const);
+
+export type ConversationFoundationLimitation = (typeof CONVERSATION_FOUNDATION_LIMITATIONS)[number];

--- a/conversation/src/scope.ts
+++ b/conversation/src/scope.ts
@@ -10,6 +10,7 @@ export const CONVERSATION_FOUNDATION_SCOPE = Object.freeze({
         'materialized_json_round_trip',
         'basic_builders_and_inspection',
         'deterministic_json_schema',
+        'idempotent_materialized_record_ingestion',
     ]),
 });
 
@@ -37,8 +38,9 @@ export const CONVERSATION_FOUNDATION_LIMITATIONS = Object.freeze([
     },
     {
         code: 'UNIMPLEMENTED_SCOPE',
-        feature: 'delivery_and_adapters',
-        message: 'Delivery, adapter, and migration contracts are not implemented in this revision.',
+        feature: 'remaining_delivery_adapters_and_migrations',
+        message:
+            'OpenAI Chat Completions and Claude Messages have native adapters; other provider adapters, delivery contracts, and migrations are not implemented.',
     },
     {
         code: 'UNIMPLEMENTED_SCOPE',

--- a/conversation/src/semantic-validation.ts
+++ b/conversation/src/semantic-validation.ts
@@ -1,0 +1,1279 @@
+import { boundConversationDiagnostic, diagnosticPointer, diagnosticValue } from './diagnostics.js';
+import { UsageMetricSchema } from './schemas/execution.js';
+import type {
+    Asset,
+    CompactionRecord,
+    ContentBlock,
+    ContextEntry,
+    ConversationDiagnostic,
+    ConversationDocument,
+    ConversationTurn,
+    Generation,
+    GenerationUsage,
+    NativeReplayBlock,
+    NestedToolResultContentBlock,
+    RequestReceipt,
+    SemanticConversationDiagnostic,
+    SemanticConversationDiagnosticCode,
+    ToolCallBlock,
+    ToolResultBlock,
+} from './types.js';
+
+const MAX_SEMANTIC_DIAGNOSTICS = 256;
+const USAGE_METRICS = UsageMetricSchema.options;
+
+type AnyBlock = ContentBlock | NestedToolResultContentBlock;
+
+interface LocatedTurn {
+    turn: ConversationTurn;
+    path: string;
+    source: boolean;
+    compaction_id?: string;
+}
+
+interface LocatedBlock {
+    block: AnyBlock;
+    turn_id: string;
+    path: string;
+}
+
+interface LocatedCall {
+    block: ToolCallBlock;
+    turn_id: string;
+    path: string;
+    source: boolean;
+}
+
+interface ActiveSelection {
+    turn_id: string;
+    all_blocks: boolean;
+    block_ids: ReadonlySet<string>;
+    origin: 'direct' | 'replacement';
+    path: string;
+    compaction_id?: string;
+}
+
+interface ActiveSelectionIndex {
+    first: ActiveSelection;
+    all?: ActiveSelection;
+    by_block_id: Map<string, ActiveSelection>;
+}
+
+interface GraphFrame {
+    id: string;
+    edges: readonly string[];
+    next_edge: number;
+}
+
+function recordPath(collection: string, id: string): string {
+    return diagnosticPointer([collection, id]);
+}
+
+function hasOwn(record: object, key: PropertyKey): boolean {
+    return Object.hasOwn(record, key);
+}
+
+function selectionsOverlap(first: ActiveSelection, second: ActiveSelection): boolean {
+    if (first.turn_id !== second.turn_id) {
+        return false;
+    }
+    if (first.all_blocks || second.all_blocks) {
+        return true;
+    }
+    for (const blockId of first.block_ids) {
+        if (second.block_ids.has(blockId)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function validateDirectedCycles(
+    nodeIds: Iterable<string>,
+    edgesFor: (id: string) => readonly string[],
+    onCycle: (from: string, to: string) => void,
+): void {
+    const colors = new Map<string, 'visiting' | 'visited'>();
+    for (const start of nodeIds) {
+        if (colors.has(start)) {
+            continue;
+        }
+        colors.set(start, 'visiting');
+        const stack: GraphFrame[] = [{ id: start, edges: edgesFor(start), next_edge: 0 }];
+        while (stack.length > 0) {
+            const frame = stack[stack.length - 1];
+            if (frame.next_edge >= frame.edges.length) {
+                colors.set(frame.id, 'visited');
+                stack.pop();
+                continue;
+            }
+            const target = frame.edges[frame.next_edge];
+            frame.next_edge += 1;
+            const targetColor = colors.get(target);
+            if (targetColor === 'visiting') {
+                onCycle(frame.id, target);
+            } else if (targetColor === undefined) {
+                colors.set(target, 'visiting');
+                stack.push({ id: target, edges: edgesFor(target), next_edge: 0 });
+            }
+        }
+    }
+}
+
+function compareTimestamps(first: string, second: string): number {
+    return Date.parse(first) - Date.parse(second);
+}
+
+function getTurnGenerationId(turn: ConversationTurn): string | undefined {
+    return turn.kind === 'agent' && 'generation_id' in turn ? turn.generation_id : undefined;
+}
+
+function allTurnBlocks(turn: ConversationTurn, turnPath: string): LocatedBlock[] {
+    const blocks: LocatedBlock[] = [];
+    for (let blockIndex = 0; blockIndex < turn.blocks.length; blockIndex += 1) {
+        const block = turn.blocks[blockIndex];
+        const path = `${turnPath}/blocks/${blockIndex}`;
+        blocks.push({ block, turn_id: turn.id, path });
+        if (block.type === 'tool_result') {
+            for (let nestedIndex = 0; nestedIndex < block.content.length; nestedIndex += 1) {
+                blocks.push({
+                    block: block.content[nestedIndex],
+                    turn_id: turn.id,
+                    path: `${path}/content/${nestedIndex}`,
+                });
+            }
+        }
+    }
+    return blocks;
+}
+
+function authorityRank(authority: ConversationTurn['authority']): number {
+    if (authority === 'system') {
+        return 2;
+    }
+    if (authority === 'developer') {
+        return 1;
+    }
+    return 0;
+}
+
+function validateUsage(
+    usage: GenerationUsage,
+    path: string,
+    add: (code: SemanticConversationDiagnosticCode, path: string, message: string, recordId?: string) => void,
+    generationId: string,
+): void {
+    const normalizedMetrics = USAGE_METRICS.filter((metric) => usage[metric] !== undefined);
+    const provenance = usage.accounting_provenance;
+    const provenanceMetrics = provenance === undefined ? [] : USAGE_METRICS.filter((metric) => provenance[metric]);
+
+    if (
+        normalizedMetrics.length === 0 &&
+        provenanceMetrics.length === 0 &&
+        (usage.reported_usage?.length ?? 0) === 0 &&
+        usage.cost === undefined
+    ) {
+        add(
+            'GENERATION_USAGE_EMPTY',
+            path,
+            'Unknown usage must be absent instead of represented by an empty object',
+            generationId,
+        );
+    }
+
+    for (const metric of USAGE_METRICS) {
+        const hasValue = usage[metric] !== undefined;
+        const hasProvenance = provenance?.[metric] !== undefined;
+        if (hasValue !== hasProvenance) {
+            add(
+                'ACCOUNTING_PROVENANCE_MISMATCH',
+                `${path}/${metric}`,
+                `Normalized ${metric} and its accounting provenance must either both be present or both be absent`,
+                generationId,
+            );
+        }
+    }
+
+    const input = usage.input_tokens;
+    const output = usage.output_tokens;
+    const total = usage.total_tokens;
+    const inputBasis = provenance?.input_tokens?.accounting_basis;
+    const outputBasis = provenance?.output_tokens?.accounting_basis;
+    const compatibleInputAndOutput =
+        input !== undefined && output !== undefined && inputBasis !== undefined && inputBasis === outputBasis;
+    if (total !== undefined && !compatibleInputAndOutput) {
+        add(
+            'USAGE_TOTAL_INVALID',
+            `${path}/total_tokens`,
+            'Canonical total_tokens requires compatible input_tokens and output_tokens',
+            generationId,
+        );
+    }
+    if (compatibleInputAndOutput) {
+        const sum = input + output;
+        if (!Number.isSafeInteger(sum)) {
+            add(
+                'USAGE_OVERFLOW',
+                `${path}/total_tokens`,
+                'input_tokens plus output_tokens exceeds Number.MAX_SAFE_INTEGER',
+                generationId,
+            );
+        } else if (total === undefined || total !== sum || provenance?.total_tokens?.accounting_basis !== inputBasis) {
+            add(
+                'USAGE_TOTAL_INVALID',
+                `${path}/total_tokens`,
+                'Canonical total_tokens must equal input_tokens plus output_tokens when both are known',
+                generationId,
+            );
+        }
+    }
+
+    if (input !== undefined) {
+        if (usage.cache_read_tokens !== undefined && usage.cache_read_tokens > input) {
+            add(
+                'USAGE_BREAKDOWN_INVALID',
+                `${path}/cache_read_tokens`,
+                'cache_read_tokens cannot exceed input_tokens',
+                generationId,
+            );
+        }
+        if (usage.cache_write_tokens !== undefined && usage.cache_write_tokens > input) {
+            add(
+                'USAGE_BREAKDOWN_INVALID',
+                `${path}/cache_write_tokens`,
+                'cache_write_tokens cannot exceed input_tokens',
+                generationId,
+            );
+        }
+    }
+    if (output !== undefined && usage.reasoning_tokens !== undefined && usage.reasoning_tokens > output) {
+        add(
+            'USAGE_BREAKDOWN_INVALID',
+            `${path}/reasoning_tokens`,
+            'reasoning_tokens cannot exceed output_tokens',
+            generationId,
+        );
+    }
+
+    if (usage.input_partition !== undefined) {
+        const newInput = usage.input_new_tokens;
+        const cacheRead = usage.cache_read_tokens;
+        const cacheWrite = usage.cache_write_tokens;
+        const includesWrite = usage.input_partition.cache_write_bucket === 'included';
+        const partitionBases = [
+            provenance?.input_new_tokens?.accounting_basis,
+            provenance?.cache_read_tokens?.accounting_basis,
+            ...(includesWrite ? [provenance?.cache_write_tokens?.accounting_basis] : []),
+        ];
+        if (
+            input === undefined ||
+            newInput === undefined ||
+            cacheRead === undefined ||
+            (includesWrite && cacheWrite === undefined) ||
+            (!includesWrite && cacheWrite !== undefined) ||
+            inputBasis === undefined ||
+            partitionBases.some((basis) => basis !== inputBasis)
+        ) {
+            add(
+                'INPUT_PARTITION_INVALID',
+                `${path}/input_partition`,
+                'A complete disjoint input partition must declare exactly its applicable token buckets',
+                generationId,
+            );
+        } else {
+            const partitionSum = newInput + cacheRead + (cacheWrite ?? 0);
+            if (!Number.isSafeInteger(partitionSum)) {
+                add(
+                    'USAGE_OVERFLOW',
+                    `${path}/input_partition`,
+                    'Input partition token buckets exceed Number.MAX_SAFE_INTEGER when added',
+                    generationId,
+                );
+            } else if (partitionSum !== input) {
+                add(
+                    'INPUT_PARTITION_INVALID',
+                    `${path}/input_partition`,
+                    'Complete disjoint input token buckets must add up to input_tokens',
+                    generationId,
+                );
+            }
+        }
+    }
+    if (
+        usage.input_new_tokens !== undefined &&
+        provenance?.input_new_tokens?.method === 'derived' &&
+        usage.input_partition === undefined
+    ) {
+        add(
+            'INPUT_PARTITION_INVALID',
+            `${path}/input_new_tokens`,
+            'Derived input_new_tokens requires a declared complete disjoint input partition',
+            generationId,
+        );
+    }
+}
+
+function validateRequestReceipt(
+    receipt: RequestReceipt,
+    generation: Generation,
+    path: string,
+    document: ConversationDocument,
+    turnsById: Map<string, LocatedTurn>,
+    blocksById: Map<string, LocatedBlock>,
+    callsById: Map<string, LocatedCall>,
+    add: (code: SemanticConversationDiagnosticCode, path: string, message: string, recordId?: string) => void,
+): void {
+    if (receipt.source.conversation_id !== document.id || receipt.source.revision > document.revision) {
+        add(
+            'GENERATION_SOURCE_INVALID',
+            `${path}/source`,
+            'Request receipt source is not a valid revision of this document',
+        );
+    }
+    if (
+        generation.record_source === 'executed' &&
+        (receipt.request_id !== generation.request_id || receipt.attempt_id !== generation.attempt_id)
+    ) {
+        add(
+            'GENERATION_REQUEST_MISMATCH',
+            path,
+            'Request receipt identity must match its executed generation',
+            generation.id,
+        );
+    }
+    if (receipt.source_tail_turn_id !== undefined) {
+        const retainedTail = turnsById.get(receipt.source_tail_turn_id);
+        if (retainedTail !== undefined && !retainedTail.source) {
+            add('REQUEST_MAPPING_INVALID', `${path}/source_tail_turn_id`, 'Retained request tail is not a source turn');
+        }
+    }
+    // Request receipts are historical facts and intentionally outlive transcript, definition, and
+    // asset deletion. Bindings are checked against retained records, but an absent historical record
+    // is not interpreted as a dangling live-document reference.
+    for (let index = 0; index < receipt.asset_versions.length; index += 1) {
+        const binding = receipt.asset_versions[index];
+        const asset = hasOwn(document.assets, binding.asset_id) ? document.assets[binding.asset_id] : undefined;
+        if (asset?.content_hash !== undefined && asset.content_hash !== binding.content_hash) {
+            add(
+                'REQUEST_MAPPING_INVALID',
+                `${path}/asset_versions/${index}/content_hash`,
+                `Asset ${diagnosticValue(binding.asset_id)} does not match the receipt content hash`,
+            );
+        }
+    }
+    for (let index = 0; index < receipt.item_mappings.length; index += 1) {
+        const mapping = receipt.item_mappings[index];
+        const exists =
+            (mapping.kind === 'turn' && turnsById.has(mapping.canonical_id)) ||
+            (mapping.kind === 'block' && blocksById.has(mapping.canonical_id)) ||
+            (mapping.kind === 'call' && callsById.has(mapping.canonical_id));
+        const retainedWithAnotherKind =
+            turnsById.has(mapping.canonical_id) ||
+            blocksById.has(mapping.canonical_id) ||
+            callsById.has(mapping.canonical_id);
+        if (!exists && retainedWithAnotherKind) {
+            add(
+                'REQUEST_MAPPING_INVALID',
+                `${path}/item_mappings/${index}/canonical_id`,
+                `Retained canonical item ${diagnosticValue(mapping.canonical_id)} does not have kind ${mapping.kind}`,
+            );
+        }
+    }
+}
+
+function validateMediaSelection(
+    block: AnyBlock,
+    blockPath: string,
+    asset: Asset,
+    add: (code: SemanticConversationDiagnosticCode, path: string, message: string, recordId?: string) => void,
+): void {
+    if (block.type === 'image' && block.selection?.coordinate_space === 'normalized') {
+        if (block.selection.x + block.selection.width > 1 || block.selection.y + block.selection.height > 1) {
+            add(
+                'SELECTION_RANGE_INVALID',
+                `${blockPath}/selection`,
+                'Normalized image selection must fit within the unit square',
+            );
+        }
+    }
+    if (block.type === 'image' && block.selection?.coordinate_space === 'pixels' && asset.media !== undefined) {
+        if (
+            (asset.media.width !== undefined && block.selection.x + block.selection.width > asset.media.width) ||
+            (asset.media.height !== undefined && block.selection.y + block.selection.height > asset.media.height)
+        ) {
+            add(
+                'SELECTION_RANGE_INVALID',
+                `${blockPath}/selection`,
+                'Pixel image selection exceeds known asset dimensions',
+            );
+        }
+    }
+    if (block.type === 'document' && block.selection !== undefined) {
+        if (block.selection.from_page > block.selection.through_page) {
+            add('SELECTION_RANGE_INVALID', `${blockPath}/selection`, 'Document page range is reversed');
+        }
+        if (asset.media?.page_count !== undefined && block.selection.through_page > asset.media.page_count) {
+            add(
+                'SELECTION_RANGE_INVALID',
+                `${blockPath}/selection`,
+                'Document page range exceeds the known page count',
+            );
+        }
+    }
+    if ((block.type === 'audio' || block.type === 'video') && block.selection !== undefined) {
+        if (block.selection.start_seconds >= block.selection.end_seconds) {
+            add('SELECTION_RANGE_INVALID', `${blockPath}/selection`, 'Media time range must be nonempty and ordered');
+        }
+        if (asset.media?.duration_seconds !== undefined && block.selection.end_seconds > asset.media.duration_seconds) {
+            add('SELECTION_RANGE_INVALID', `${blockPath}/selection`, 'Media time range exceeds the known duration');
+        }
+    }
+}
+
+function validateReplayDependencies(
+    replay: NativeReplayBlock,
+    path: string,
+    turnsById: Map<string, LocatedTurn>,
+    blocksById: Map<string, LocatedBlock>,
+    callsById: Map<string, LocatedCall>,
+    requestIds: Set<string>,
+    add: (code: SemanticConversationDiagnosticCode, path: string, message: string, recordId?: string) => void,
+): void {
+    const groups: Array<[readonly string[], { has(id: string): boolean }, string]> = [
+        [replay.dependencies.turn_ids, turnsById, 'turn_ids'],
+        [replay.dependencies.block_ids, blocksById, 'block_ids'],
+        [replay.dependencies.call_ids, callsById, 'call_ids'],
+        [replay.dependencies.request_ids, requestIds, 'request_ids'],
+    ];
+    for (const [ids, known, field] of groups) {
+        for (let index = 0; index < ids.length; index += 1) {
+            if (!known.has(ids[index])) {
+                add(
+                    'REFERENCE_NOT_FOUND',
+                    `${path}/dependencies/${field}/${index}`,
+                    `Replay dependency ${diagnosticValue(ids[index])} is missing`,
+                );
+            }
+        }
+    }
+}
+
+function validateCompaction(
+    compaction: CompactionRecord,
+    path: string,
+    sourceTurnsById: Map<string, LocatedTurn>,
+    blocksById: Map<string, LocatedBlock>,
+    document: ConversationDocument,
+    add: (code: SemanticConversationDiagnosticCode, path: string, message: string, recordId?: string) => void,
+): void {
+    const sourceAuthorities = new Set<ConversationTurn['authority']>();
+    const declaredSourceTurns = new Set(compaction.source.turn_ids);
+    for (let index = 0; index < compaction.source.turn_ids.length; index += 1) {
+        const turnId = compaction.source.turn_ids[index];
+        const located = sourceTurnsById.get(turnId);
+        if (located === undefined || located.compaction_id === compaction.id) {
+            add(
+                'REFERENCE_NOT_FOUND',
+                `${path}/source/turn_ids/${index}`,
+                `Compaction source turn ${diagnosticValue(turnId)} is missing or belongs to the same compaction`,
+            );
+        } else {
+            sourceAuthorities.add(located.turn.authority);
+        }
+    }
+    for (let index = 0; index < (compaction.source.block_ids?.length ?? 0); index += 1) {
+        const blockId = compaction.source.block_ids?.[index];
+        const located = blockId === undefined ? undefined : blocksById.get(blockId);
+        if (located === undefined || !declaredSourceTurns.has(located.turn_id)) {
+            add(
+                'REFERENCE_NOT_FOUND',
+                `${path}/source/block_ids/${index}`,
+                `Compaction block ${diagnosticValue(blockId ?? '')} is outside the declared source turns`,
+            );
+        }
+    }
+    if (sourceAuthorities.size > 1) {
+        add(
+            'DERIVED_AUTHORITY_MIXED',
+            `${path}/source/turn_ids`,
+            'One compaction replacement cannot combine mixed source authorities',
+            compaction.id,
+        );
+    }
+    const sourceAuthority = sourceAuthorities.values().next().value;
+    const declaredSourceBlocks =
+        compaction.source.block_ids === undefined ? undefined : new Set(compaction.source.block_ids);
+    for (let index = 0; index < compaction.replacement_turns.length; index += 1) {
+        const replacement = compaction.replacement_turns[index];
+        const replacementPath = `${path}/replacement_turns/${index}`;
+        if (replacement.provenance.type !== 'derived' || replacement.provenance.derivation_id !== compaction.id) {
+            add(
+                'DERIVED_PROVENANCE_MISMATCH',
+                `${replacementPath}/provenance`,
+                'Compaction replacement must be derived by the containing compaction',
+                replacement.id,
+            );
+            continue;
+        }
+        for (let sourceIndex = 0; sourceIndex < replacement.provenance.source_turn_ids.length; sourceIndex += 1) {
+            const sourceTurnId = replacement.provenance.source_turn_ids[sourceIndex];
+            if (!declaredSourceTurns.has(sourceTurnId)) {
+                add(
+                    'DERIVED_PROVENANCE_MISMATCH',
+                    `${replacementPath}/provenance/source_turn_ids/${sourceIndex}`,
+                    `Derived source turn ${diagnosticValue(sourceTurnId)} is outside the compaction selection`,
+                    replacement.id,
+                );
+            }
+        }
+        if (declaredSourceBlocks !== undefined && replacement.provenance.source_block_ids === undefined) {
+            add(
+                'DERIVED_PROVENANCE_MISMATCH',
+                `${replacementPath}/provenance/source_block_ids`,
+                'A replacement of a partial block selection must identify its source blocks',
+                replacement.id,
+            );
+        }
+        const replacementSourceTurns = new Set(replacement.provenance.source_turn_ids);
+        for (
+            let sourceIndex = 0;
+            sourceIndex < (replacement.provenance.source_block_ids?.length ?? 0);
+            sourceIndex += 1
+        ) {
+            const sourceBlockId = replacement.provenance.source_block_ids?.[sourceIndex];
+            const located = sourceBlockId === undefined ? undefined : blocksById.get(sourceBlockId);
+            if (
+                located === undefined ||
+                !replacementSourceTurns.has(located.turn_id) ||
+                !declaredSourceTurns.has(located.turn_id) ||
+                (declaredSourceBlocks !== undefined && !declaredSourceBlocks.has(sourceBlockId ?? ''))
+            ) {
+                add(
+                    'DERIVED_PROVENANCE_MISMATCH',
+                    `${replacementPath}/provenance/source_block_ids/${sourceIndex}`,
+                    `Derived block ${diagnosticValue(sourceBlockId ?? '')} is outside the declared source selection`,
+                    replacement.id,
+                );
+            }
+        }
+        if (sourceAuthority !== undefined && authorityRank(replacement.authority) > authorityRank(sourceAuthority)) {
+            add(
+                'DERIVED_AUTHORITY_PROMOTED',
+                `${replacementPath}/authority`,
+                'Derived replacement authority cannot exceed its source authority',
+                replacement.id,
+            );
+        }
+    }
+    for (let index = 0; index < compaction.retained_asset_ids.length; index += 1) {
+        const assetId = compaction.retained_asset_ids[index];
+        if (!hasOwn(document.assets, assetId)) {
+            add(
+                'REFERENCE_NOT_FOUND',
+                `${path}/retained_asset_ids/${index}`,
+                `Retained asset ${diagnosticValue(assetId)} does not exist`,
+            );
+        }
+    }
+    for (let index = 0; index < compaction.generation_ids.length; index += 1) {
+        const generationId = compaction.generation_ids[index];
+        if (!hasOwn(document.generations, generationId)) {
+            add(
+                'REFERENCE_NOT_FOUND',
+                `${path}/generation_ids/${index}`,
+                `Generation ${diagnosticValue(generationId)} does not exist`,
+            );
+        }
+    }
+}
+
+export function validateConversationSemantics(document: ConversationDocument): ConversationDiagnostic[] {
+    const diagnostics: ConversationDiagnostic[] = [];
+    const add = (code: SemanticConversationDiagnosticCode, path: string, message: string, recordId?: string): void => {
+        if (diagnostics.length < MAX_SEMANTIC_DIAGNOSTICS - 1) {
+            const diagnostic: SemanticConversationDiagnostic = {
+                code,
+                stage: 'semantic',
+                path,
+                message,
+                record_id: recordId,
+            };
+            diagnostics.push(boundConversationDiagnostic(diagnostic));
+        } else if (diagnostics.length === MAX_SEMANTIC_DIAGNOSTICS - 1) {
+            diagnostics.push(
+                boundConversationDiagnostic({
+                    code: 'SEMANTIC_DIAGNOSTIC_LIMIT',
+                    stage: 'semantic',
+                    path,
+                    message: `Semantic validation stopped reporting after ${MAX_SEMANTIC_DIAGNOSTICS - 1} diagnostics`,
+                    limit: MAX_SEMANTIC_DIAGNOSTICS - 1,
+                }),
+            );
+        }
+    };
+
+    const globalIds = new Map<string, { kind: string; path: string }>();
+    const registerId = (id: string, kind: string, path: string): void => {
+        const prior = globalIds.get(id);
+        if (prior !== undefined) {
+            add(
+                'DUPLICATE_ID',
+                path,
+                `${kind} ID ${diagnosticValue(id)} duplicates ${prior.kind} at ${prior.path}`,
+                id,
+            );
+        } else {
+            globalIds.set(id, { kind, path });
+        }
+    };
+    registerId(document.id, 'conversation', '/id');
+
+    if (compareTimestamps(document.created_at, document.updated_at) > 0) {
+        add('TIMESTAMP_ORDER_INVALID', '/updated_at', 'updated_at cannot be earlier than created_at', document.id);
+    }
+    if (document.context.revision > document.revision) {
+        add(
+            'CONTEXT_REVISION_INVALID',
+            '/context/revision',
+            'Context revision cannot exceed document revision',
+            document.id,
+        );
+    }
+
+    const turnsById = new Map<string, LocatedTurn>();
+    const blocksById = new Map<string, LocatedBlock>();
+    const callsById = new Map<string, LocatedCall>();
+    const sourceResultCalls = new Map<string, string>();
+    const requestIds = new Set<string>();
+
+    const registerTurn = (turn: ConversationTurn, path: string, source: boolean, compactionId?: string): void => {
+        registerId(turn.id, source ? 'source turn' : 'replacement turn', `${path}/id`);
+        if (!turnsById.has(turn.id)) {
+            turnsById.set(turn.id, { turn, path, source, compaction_id: compactionId });
+        }
+        const blocks = allTurnBlocks(turn, path);
+        for (const located of blocks) {
+            registerId(located.block.id, 'block', `${located.path}/id`);
+            if (!blocksById.has(located.block.id)) {
+                blocksById.set(located.block.id, located);
+            }
+            if (located.block.type === 'tool_call') {
+                registerId(located.block.call_id, 'tool call', `${located.path}/call_id`);
+                if (!callsById.has(located.block.call_id)) {
+                    callsById.set(located.block.call_id, { ...located, block: located.block, source });
+                }
+            }
+            if (source && located.block.type === 'tool_result') {
+                const priorResult = sourceResultCalls.get(located.block.call_id);
+                if (priorResult !== undefined) {
+                    add(
+                        'DUPLICATE_TERMINAL_RESULT',
+                        `${located.path}/call_id`,
+                        `Call ${diagnosticValue(located.block.call_id)} already has terminal result at ${priorResult}`,
+                        located.block.call_id,
+                    );
+                } else {
+                    sourceResultCalls.set(located.block.call_id, located.path);
+                }
+            }
+        }
+    };
+
+    for (let index = 0; index < document.turns.length; index += 1) {
+        registerTurn(document.turns[index], `/turns/${index}`, true);
+    }
+    for (const [compactionId, compaction] of Object.entries(document.compactions)) {
+        const path = recordPath('compactions', compactionId);
+        if (compactionId !== compaction.id) {
+            add(
+                'MAP_KEY_ID_MISMATCH',
+                path,
+                `Compaction key ${diagnosticValue(compactionId)} differs from ID ${diagnosticValue(compaction.id)}`,
+            );
+        }
+        registerId(compaction.id, 'compaction', `${path}/id`);
+        for (let index = 0; index < compaction.replacement_turns.length; index += 1) {
+            registerTurn(
+                compaction.replacement_turns[index],
+                `${path}/replacement_turns/${index}`,
+                false,
+                compaction.id,
+            );
+        }
+    }
+
+    const checkEntityMap = <T extends { id: string }>(
+        collection: string,
+        record: Record<string, T>,
+        kind: string,
+    ): void => {
+        for (const [key, value] of Object.entries(record)) {
+            const path = recordPath(collection, key);
+            if (key !== value.id) {
+                add(
+                    'MAP_KEY_ID_MISMATCH',
+                    path,
+                    `${kind} map key ${diagnosticValue(key)} does not match id ${diagnosticValue(value.id)}`,
+                    value.id,
+                );
+            }
+            registerId(value.id, kind, `${path}/id`);
+        }
+    };
+
+    checkEntityMap('generations', document.generations, 'generation');
+    checkEntityMap('operation_receipts', document.operation_receipts, 'operation receipt');
+    checkEntityMap('execution_receipts', document.execution_receipts, 'execution receipt');
+    checkEntityMap('assets', document.assets, 'asset');
+    checkEntityMap('tool_definitions', document.tool_definitions, 'tool definition');
+
+    for (const [generationId, generation] of Object.entries(document.generations)) {
+        const path = recordPath('generations', generationId);
+        if (generation.source.conversation_id !== document.id || generation.source.revision > document.revision) {
+            add(
+                'GENERATION_SOURCE_INVALID',
+                `${path}/source`,
+                'Generation source is not a valid revision of this document',
+            );
+        }
+        if (generation.request_id !== undefined) {
+            requestIds.add(generation.request_id);
+        }
+        if (generation.request_receipt !== undefined) {
+            registerId(generation.request_receipt.id, 'request receipt', `${path}/request_receipt/id`);
+            requestIds.add(generation.request_receipt.request_id);
+            validateRequestReceipt(
+                generation.request_receipt,
+                generation,
+                `${path}/request_receipt`,
+                document,
+                turnsById,
+                blocksById,
+                callsById,
+                add,
+            );
+        }
+        if (generation.usage !== undefined) {
+            validateUsage(generation.usage, `${path}/usage`, add, generation.id);
+        }
+        if (
+            generation.timestamps.started_at !== undefined &&
+            generation.timestamps.completed_at !== undefined &&
+            compareTimestamps(generation.timestamps.started_at, generation.timestamps.completed_at) > 0
+        ) {
+            add(
+                'TIMESTAMP_ORDER_INVALID',
+                `${path}/timestamps/completed_at`,
+                'Generation completed_at cannot be earlier than started_at',
+                generation.id,
+            );
+        }
+    }
+
+    for (const located of turnsById.values()) {
+        const { turn, path } = located;
+        const generationId = getTurnGenerationId(turn);
+        if (generationId !== undefined && !hasOwn(document.generations, generationId)) {
+            add(
+                'REFERENCE_NOT_FOUND',
+                `${path}/generation_id`,
+                `Generation ${diagnosticValue(generationId)} does not exist`,
+                turn.id,
+            );
+        }
+        if (turn.parent_turn_id !== undefined && !turnsById.has(turn.parent_turn_id)) {
+            add(
+                'REFERENCE_NOT_FOUND',
+                `${path}/parent_turn_id`,
+                `Parent turn ${diagnosticValue(turn.parent_turn_id)} does not exist`,
+                turn.id,
+            );
+        }
+        if (turn.execution_id !== undefined && !hasOwn(document.execution_receipts, turn.execution_id)) {
+            add(
+                'REFERENCE_NOT_FOUND',
+                `${path}/execution_id`,
+                `Execution receipt ${diagnosticValue(turn.execution_id)} does not exist`,
+                turn.id,
+            );
+        }
+        if (
+            turn.timestamps.started_at !== undefined &&
+            turn.timestamps.completed_at !== undefined &&
+            compareTimestamps(turn.timestamps.started_at, turn.timestamps.completed_at) > 0
+        ) {
+            add(
+                'TIMESTAMP_ORDER_INVALID',
+                `${path}/timestamps/completed_at`,
+                'Turn completed_at cannot be earlier than started_at',
+                turn.id,
+            );
+        }
+    }
+
+    validateDirectedCycles(
+        turnsById.keys(),
+        (turnId) => {
+            const parentId = turnsById.get(turnId)?.turn.parent_turn_id;
+            return parentId !== undefined && turnsById.has(parentId) ? [parentId] : [];
+        },
+        (from, to) => {
+            const located = turnsById.get(from);
+            add(
+                'PARENT_TURN_CYCLE',
+                `${located?.path ?? ''}/parent_turn_id`,
+                `Parent-turn relationship contains a cycle through ${diagnosticValue(to)}`,
+                from,
+            );
+        },
+    );
+    validateDirectedCycles(
+        turnsById.keys(),
+        (turnId) => {
+            const turn = turnsById.get(turnId)?.turn;
+            return turn?.provenance.type === 'derived'
+                ? turn.provenance.source_turn_ids.filter((sourceId) => turnsById.has(sourceId))
+                : [];
+        },
+        (from, to) => {
+            const located = turnsById.get(from);
+            add(
+                'DERIVED_PROVENANCE_CYCLE',
+                `${located?.path ?? ''}/provenance/source_turn_ids`,
+                `Derived-turn provenance contains a cycle through ${diagnosticValue(to)}`,
+                from,
+            );
+        },
+    );
+
+    for (const [assetId, asset] of Object.entries(document.assets)) {
+        const path = recordPath('assets', assetId);
+        if (asset.provenance.type === 'generated' && !hasOwn(document.generations, asset.provenance.generation_id)) {
+            add(
+                'REFERENCE_NOT_FOUND',
+                `${path}/provenance/generation_id`,
+                `Generation ${diagnosticValue(asset.provenance.generation_id)} does not exist`,
+                asset.id,
+            );
+        }
+        if (asset.provenance.type === 'derived') {
+            if (
+                asset.provenance.source_asset_id === asset.id ||
+                !hasOwn(document.assets, asset.provenance.source_asset_id)
+            ) {
+                add(
+                    'REFERENCE_NOT_FOUND',
+                    `${path}/provenance/source_asset_id`,
+                    `Derived asset ${diagnosticValue(asset.provenance.source_asset_id)} is missing or self-referential`,
+                    asset.id,
+                );
+            }
+        }
+        if (asset.provenance.type === 'received' && asset.provenance.source_turn_id !== undefined) {
+            if (!turnsById.has(asset.provenance.source_turn_id)) {
+                add(
+                    'REFERENCE_NOT_FOUND',
+                    `${path}/provenance/source_turn_id`,
+                    `Source turn ${diagnosticValue(asset.provenance.source_turn_id)} does not exist`,
+                    asset.id,
+                );
+            }
+        }
+    }
+
+    validateDirectedCycles(
+        Object.keys(document.assets),
+        (assetId) => {
+            const asset = hasOwn(document.assets, assetId) ? document.assets[assetId] : undefined;
+            return asset?.provenance.type === 'derived' && hasOwn(document.assets, asset.provenance.source_asset_id)
+                ? [asset.provenance.source_asset_id]
+                : [];
+        },
+        (from, to) => {
+            add(
+                'DERIVED_PROVENANCE_CYCLE',
+                `${recordPath('assets', from)}/provenance/source_asset_id`,
+                `Derived-asset provenance contains a cycle through ${diagnosticValue(to)}`,
+                from,
+            );
+        },
+    );
+
+    const terminalReceiptCalls = new Map<string, string>();
+    for (const [receiptId, receipt] of Object.entries(document.execution_receipts)) {
+        const path = recordPath('execution_receipts', receiptId);
+        const call = callsById.get(receipt.call_id);
+        // Receipts outlive logically deleted call/result content. Absence is therefore valid; when
+        // the content remains present, its executor and result identity are checked.
+        if (call !== undefined && call.block.executor !== receipt.executor) {
+            add('TOOL_RECEIPT_MISMATCH', `${path}/executor`, 'Execution receipt executor does not match its tool call');
+        }
+        const prior = terminalReceiptCalls.get(receipt.call_id);
+        if (prior !== undefined) {
+            add(
+                'DUPLICATE_TERMINAL_RESULT',
+                `${path}/call_id`,
+                `Call ${diagnosticValue(receipt.call_id)} already has terminal receipt ${diagnosticValue(prior)}`,
+                receipt.call_id,
+            );
+        } else {
+            terminalReceiptCalls.set(receipt.call_id, receipt.id);
+        }
+        if (receipt.result_turn_id !== undefined) {
+            const resultTurn = turnsById.get(receipt.result_turn_id);
+            if (resultTurn !== undefined) {
+                const matchingResult = resultTurn.turn.blocks.find(
+                    (block): block is ToolResultBlock =>
+                        block.type === 'tool_result' && block.call_id === receipt.call_id,
+                );
+                if (matchingResult === undefined) {
+                    add(
+                        'TOOL_RESULT_UNRESOLVED',
+                        `${path}/result_turn_id`,
+                        'Execution receipt result turn does not contain its call result',
+                        receipt.id,
+                    );
+                } else if (matchingResult.status !== receipt.status) {
+                    add(
+                        'TOOL_RECEIPT_MISMATCH',
+                        `${path}/status`,
+                        'Execution receipt status does not match its retained terminal result',
+                        receipt.id,
+                    );
+                }
+            }
+        }
+    }
+
+    for (const located of blocksById.values()) {
+        const { block, path } = located;
+        if (block.type === 'tool_call' && block.definition_id !== undefined) {
+            const definition = hasOwn(document.tool_definitions, block.definition_id)
+                ? document.tool_definitions[block.definition_id]
+                : undefined;
+            if (definition === undefined) {
+                add(
+                    'REFERENCE_NOT_FOUND',
+                    `${path}/definition_id`,
+                    `Tool definition ${diagnosticValue(block.definition_id)} does not exist`,
+                    block.id,
+                );
+            } else if (definition.name !== block.tool_name) {
+                add(
+                    'TOOL_DEFINITION_MISMATCH',
+                    `${path}/tool_name`,
+                    `Tool call name ${diagnosticValue(block.tool_name)} does not match its pinned definition`,
+                    block.id,
+                );
+            }
+        }
+        if (block.type === 'tool_result' && !callsById.has(block.call_id) && !terminalReceiptCalls.has(block.call_id)) {
+            add(
+                'TOOL_RESULT_UNRESOLVED',
+                `${path}/call_id`,
+                `Tool result call ${diagnosticValue(block.call_id)} has no retained call or terminal receipt`,
+                block.id,
+            );
+        }
+        if (
+            block.type === 'image' ||
+            block.type === 'document' ||
+            block.type === 'audio' ||
+            block.type === 'video' ||
+            block.type === 'external_reference'
+        ) {
+            const asset = hasOwn(document.assets, block.asset_id) ? document.assets[block.asset_id] : undefined;
+            if (asset === undefined) {
+                add(
+                    'REFERENCE_NOT_FOUND',
+                    `${path}/asset_id`,
+                    `Asset ${diagnosticValue(block.asset_id)} does not exist`,
+                    block.id,
+                );
+            } else if (block.type !== 'external_reference') {
+                if (asset.kind !== block.type) {
+                    add(
+                        'ASSET_KIND_MISMATCH',
+                        `${path}/asset_id`,
+                        `${block.type} block references ${asset.kind} asset ${diagnosticValue(asset.id)}`,
+                        block.id,
+                    );
+                }
+                validateMediaSelection(block, path, asset, add);
+            }
+            if (
+                block.type === 'external_reference' &&
+                block.retrieval.tool_definition_id !== undefined &&
+                !hasOwn(document.tool_definitions, block.retrieval.tool_definition_id)
+            ) {
+                add(
+                    'REFERENCE_NOT_FOUND',
+                    `${path}/retrieval/tool_definition_id`,
+                    `Retrieval tool definition ${diagnosticValue(block.retrieval.tool_definition_id)} does not exist`,
+                    block.id,
+                );
+            }
+        }
+        if (block.type === 'native_replay') {
+            validateReplayDependencies(block, path, turnsById, blocksById, callsById, requestIds, add);
+        }
+    }
+
+    for (const [operationId, receipt] of Object.entries(document.operation_receipts)) {
+        const path = recordPath('operation_receipts', operationId);
+        if (receipt.conversation_id !== document.id) {
+            add('REFERENCE_NOT_FOUND', `${path}/conversation_id`, 'Operation receipt belongs to another conversation');
+        }
+        if (receipt.base_revision > receipt.result_revision || receipt.result_revision > document.revision) {
+            add(
+                'CONTEXT_REVISION_INVALID',
+                path,
+                'Operation receipt revisions are reversed or newer than the document',
+            );
+        }
+    }
+
+    for (const [compactionId, compaction] of Object.entries(document.compactions)) {
+        validateCompaction(compaction, recordPath('compactions', compactionId), turnsById, blocksById, document, add);
+    }
+
+    for (const [compactionId, compaction] of Object.entries(document.compactions)) {
+        const supersededId = compaction.supersedes_compaction_id;
+        if (supersededId !== undefined && !hasOwn(document.compactions, supersededId)) {
+            add(
+                'REFERENCE_NOT_FOUND',
+                `${recordPath('compactions', compactionId)}/supersedes_compaction_id`,
+                `Superseded compaction ${diagnosticValue(supersededId)} does not exist`,
+                compactionId,
+            );
+        }
+    }
+    validateDirectedCycles(
+        Object.keys(document.compactions),
+        (compactionId) => {
+            const nextId = document.compactions[compactionId]?.supersedes_compaction_id;
+            return nextId !== undefined && hasOwn(document.compactions, nextId) ? [nextId] : [];
+        },
+        (from, to) => {
+            add(
+                'SUPERSEDES_CYCLE',
+                `${recordPath('compactions', from)}/supersedes_compaction_id`,
+                `Compaction supersedes chain contains a cycle through ${diagnosticValue(to)}`,
+                from,
+            );
+        },
+    );
+
+    const contextEntryIds = new Map<string, string>();
+    const activeSelections = new Map<string, ActiveSelectionIndex>();
+    const sourceSelectionsForEntry = (entry: ContextEntry, path: string, located: LocatedTurn): ActiveSelection[] => {
+        if (entry.type === 'source_turn') {
+            return [
+                {
+                    turn_id: entry.turn_id,
+                    all_blocks: entry.block_ids === undefined,
+                    block_ids: new Set(entry.block_ids ?? []),
+                    origin: 'direct',
+                    path,
+                },
+            ];
+        }
+        const provenance = located.turn.provenance;
+        if (provenance.type !== 'derived') {
+            return [];
+        }
+        if (provenance.source_block_ids === undefined) {
+            return provenance.source_turn_ids.map((turnId) => ({
+                turn_id: turnId,
+                all_blocks: true,
+                block_ids: new Set<string>(),
+                origin: 'replacement',
+                path,
+                compaction_id: entry.compaction_id,
+            }));
+        }
+        const blocksByTurn = new Map<string, Set<string>>();
+        for (const blockId of provenance.source_block_ids) {
+            const sourceTurnId = blocksById.get(blockId)?.turn_id;
+            if (sourceTurnId === undefined) {
+                continue;
+            }
+            const selectedBlocks = blocksByTurn.get(sourceTurnId) ?? new Set<string>();
+            selectedBlocks.add(blockId);
+            blocksByTurn.set(sourceTurnId, selectedBlocks);
+        }
+        return [...blocksByTurn].map(([turnId, blockIds]) => ({
+            turn_id: turnId,
+            all_blocks: false,
+            block_ids: blockIds,
+            origin: 'replacement',
+            path,
+            compaction_id: entry.compaction_id,
+        }));
+    };
+    const registerActiveSelection = (selection: ActiveSelection, entryId: string): void => {
+        const existing = activeSelections.get(selection.turn_id);
+        let overlap: ActiveSelection | undefined;
+        if (existing !== undefined) {
+            if (selection.all_blocks) {
+                overlap = existing.first;
+            } else if (existing.all !== undefined) {
+                overlap = existing.all;
+            } else {
+                for (const blockId of selection.block_ids) {
+                    const prior = existing.by_block_id.get(blockId);
+                    if (prior !== undefined) {
+                        overlap = prior;
+                        break;
+                    }
+                }
+            }
+        }
+        if (overlap !== undefined && selectionsOverlap(overlap, selection)) {
+            const directAndReplacement = overlap.origin !== selection.origin;
+            add(
+                directAndReplacement ? 'CONTEXT_DIRECT_REPLACEMENT_OVERLAP' : 'CONTEXT_SELECTION_OVERLAP',
+                selection.path,
+                `Context selection overlaps the active selection at ${overlap.path}`,
+                entryId,
+            );
+        }
+        const index = existing ?? { first: selection, by_block_id: new Map<string, ActiveSelection>() };
+        if (selection.all_blocks && index.all === undefined) {
+            index.all = selection;
+        }
+        for (const blockId of selection.block_ids) {
+            if (!index.by_block_id.has(blockId)) {
+                index.by_block_id.set(blockId, selection);
+            }
+        }
+        activeSelections.set(selection.turn_id, index);
+    };
+    for (let index = 0; index < document.context.entries.length; index += 1) {
+        const entry = document.context.entries[index];
+        const path = `/context/entries/${index}`;
+        registerId(entry.id, 'context entry', `${path}/id`);
+        const prior = contextEntryIds.get(entry.id);
+        if (prior !== undefined) {
+            add(
+                'DUPLICATE_ID',
+                `${path}/id`,
+                `Context entry ${diagnosticValue(entry.id)} duplicates ${prior}`,
+                entry.id,
+            );
+        } else {
+            contextEntryIds.set(entry.id, path);
+        }
+        const located = turnsById.get(entry.turn_id);
+        const validTarget =
+            entry.type === 'source_turn'
+                ? located?.source === true
+                : located?.source === false && located.compaction_id === entry.compaction_id;
+        if (!validTarget || located === undefined) {
+            add(
+                'REFERENCE_NOT_FOUND',
+                `${path}/turn_id`,
+                `Context turn ${diagnosticValue(entry.turn_id)} is missing or has the wrong source kind`,
+            );
+            continue;
+        }
+        if (entry.block_ids !== undefined) {
+            let priorBlockIndex = -1;
+            const turnBlockIds = located.turn.blocks.map((block) => block.id);
+            for (let blockIndex = 0; blockIndex < entry.block_ids.length; blockIndex += 1) {
+                const selectedId = entry.block_ids[blockIndex];
+                const currentBlockIndex = turnBlockIds.indexOf(selectedId);
+                if (currentBlockIndex <= priorBlockIndex) {
+                    add(
+                        'CONTEXT_BLOCK_ORDER_INVALID',
+                        `${path}/block_ids/${blockIndex}`,
+                        `Selected block ${diagnosticValue(selectedId)} is missing, duplicated, or out of source order`,
+                        entry.id,
+                    );
+                }
+                priorBlockIndex = currentBlockIndex;
+            }
+        }
+        for (const selection of sourceSelectionsForEntry(entry, path, located)) {
+            registerActiveSelection(selection, entry.id);
+        }
+    }
+    for (let index = 0; index < document.context.active_tool_definition_ids.length; index += 1) {
+        const definitionId = document.context.active_tool_definition_ids[index];
+        if (!hasOwn(document.tool_definitions, definitionId)) {
+            add(
+                'REFERENCE_NOT_FOUND',
+                `/context/active_tool_definition_ids/${index}`,
+                `Active tool definition ${diagnosticValue(definitionId)} does not exist`,
+            );
+        }
+    }
+    for (let index = 0; index < document.context.protected_entry_ids.length; index += 1) {
+        const entryId = document.context.protected_entry_ids[index];
+        if (!contextEntryIds.has(entryId)) {
+            add(
+                'REFERENCE_NOT_FOUND',
+                `/context/protected_entry_ids/${index}`,
+                `Protected context entry ${diagnosticValue(entryId)} does not exist`,
+            );
+        }
+    }
+    if (
+        document.context.cache_intent?.stable_through_entry_id !== undefined &&
+        !contextEntryIds.has(document.context.cache_intent.stable_through_entry_id)
+    ) {
+        add(
+            'REFERENCE_NOT_FOUND',
+            '/context/cache_intent/stable_through_entry_id',
+            `Cache boundary ${diagnosticValue(document.context.cache_intent.stable_through_entry_id)} does not exist`,
+        );
+    }
+    const retrievalRequirementIds = new Set<string>();
+    for (let index = 0; index < document.context.retrieval_requirements.length; index += 1) {
+        const requirement = document.context.retrieval_requirements[index];
+        const path = `/context/retrieval_requirements/${index}`;
+        registerId(requirement.id, 'retrieval requirement', `${path}/id`);
+        if (retrievalRequirementIds.has(requirement.id)) {
+            add(
+                'DUPLICATE_ID',
+                `${path}/id`,
+                `Retrieval requirement ${diagnosticValue(requirement.id)} is duplicated`,
+                requirement.id,
+            );
+        }
+        retrievalRequirementIds.add(requirement.id);
+        if (!hasOwn(document.assets, requirement.asset_id)) {
+            add(
+                'REFERENCE_NOT_FOUND',
+                `${path}/asset_id`,
+                `Retrieval asset ${diagnosticValue(requirement.asset_id)} does not exist`,
+            );
+        }
+        if (
+            requirement.retrieval.tool_definition_id !== undefined &&
+            !hasOwn(document.tool_definitions, requirement.retrieval.tool_definition_id)
+        ) {
+            add(
+                'REFERENCE_NOT_FOUND',
+                `${path}/retrieval/tool_definition_id`,
+                `Retrieval tool definition ${diagnosticValue(requirement.retrieval.tool_definition_id)} does not exist`,
+            );
+        }
+    }
+
+    const processorKeys = new Set<string>();
+    for (let index = 0; index < document.processing.processors.length; index += 1) {
+        const processor = document.processing.processors[index];
+        const key = `${processor.id}\u0000${processor.version}`;
+        if (processorKeys.has(key)) {
+            add(
+                'DUPLICATE_ID',
+                `/processing/processors/${index}`,
+                `Processor ${diagnosticValue(processor.id)}@${diagnosticValue(processor.version)} is duplicated`,
+            );
+        }
+        processorKeys.add(key);
+    }
+
+    return diagnostics;
+}

--- a/conversation/src/serialization.ts
+++ b/conversation/src/serialization.ts
@@ -1,0 +1,101 @@
+import {
+    boundConversationDiagnostic,
+    ConversationValidationError,
+    type ConversationValidationResult,
+} from './diagnostics.js';
+import { DEFAULT_JSON_INPUT_LIMITS } from './json-preflight.js';
+import type { ConversationDocument } from './types.js';
+import {
+    type ConversationValidationOptions,
+    parseConversationDocument,
+    validateConversationDocument,
+} from './validation.js';
+
+function materializedByteLimit(options: ConversationValidationOptions): number {
+    const limit = options.json_input_limits?.max_bytes ?? DEFAULT_JSON_INPUT_LIMITS.max_bytes;
+    if (!Number.isSafeInteger(limit) || limit < 1) {
+        throw new RangeError('max_bytes must be a positive safe integer');
+    }
+    return limit;
+}
+
+function jsonTextBytesWithinLimit(text: string, limit: number): number | undefined {
+    // Every UTF-16 code unit occupies at least one UTF-8 byte. Avoid encoding a text that already
+    // exceeds the limit by this cheap lower bound.
+    if (text.length > limit) {
+        return undefined;
+    }
+    const bytes = new TextEncoder().encode(text).byteLength;
+    return bytes <= limit ? bytes : undefined;
+}
+
+export function parseConversationJson(
+    text: string,
+    options: ConversationValidationOptions = {},
+): ConversationValidationResult<ConversationDocument> {
+    const limit = materializedByteLimit(options);
+    const bytes = jsonTextBytesWithinLimit(text, limit);
+    if (bytes === undefined) {
+        return {
+            success: false,
+            diagnostics: [
+                boundConversationDiagnostic({
+                    code: 'JSON_MAX_BYTES',
+                    stage: 'preflight',
+                    path: '',
+                    message: 'Materialized conversation JSON exceeds the configured byte limit',
+                    limit,
+                    observed: Math.min(Number.MAX_SAFE_INTEGER, Math.max(limit + 1, text.length)),
+                }),
+            ],
+        };
+    }
+
+    let input: unknown;
+    try {
+        input = JSON.parse(text);
+    } catch {
+        return {
+            success: false,
+            diagnostics: [
+                boundConversationDiagnostic({
+                    code: 'SCHEMA_INVALID',
+                    stage: 'schema',
+                    path: '',
+                    message: 'Conversation input is not valid JSON text',
+                }),
+            ],
+        };
+    }
+    return validateConversationDocument(input, options);
+}
+
+export function conversationDocumentFromJson(
+    text: string,
+    options: ConversationValidationOptions = {},
+): ConversationDocument {
+    const result = parseConversationJson(text, options);
+    if (!result.success) {
+        throw new ConversationValidationError('Conversation JSON validation failed', result.diagnostics);
+    }
+    return result.data;
+}
+
+export function conversationDocumentToJson(input: unknown, options: ConversationValidationOptions = {}): string {
+    const document = parseConversationDocument(input, options);
+    const text = JSON.stringify(document);
+    const limit = materializedByteLimit(options);
+    if (jsonTextBytesWithinLimit(text, limit) === undefined) {
+        throw new ConversationValidationError('Serialized conversation exceeds the configured byte limit', [
+            boundConversationDiagnostic({
+                code: 'JSON_MAX_BYTES',
+                stage: 'preflight',
+                path: '',
+                message: 'Serialized conversation exceeds the configured byte limit',
+                limit,
+                observed: Math.min(Number.MAX_SAFE_INTEGER, Math.max(limit + 1, text.length)),
+            }),
+        ]);
+    }
+    return text;
+}

--- a/conversation/src/types.ts
+++ b/conversation/src/types.ts
@@ -4,6 +4,8 @@ import type {
     AgentContentBlockSchema,
     AgentTurnProvenanceSchema,
     AgentTurnSchema,
+    AppendConversationRecordsOptionsSchema,
+    AppendConversationRecordsResultSchema,
     AssetKindSchema,
     AssetMediaMetadataSchema,
     AssetProvenanceSchema,
@@ -28,8 +30,11 @@ import type {
     ConversationInspectionSchema,
     ConversationLineageParentSchema,
     ConversationLineageSchema,
+    ConversationRecordBatchSchema,
     ConversationRefSchema,
+    ConversationRuntimeContextSchema,
     ConversationTurnSchema,
+    DecodedConversationResponseSchema,
     DerivedAgentTurnSchema,
     DerivedAssetProvenanceSchema,
     DerivedTurnProvenanceSchema,
@@ -119,6 +124,10 @@ export type ConversationDiagnostic = z.infer<typeof ConversationDiagnosticSchema
 export type ConversationDiagnosticCode = z.infer<typeof ConversationDiagnosticCodeSchema>;
 export type TurnKindCounts = z.infer<typeof TurnKindCountsSchema>;
 export type ConversationInspection = z.infer<typeof ConversationInspectionSchema>;
+export type ConversationRecordBatch = z.infer<typeof ConversationRecordBatchSchema>;
+export type AppendConversationRecordsOptions = z.infer<typeof AppendConversationRecordsOptionsSchema>;
+export type AppendConversationRecordsResult = z.infer<typeof AppendConversationRecordsResultSchema>;
+export type DecodedConversationResponse = z.infer<typeof DecodedConversationResponseSchema>;
 
 export type NativeIdentity = z.infer<typeof NativeIdentitySchema>;
 export type ImageRegion = z.infer<typeof ImageRegionSchema>;
@@ -188,6 +197,7 @@ export type AccountingProvenance = z.infer<typeof AccountingProvenanceSchema>;
 export type UsageAccountingProvenance = z.infer<typeof UsageAccountingProvenanceSchema>;
 export type ReportedUsage = z.infer<typeof ReportedUsageSchema>;
 export type CompleteInputPartition = z.infer<typeof CompleteInputPartitionSchema>;
+export type ConversationRuntimeContext = z.infer<typeof ConversationRuntimeContextSchema>;
 export type GenerationCost = z.infer<typeof GenerationCostSchema>;
 export type GenerationUsage = z.infer<typeof GenerationUsageSchema>;
 export type ContextMeasurement = z.infer<typeof ContextMeasurementSchema>;

--- a/conversation/src/types.ts
+++ b/conversation/src/types.ts
@@ -1,0 +1,218 @@
+import type { z } from 'zod';
+import type {
+    AccountingProvenanceSchema,
+    AgentContentBlockSchema,
+    AgentTurnProvenanceSchema,
+    AgentTurnSchema,
+    AssetKindSchema,
+    AssetMediaMetadataSchema,
+    AssetProvenanceSchema,
+    AssetSchema,
+    AssetStorageSchema,
+    AssetVersionBindingSchema,
+    AudioBlockSchema,
+    CacheIntentSchema,
+    CompactionRecordSchema,
+    CompactionSourceSchema,
+    CompactionStrategySchema,
+    CompleteInputPartitionSchema,
+    ContentBlockSchema,
+    ContextEntrySchema,
+    ContextMeasurementSchema,
+    ContextRetrievalRequirementSchema,
+    ConversationContextSchema,
+    ConversationDiagnosticCodeSchema,
+    ConversationDiagnosticSchema,
+    ConversationDiagnosticStageSchema,
+    ConversationDocumentSchema,
+    ConversationInspectionSchema,
+    ConversationLineageParentSchema,
+    ConversationLineageSchema,
+    ConversationRefSchema,
+    ConversationTurnSchema,
+    DerivedAgentTurnSchema,
+    DerivedAssetProvenanceSchema,
+    DerivedTurnProvenanceSchema,
+    DocumentBlockSchema,
+    ExecutedGenerationSchema,
+    ExecutionReceiptSchema,
+    ExtensionBlockSchema,
+    ExternalAssetStorageSchema,
+    ExternalReferenceBlockSchema,
+    GeneratedAgentTurnSchema,
+    GeneratedAssetProvenanceSchema,
+    GeneratedTurnProvenanceSchema,
+    GenerationCostSchema,
+    GenerationSchema,
+    GenerationTimestampsSchema,
+    GenerationUsageSchema,
+    ImageBlockSchema,
+    ImageRegionSchema,
+    ImportedAgentTurnSchema,
+    ImportedAssetProvenanceSchema,
+    ImportedGenerationSchema,
+    ImportedTurnProvenanceSchema,
+    InlineBase64AssetStorageSchema,
+    InlineJsonAssetStorageSchema,
+    InlineTextAssetStorageSchema,
+    InsertedTurnProvenanceSchema,
+    InvalidToolArgumentsSchema,
+    JsonBlockSchema,
+    JsonObjectSchema,
+    JsonPreflightDiagnosticCodeSchema,
+    JsonPreflightDiagnosticSchema,
+    JsonValueSchema,
+    MetadataSchema,
+    ModelTargetSchema,
+    NativeIdentitySchema,
+    NativeItemMappingSchema,
+    NativeReplayBlockSchema,
+    NestedToolResultContentBlockSchema,
+    NonGeneratedTurnProvenanceSchema,
+    NongeneratedAgentTurnSchema,
+    OperationReceiptSchema,
+    PageRangeSchema,
+    ProcessingStateSchema,
+    ProcessorConfigurationSchema,
+    ProgramContentBlockSchema,
+    ProgramTurnSchema,
+    ReasoningBlockSchema,
+    ReceivedAssetProvenanceSchema,
+    ReceivedTurnProvenanceSchema,
+    ReplacementTurnContextEntrySchema,
+    ReplayCompatibilityScopeSchema,
+    ReplayDependenciesSchema,
+    ReportedUsageSchema,
+    RequestReceiptSchema,
+    RetrievalCapabilitySchema,
+    SemanticConversationDiagnosticCodeSchema,
+    SemanticConversationDiagnosticSchema,
+    SourceTurnContextEntrySchema,
+    StructuredToolArgumentsSchema,
+    TextBlockSchema,
+    TimeRangeSchema,
+    ToolArgumentsSchema,
+    ToolCallBlockSchema,
+    ToolDefinitionSchema,
+    ToolInputSchemaSchema,
+    ToolResultBlockSchema,
+    ToolResultCapabilitySchema,
+    ToolTurnSchema,
+    TurnKindCountsSchema,
+    UsageAccountingProvenanceSchema,
+    UsageMetricSchema,
+    UserContentBlockSchema,
+    UserTurnSchema,
+    VideoBlockSchema,
+} from './schemas/index.js';
+
+export type JsonValue = z.infer<typeof JsonValueSchema>;
+export type JsonObject = z.infer<typeof JsonObjectSchema>;
+export type ConversationMetadata = z.infer<typeof MetadataSchema>;
+export type ConversationRef = z.infer<typeof ConversationRefSchema>;
+export type JsonPreflightDiagnosticCode = z.infer<typeof JsonPreflightDiagnosticCodeSchema>;
+export type JsonPreflightDiagnostic = z.infer<typeof JsonPreflightDiagnosticSchema>;
+export type SemanticConversationDiagnosticCode = z.infer<typeof SemanticConversationDiagnosticCodeSchema>;
+export type SemanticConversationDiagnostic = z.infer<typeof SemanticConversationDiagnosticSchema>;
+export type ConversationDiagnosticStage = z.infer<typeof ConversationDiagnosticStageSchema>;
+export type ConversationDiagnostic = z.infer<typeof ConversationDiagnosticSchema>;
+export type ConversationDiagnosticCode = z.infer<typeof ConversationDiagnosticCodeSchema>;
+export type TurnKindCounts = z.infer<typeof TurnKindCountsSchema>;
+export type ConversationInspection = z.infer<typeof ConversationInspectionSchema>;
+
+export type NativeIdentity = z.infer<typeof NativeIdentitySchema>;
+export type ImageRegion = z.infer<typeof ImageRegionSchema>;
+export type PageRange = z.infer<typeof PageRangeSchema>;
+export type TimeRange = z.infer<typeof TimeRangeSchema>;
+
+export type AssetKind = z.infer<typeof AssetKindSchema>;
+export type InlineTextAssetStorage = z.infer<typeof InlineTextAssetStorageSchema>;
+export type InlineJsonAssetStorage = z.infer<typeof InlineJsonAssetStorageSchema>;
+export type InlineBase64AssetStorage = z.infer<typeof InlineBase64AssetStorageSchema>;
+export type ExternalAssetStorage = z.infer<typeof ExternalAssetStorageSchema>;
+export type AssetStorage = z.infer<typeof AssetStorageSchema>;
+export type ReceivedAssetProvenance = z.infer<typeof ReceivedAssetProvenanceSchema>;
+export type GeneratedAssetProvenance = z.infer<typeof GeneratedAssetProvenanceSchema>;
+export type ImportedAssetProvenance = z.infer<typeof ImportedAssetProvenanceSchema>;
+export type DerivedAssetProvenance = z.infer<typeof DerivedAssetProvenanceSchema>;
+export type AssetProvenance = z.infer<typeof AssetProvenanceSchema>;
+export type AssetMediaMetadata = z.infer<typeof AssetMediaMetadataSchema>;
+export type Asset = z.infer<typeof AssetSchema>;
+
+export type ToolResultCapability = z.infer<typeof ToolResultCapabilitySchema>;
+export type ToolInputSchema = z.infer<typeof ToolInputSchemaSchema>;
+export type ToolDefinition = z.infer<typeof ToolDefinitionSchema>;
+export type TextBlock = z.infer<typeof TextBlockSchema>;
+export type JsonBlock = z.infer<typeof JsonBlockSchema>;
+export type ImageBlock = z.infer<typeof ImageBlockSchema>;
+export type DocumentBlock = z.infer<typeof DocumentBlockSchema>;
+export type AudioBlock = z.infer<typeof AudioBlockSchema>;
+export type VideoBlock = z.infer<typeof VideoBlockSchema>;
+export type StructuredToolArguments = z.infer<typeof StructuredToolArgumentsSchema>;
+export type InvalidToolArguments = z.infer<typeof InvalidToolArgumentsSchema>;
+export type ToolArguments = z.infer<typeof ToolArgumentsSchema>;
+export type ToolCallBlock = z.infer<typeof ToolCallBlockSchema>;
+export type RetrievalCapability = z.infer<typeof RetrievalCapabilitySchema>;
+export type ExternalReferenceBlock = z.infer<typeof ExternalReferenceBlockSchema>;
+export type ReasoningBlock = z.infer<typeof ReasoningBlockSchema>;
+export type ReplayCompatibilityScope = z.infer<typeof ReplayCompatibilityScopeSchema>;
+export type ReplayDependencies = z.infer<typeof ReplayDependenciesSchema>;
+export type NativeReplayBlock = z.infer<typeof NativeReplayBlockSchema>;
+export type ExtensionBlock = z.infer<typeof ExtensionBlockSchema>;
+export type NestedToolResultContentBlock = z.infer<typeof NestedToolResultContentBlockSchema>;
+export type ToolResultBlock = z.infer<typeof ToolResultBlockSchema>;
+export type ContentBlock = z.infer<typeof ContentBlockSchema>;
+export type UserContentBlock = z.infer<typeof UserContentBlockSchema>;
+export type AgentContentBlock = z.infer<typeof AgentContentBlockSchema>;
+export type ProgramContentBlock = z.infer<typeof ProgramContentBlockSchema>;
+
+export type ReceivedTurnProvenance = z.infer<typeof ReceivedTurnProvenanceSchema>;
+export type InsertedTurnProvenance = z.infer<typeof InsertedTurnProvenanceSchema>;
+export type GeneratedTurnProvenance = z.infer<typeof GeneratedTurnProvenanceSchema>;
+export type ImportedTurnProvenance = z.infer<typeof ImportedTurnProvenanceSchema>;
+export type DerivedTurnProvenance = z.infer<typeof DerivedTurnProvenanceSchema>;
+export type NonGeneratedTurnProvenance = z.infer<typeof NonGeneratedTurnProvenanceSchema>;
+export type AgentTurnProvenance = z.infer<typeof AgentTurnProvenanceSchema>;
+export type UserTurn = z.infer<typeof UserTurnSchema>;
+export type AgentTurn = z.infer<typeof AgentTurnSchema>;
+export type GeneratedAgentTurn = z.infer<typeof GeneratedAgentTurnSchema>;
+export type ImportedAgentTurn = z.infer<typeof ImportedAgentTurnSchema>;
+export type DerivedAgentTurn = z.infer<typeof DerivedAgentTurnSchema>;
+export type NongeneratedAgentTurn = z.infer<typeof NongeneratedAgentTurnSchema>;
+export type ToolTurn = z.infer<typeof ToolTurnSchema>;
+export type ProgramTurn = z.infer<typeof ProgramTurnSchema>;
+export type ConversationTurn = z.infer<typeof ConversationTurnSchema>;
+
+export type UsageMetric = z.infer<typeof UsageMetricSchema>;
+export type AccountingProvenance = z.infer<typeof AccountingProvenanceSchema>;
+export type UsageAccountingProvenance = z.infer<typeof UsageAccountingProvenanceSchema>;
+export type ReportedUsage = z.infer<typeof ReportedUsageSchema>;
+export type CompleteInputPartition = z.infer<typeof CompleteInputPartitionSchema>;
+export type GenerationCost = z.infer<typeof GenerationCostSchema>;
+export type GenerationUsage = z.infer<typeof GenerationUsageSchema>;
+export type ContextMeasurement = z.infer<typeof ContextMeasurementSchema>;
+export type ModelTarget = z.infer<typeof ModelTargetSchema>;
+export type AssetVersionBinding = z.infer<typeof AssetVersionBindingSchema>;
+export type NativeItemMapping = z.infer<typeof NativeItemMappingSchema>;
+export type RequestReceipt = z.infer<typeof RequestReceiptSchema>;
+export type GenerationTimestamps = z.infer<typeof GenerationTimestampsSchema>;
+export type ExecutedGeneration = z.infer<typeof ExecutedGenerationSchema>;
+export type ImportedGeneration = z.infer<typeof ImportedGenerationSchema>;
+export type Generation = z.infer<typeof GenerationSchema>;
+export type OperationReceipt = z.infer<typeof OperationReceiptSchema>;
+export type ExecutionReceipt = z.infer<typeof ExecutionReceiptSchema>;
+
+export type SourceTurnContextEntry = z.infer<typeof SourceTurnContextEntrySchema>;
+export type ReplacementTurnContextEntry = z.infer<typeof ReplacementTurnContextEntrySchema>;
+export type ContextEntry = z.infer<typeof ContextEntrySchema>;
+export type ContextRetrievalRequirement = z.infer<typeof ContextRetrievalRequirementSchema>;
+export type CacheIntent = z.infer<typeof CacheIntentSchema>;
+export type ConversationContext = z.infer<typeof ConversationContextSchema>;
+export type CompactionStrategy = z.infer<typeof CompactionStrategySchema>;
+export type CompactionSource = z.infer<typeof CompactionSourceSchema>;
+export type CompactionRecord = z.infer<typeof CompactionRecordSchema>;
+export type ProcessorConfiguration = z.infer<typeof ProcessorConfigurationSchema>;
+export type ProcessingState = z.infer<typeof ProcessingStateSchema>;
+export type ConversationLineageParent = z.infer<typeof ConversationLineageParentSchema>;
+export type ConversationLineage = z.infer<typeof ConversationLineageSchema>;
+export type ConversationDocument = z.infer<typeof ConversationDocumentSchema>;

--- a/conversation/src/validation.ts
+++ b/conversation/src/validation.ts
@@ -1,0 +1,70 @@
+import type { z } from 'zod';
+import { boundConversationDiagnostic, ConversationValidationError, diagnosticPointer } from './diagnostics.js';
+import { type JsonInputLimits, preflightJsonInput } from './json-preflight.js';
+import { ConversationDocumentSchema } from './schemas/document.js';
+import { validateConversationSemantics } from './semantic-validation.js';
+import type { ConversationDiagnostic, ConversationDocument } from './types.js';
+
+export interface ConversationValidationOptions {
+    json_input_limits?: Partial<JsonInputLimits>;
+}
+
+const MAX_SCHEMA_DIAGNOSTICS = 32;
+
+function schemaIssuePath(issue: z.core.$ZodIssue): string {
+    return diagnosticPointer(
+        issue.path.map((segment) => (typeof segment === 'symbol' ? (segment.description ?? 'symbol') : segment)),
+    );
+}
+
+export function diagnosticsFromZodError(error: z.ZodError): ConversationDiagnostic[] {
+    return error.issues.slice(0, MAX_SCHEMA_DIAGNOSTICS).map((issue) =>
+        boundConversationDiagnostic({
+            code: 'SCHEMA_INVALID',
+            stage: 'schema',
+            path: schemaIssuePath(issue),
+            // Zod messages for unrecognized keys may embed every untrusted key. The public diagnostic
+            // reports the authoritative issue code while the path identifies the affected value.
+            message: `Conversation schema validation failed with ${issue.code}`,
+        }),
+    );
+}
+
+function cloneValidatedDocument(input: unknown): ConversationDocument {
+    // Shape validation above proves this is a JSON-only document. Cloning the original, rather than
+    // returning Zod's reconstructed record output, preserves every validated own JSON key and value.
+    return structuredClone(input) as ConversationDocument;
+}
+
+export function validateConversationDocument(
+    input: unknown,
+    options: ConversationValidationOptions = {},
+): import('./diagnostics.js').ConversationValidationResult<ConversationDocument> {
+    const preflight = preflightJsonInput(input, options.json_input_limits);
+    if (!preflight.success) {
+        return { success: false, diagnostics: preflight.diagnostics };
+    }
+
+    const shape = ConversationDocumentSchema.safeParse(input);
+    if (!shape.success) {
+        return { success: false, diagnostics: diagnosticsFromZodError(shape.error) };
+    }
+
+    const document = cloneValidatedDocument(input);
+    const diagnostics = validateConversationSemantics(document);
+    if (diagnostics.length > 0) {
+        return { success: false, diagnostics };
+    }
+    return { success: true, data: document, diagnostics: [] };
+}
+
+export function parseConversationDocument(
+    input: unknown,
+    options: ConversationValidationOptions = {},
+): ConversationDocument {
+    const result = validateConversationDocument(input, options);
+    if (!result.success) {
+        throw new ConversationValidationError('Conversation document validation failed', result.diagnostics);
+    }
+    return result.data;
+}

--- a/conversation/test-fixtures/narrowing.ts
+++ b/conversation/test-fixtures/narrowing.ts
@@ -1,0 +1,17 @@
+import { type ConversationTurn, isGeneratedAgentTurn } from '@llumiverse/conversation';
+
+export function inspectNarrowedTurn(turn: ConversationTurn): string {
+    if (turn.kind === 'tool') {
+        return `${turn.blocks[0].call_id}:${turn.blocks[0].status}`;
+    }
+    if (turn.kind === 'user') {
+        return turn.provenance.type;
+    }
+    if (turn.kind === 'program') {
+        return turn.authority;
+    }
+    if (isGeneratedAgentTurn(turn)) {
+        return turn.generation_id;
+    }
+    return turn.provenance.type;
+}

--- a/conversation/test-fixtures/tsconfig.json
+++ b/conversation/test-fixtures/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "compilerOptions": {
+        "target": "ES2024",
+        "module": "nodenext",
+        "moduleResolution": "nodenext",
+        "strict": true,
+        "skipLibCheck": true,
+        "outDir": "../.verify",
+        "rootDir": "."
+    },
+    "include": ["type-only.ts", "narrowing.ts"]
+}

--- a/conversation/test-fixtures/type-only.ts
+++ b/conversation/test-fixtures/type-only.ts
@@ -1,0 +1,5 @@
+import type { ConversationDocument } from '@llumiverse/conversation';
+
+export function getConversationId(document: ConversationDocument): string {
+    return document.id;
+}

--- a/conversation/test/fixtures.ts
+++ b/conversation/test/fixtures.ts
@@ -1,0 +1,103 @@
+import {
+    type ConversationDocument,
+    createConversationDocument,
+    createGeneratedAgentTurn,
+    createTextBlock,
+    createToolTurn,
+    createUserTurn,
+    type GeneratedAgentTurn,
+    type ImportedGeneration,
+    type TextBlock,
+    type ToolCallBlock,
+    type ToolTurn,
+    type UserTurn,
+} from '../src/index.js';
+
+export const RECORDED_AT = '2026-09-11T00:00:00.000Z';
+
+export function emptyDocument(id = 'conversation'): ConversationDocument {
+    return createConversationDocument({ id, created_at: RECORDED_AT });
+}
+
+export function textBlock(id: string, text = id): TextBlock {
+    return createTextBlock({ id, text, format: 'plain' });
+}
+
+export function userTurn(id: string, blockId = `${id}-text`): UserTurn {
+    return createUserTurn({
+        id,
+        authority: 'ordinary',
+        blocks: [textBlock(blockId)],
+        status: 'completed',
+        timestamps: { recorded_at: RECORDED_AT },
+        provenance: { type: 'received' },
+        model_visibility: 'include',
+    });
+}
+
+export function generatedAgentTurn(
+    id: string,
+    generationId: string,
+    blocks: GeneratedAgentTurn['blocks'] = [textBlock(`${id}-text`)],
+): GeneratedAgentTurn {
+    return createGeneratedAgentTurn({
+        id,
+        generation_id: generationId,
+        authority: 'ordinary',
+        blocks,
+        status: 'completed',
+        timestamps: { recorded_at: RECORDED_AT },
+        provenance: { type: 'generated' },
+        model_visibility: 'include',
+    });
+}
+
+export function toolCallBlock(
+    id: string,
+    callId: string,
+    executor: 'application' | 'provider' = 'application',
+): ToolCallBlock {
+    return {
+        id,
+        type: 'tool_call',
+        call_id: callId,
+        tool_name: 'read',
+        executor,
+        arguments: { type: 'json', value: { path: '/tmp/example' } },
+    };
+}
+
+export function toolResultTurn(
+    id: string,
+    callId: string,
+    status: 'success' | 'error' | 'cancelled' | 'denied' = 'success',
+): ToolTurn {
+    return createToolTurn({
+        id,
+        authority: 'ordinary',
+        blocks: [
+            {
+                id: `${id}-result`,
+                type: 'tool_result',
+                call_id: callId,
+                status,
+                content: [textBlock(`${id}-content`, status)],
+            },
+        ],
+        status: 'completed',
+        timestamps: { recorded_at: RECORDED_AT },
+        provenance: { type: 'received' },
+        model_visibility: 'include',
+    });
+}
+
+export function importedGeneration(id: string): ImportedGeneration {
+    return {
+        id,
+        record_source: 'imported',
+        status: 'completed',
+        timestamps: { recorded_at: RECORDED_AT },
+        source: { conversation_id: 'conversation', revision: 0 },
+        missing_metadata: ['requested_model', 'provider'],
+    };
+}

--- a/conversation/test/ingestion-schemas.test.ts
+++ b/conversation/test/ingestion-schemas.test.ts
@@ -1,0 +1,81 @@
+import { Ajv2020 } from 'ajv/dist/2020.js';
+import formatsPlugin from 'ajv-formats';
+import { describe, expect, it } from 'vitest';
+import {
+    AppendConversationRecordsOptionsJsonSchema,
+    AppendConversationRecordsResultJsonSchema,
+    ConversationRecordBatchJsonSchema,
+    DecodedConversationResponseJsonSchema,
+} from '../src/json-schema.js';
+import {
+    AppendConversationRecordsOptionsSchema,
+    AppendConversationRecordsResultSchema,
+    ConversationRecordBatchSchema,
+    DecodedConversationResponseSchema,
+} from '../src/schemas/ingestion.js';
+import { emptyDocument, importedGeneration, RECORDED_AT, userTurn } from './fixtures.js';
+
+describe('ingestion schema contracts', () => {
+    const options = {
+        expected_revision: 0,
+        operation_id: 'operation',
+        payload_fingerprint: 'fingerprint',
+        recorded_at: RECORDED_AT,
+    };
+
+    it('keeps Zod and emitted JSON Schema aligned on append inputs and results', () => {
+        const pairs = [
+            {
+                zod: AppendConversationRecordsOptionsSchema,
+                json: AppendConversationRecordsOptionsJsonSchema,
+                valid: options,
+                invalid: [
+                    { ...options, expected_revision: -1 },
+                    { ...options, expected_revision: 1.5 },
+                    { ...options, expected_revision: Number.MAX_SAFE_INTEGER + 1 },
+                    { ...options, operation_id: '' },
+                    { ...options, recorded_at: 'tomorrow' },
+                    { ...options, extra: true },
+                ],
+            },
+            {
+                zod: ConversationRecordBatchSchema,
+                json: ConversationRecordBatchJsonSchema,
+                valid: { turns: [userTurn('user')], active_tool_definition_ids: [] },
+                invalid: [{ turns: [{}] }, { active_tool_definition_ids: [''] }, { extra: true }],
+            },
+            {
+                zod: AppendConversationRecordsResultSchema,
+                json: AppendConversationRecordsResultJsonSchema,
+                valid: { document: emptyDocument(), applied: true, accepted_turn_ids: [], accepted_generation_ids: [] },
+                invalid: [
+                    { document: emptyDocument(), applied: 'yes', accepted_turn_ids: [], accepted_generation_ids: [] },
+                ],
+            },
+        ];
+        for (const pair of pairs) {
+            const ajv = new Ajv2020({ strict: true });
+            formatsPlugin.default(ajv);
+            const validate = ajv.compile(pair.json);
+            expect(pair.zod.safeParse(pair.valid).success).toBe(true);
+            expect(validate(pair.valid), JSON.stringify(validate.errors)).toBe(true);
+            for (const invalid of pair.invalid) {
+                expect(pair.zod.safeParse(invalid).success).toBe(false);
+                expect(validate(invalid)).toBe(false);
+            }
+        }
+    });
+
+    it('does not accept imported historical metadata as a decoded live response', () => {
+        const value = {
+            turns: [],
+            generation: importedGeneration('imported'),
+            diagnostics: [],
+            payload_fingerprint: 'fp',
+        };
+        const ajv = new Ajv2020({ strict: true });
+        formatsPlugin.default(ajv);
+        expect(DecodedConversationResponseSchema.safeParse(value).success).toBe(false);
+        expect(ajv.compile(DecodedConversationResponseJsonSchema)(value)).toBe(false);
+    });
+});

--- a/conversation/test/ingestion-schemas.test.ts
+++ b/conversation/test/ingestion-schemas.test.ts
@@ -64,7 +64,7 @@ describe('ingestion schema contracts', () => {
                 expect(validate(invalid)).toBe(false);
             }
         }
-    });
+    }, 15_000);
 
     it('does not accept imported historical metadata as a decoded live response', () => {
         const value = {

--- a/conversation/test/json-preflight.test.ts
+++ b/conversation/test/json-preflight.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { preflightJsonInput } from '../src/index.js';
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('preflightJsonInput', () => {
+    it('accepts shared acyclic values and counts each serialized occurrence', () => {
+        const shared = { text: 'same' };
+        const input = { first: shared, second: shared };
+        const result = preflightJsonInput(input);
+
+        expect(result).toMatchObject({ success: true, nodes: 5 });
+        expect(result.bytes).toBe(new TextEncoder().encode(JSON.stringify(input)).byteLength);
+    });
+
+    it('rejects cycles while reporting the earlier active path', () => {
+        const input: { self?: unknown } = {};
+        input.self = input;
+
+        const result = preflightJsonInput(input);
+        expect(result.success).toBe(false);
+        expect(result.diagnostics[0]).toMatchObject({
+            code: 'JSON_CYCLE',
+            path: '/self',
+            related_paths: [''],
+        });
+    });
+
+    it('rejects accessors without invoking their getters', () => {
+        let getterCalls = 0;
+        const input = Object.defineProperty({}, 'secret', {
+            enumerable: true,
+            get() {
+                getterCalls += 1;
+                return 'should-not-run';
+            },
+        });
+
+        const result = preflightJsonInput(input);
+        expect(result.success).toBe(false);
+        expect(result.diagnostics[0]?.code).toBe('JSON_ACCESSOR_PROPERTY');
+        expect(getterCalls).toBe(0);
+    });
+
+    it.each([
+        { value: new Date(0), code: 'JSON_NON_PLAIN_OBJECT' },
+        { value: [undefined], code: 'JSON_UNSUPPORTED_TYPE' },
+        { value: [Number.NaN], code: 'JSON_NON_FINITE_NUMBER' },
+        { value: [-0], code: 'JSON_NEGATIVE_ZERO' },
+        { value: Array(1), code: 'JSON_SPARSE_ARRAY' },
+    ])('rejects non-JSON input with $code', ({ value, code }) => {
+        const result = preflightJsonInput(value);
+        expect(result.success).toBe(false);
+        expect(result.diagnostics.some((diagnostic) => diagnostic.code === code)).toBe(true);
+    });
+
+    it('rejects symbols and named array properties', () => {
+        const symbolObject = { value: 1, [Symbol('hidden')]: 2 };
+        const symbolResult = preflightJsonInput(symbolObject);
+        expect(symbolResult.success).toBe(false);
+        expect(symbolResult.diagnostics[0]?.code).toBe('JSON_SYMBOL_KEY');
+
+        const array = [1] as number[] & { label?: string };
+        array.label = 'named';
+        const arrayResult = preflightJsonInput(array);
+        expect(arrayResult.success).toBe(false);
+        expect(arrayResult.diagnostics[0]?.code).toBe('JSON_ARRAY_PROPERTY');
+    });
+
+    it('checks oversized array length before scanning keys or element descriptors', () => {
+        let ownKeyReads = 0;
+        let descriptorReads = 0;
+        const input = new Proxy(Array(10_000), {
+            ownKeys(target) {
+                ownKeyReads += 1;
+                return Reflect.ownKeys(target);
+            },
+            getOwnPropertyDescriptor(target, key) {
+                descriptorReads += 1;
+                return Reflect.getOwnPropertyDescriptor(target, key);
+            },
+        });
+
+        const result = preflightJsonInput(input, { max_array_length: 1 });
+        expect(result.success).toBe(false);
+        expect(result.diagnostics[0]?.code).toBe('JSON_MAX_ARRAY_LENGTH');
+        expect(ownKeyReads).toBe(0);
+        expect(descriptorReads).toBe(0);
+    });
+
+    it('enforces depth and object-property limits', () => {
+        const depth = preflightJsonInput({ nested: { value: 1 } }, { max_depth: 1 });
+        expect(depth.success).toBe(false);
+        expect(depth.diagnostics.some((diagnostic) => diagnostic.code === 'JSON_MAX_DEPTH')).toBe(true);
+
+        const properties = preflightJsonInput({ first: 1, second: 2 }, { max_object_properties: 1 });
+        expect(properties.success).toBe(false);
+        expect(properties.diagnostics[0]?.code).toBe('JSON_MAX_OBJECT_PROPERTIES');
+    });
+
+    it('caps diagnostics exactly and does not append a synthetic extra diagnostic', () => {
+        const result = preflightJsonInput([undefined, undefined], { max_diagnostics: 1 });
+        expect(result.success).toBe(false);
+        expect(result.diagnostics).toHaveLength(1);
+    });
+
+    it('bounds oversized diagnostic paths and marks truncation', () => {
+        const key = 'x'.repeat(100_000);
+        const result = preflightJsonInput({ [key]: 'value' }, { max_string_bytes: 32, max_bytes: 128 });
+        expect(result.success).toBe(false);
+        expect(result.diagnostics[0]?.path).toHaveLength(512);
+        expect(result.diagnostics[0]?.path.endsWith('…')).toBe(true);
+        expect(JSON.stringify(result.diagnostics).length).toBeLessThan(5_000);
+    });
+
+    it('stops byte observation at a bounded over-limit value', () => {
+        const result = preflightJsonInput('x'.repeat(100_000), { max_string_bytes: 32, max_bytes: 128 });
+        expect(result.success).toBe(false);
+        expect(result.diagnostics[0]).toMatchObject({ code: 'JSON_MAX_STRING_BYTES', observed: 33 });
+    });
+
+    it.each([
+        { limits: { max_bytes: 128 }, code: 'JSON_MAX_BYTES' },
+        { limits: { max_string_bytes: 128 }, code: 'JSON_MAX_STRING_BYTES' },
+    ])('stops scanning at the first applicable $code budget', ({ limits, code }) => {
+        const charCodeAt = vi.spyOn(String.prototype, 'charCodeAt');
+        const result = preflightJsonInput('x'.repeat(1_000_000), limits);
+        expect(result.success).toBe(false);
+        expect(result.diagnostics[0]?.code).toBe(code);
+        expect(charCodeAt).not.toHaveBeenCalled();
+    });
+
+    it('does not schedule or inspect pending siblings beyond the node budget', () => {
+        let siblingKeyReads = 0;
+        const untouchedSibling = new Proxy([1, 2, 3], {
+            ownKeys(target) {
+                siblingKeyReads += 1;
+                return Reflect.ownKeys(target);
+            },
+        });
+        const result = preflightJsonInput([[0], untouchedSibling], { max_nodes: 2 });
+        expect(result.success).toBe(false);
+        expect(result.diagnostics[0]?.code).toBe('JSON_MAX_NODES');
+        expect(siblingKeyReads).toBe(0);
+    });
+
+    it('rejects the reserved record key without rejecting ordinary built-in-looking keys', () => {
+        const reserved = preflightJsonInput(JSON.parse('{"__proto__":{"value":1}}'));
+        expect(reserved.success).toBe(false);
+        expect(reserved.diagnostics[0]?.code).toBe('JSON_RESERVED_PROPERTY_KEY');
+
+        expect(preflightJsonInput({ constructor: 1, toString: 2, hasOwnProperty: 3 }).success).toBe(true);
+    });
+});

--- a/conversation/test/json-schema.test.ts
+++ b/conversation/test/json-schema.test.ts
@@ -38,6 +38,12 @@ function expectSortedAndFrozen(value: unknown): void {
 }
 
 describe('generated JSON Schema', () => {
+    it('names recursive JSON without anonymous generator components', () => {
+        const schema = ConversationDocumentSchema.toJSONSchema({ target: 'draft-2020-12', io: 'input' });
+        expect(Object.keys(schema.$defs ?? {}).some((name) => name.startsWith('__'))).toBe(false);
+        expect(schema.$defs?.ConversationJsonValue).toHaveProperty('anyOf');
+    });
+
     it('exports deterministic, deeply frozen Draft 2020-12 schema objects', () => {
         for (const schema of [
             ConversationDocumentJsonSchema,

--- a/conversation/test/json-schema.test.ts
+++ b/conversation/test/json-schema.test.ts
@@ -1,0 +1,100 @@
+import { Ajv2020 } from 'ajv/dist/2020.js';
+import formatsPlugin from 'ajv-formats';
+import { describe, expect, it } from 'vitest';
+import { ConversationDocumentSchema, validateConversationDocument } from '../src/index.js';
+import {
+    ConversationContentBlockJsonSchema,
+    ConversationDiagnosticJsonSchema,
+    ConversationDocumentJsonSchema,
+    ConversationGenerationJsonSchema,
+    ConversationInspectionJsonSchema,
+    ConversationTurnJsonSchema,
+} from '../src/json-schema.js';
+import { emptyDocument, generatedAgentTurn, importedGeneration, toolResultTurn } from './fixtures.js';
+
+function compileDocumentSchema() {
+    const ajv = new Ajv2020({ allErrors: true, strict: true });
+    formatsPlugin.default(ajv);
+    return ajv.compile(ConversationDocumentJsonSchema);
+}
+
+function expectSortedAndFrozen(value: unknown): void {
+    if (Array.isArray(value)) {
+        expect(Object.isFrozen(value)).toBe(true);
+        for (const item of value) {
+            expectSortedAndFrozen(item);
+        }
+        return;
+    }
+    if (value === null || typeof value !== 'object') {
+        return;
+    }
+    expect(Object.isFrozen(value)).toBe(true);
+    const keys = Object.keys(value);
+    expect(keys).toEqual([...keys].sort((first, second) => (first < second ? -1 : first > second ? 1 : 0)));
+    for (const item of Object.values(value)) {
+        expectSortedAndFrozen(item);
+    }
+}
+
+describe('generated JSON Schema', () => {
+    it('exports deterministic, deeply frozen Draft 2020-12 schema objects', () => {
+        for (const schema of [
+            ConversationDocumentJsonSchema,
+            ConversationTurnJsonSchema,
+            ConversationContentBlockJsonSchema,
+            ConversationGenerationJsonSchema,
+            ConversationDiagnosticJsonSchema,
+            ConversationInspectionJsonSchema,
+        ]) {
+            expect(schema.$schema).toBe('https://json-schema.org/draft/2020-12/schema');
+            expect(String(schema.$id)).toContain('2026-09-11.foundation.1');
+            expectSortedAndFrozen(schema);
+        }
+    });
+
+    it('compiles in strict Ajv 2020 mode with formats', () => {
+        const validate = compileDocumentSchema();
+        expect(validate(emptyDocument())).toBe(true);
+    });
+
+    it('matches Zod on positive and adversarial shape fixtures', () => {
+        const validImported = emptyDocument();
+        validImported.generations.imported = importedGeneration('imported');
+
+        const unknownField = { ...emptyDocument(), surprise: true };
+
+        const missingGenerationId = emptyDocument();
+        const agent = generatedAgentTurn('agent', 'generation');
+        Reflect.deleteProperty(agent, 'generation_id');
+        missingGenerationId.turns.push(agent);
+
+        const multipleToolResults = emptyDocument();
+        const result = toolResultTurn('result', 'call');
+        multipleToolResults.turns.push({ ...result, blocks: [...result.blocks, ...result.blocks] });
+
+        const fixtures: unknown[] = [
+            emptyDocument(),
+            validImported,
+            unknownField,
+            missingGenerationId,
+            multipleToolResults,
+        ];
+        const validate = compileDocumentSchema();
+        for (const fixture of fixtures) {
+            expect(validate(fixture), JSON.stringify(validate.errors)).toBe(
+                ConversationDocumentSchema.safeParse(fixture).success,
+            );
+        }
+    });
+
+    it('keeps graph validation separate from shape parity', () => {
+        const dangling = emptyDocument();
+        dangling.turns.push(generatedAgentTurn('agent', 'missing-generation'));
+        const validate = compileDocumentSchema();
+
+        expect(validate(dangling)).toBe(true);
+        expect(ConversationDocumentSchema.safeParse(dangling).success).toBe(true);
+        expect(validateConversationDocument(dangling).success).toBe(false);
+    });
+});

--- a/conversation/test/json-schema.test.ts
+++ b/conversation/test/json-schema.test.ts
@@ -48,7 +48,7 @@ describe('generated JSON Schema', () => {
             ConversationInspectionJsonSchema,
         ]) {
             expect(schema.$schema).toBe('https://json-schema.org/draft/2020-12/schema');
-            expect(String(schema.$id)).toContain('2026-09-11.foundation.1');
+            expect(String(schema.$id)).toContain('2026-09-11.ingestion.1');
             expectSortedAndFrozen(schema);
         }
     });

--- a/conversation/test/rendering.test.ts
+++ b/conversation/test/rendering.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { isConversationDocumentFormat, renderContentBlockText, renderConversationText } from '../src/index.js';
+import { emptyDocument, textBlock, toolResultTurn, userTurn } from './fixtures.js';
+
+describe('human-readable canonical history', () => {
+    it('renders source history independently of active context and nested media', () => {
+        const document = emptyDocument();
+        const user = userTurn('user');
+        user.blocks = [textBlock('question', 'Look here'), { type: 'image', id: 'image', asset_id: 'asset' }];
+        const result = toolResultTurn('result', 'call');
+        result.blocks[0].content = [textBlock('answer', 'Found it'), { type: 'audio', id: 'audio', asset_id: 'sound' }];
+        document.turns = [user, result];
+        expect(renderConversationText(document)).toBe(
+            '[USER]: Look here [Image]\n\n[TOOL]: [TOOL RESULT]: call → Found it [Audio]',
+        );
+    });
+
+    it('does not expose opaque replay or extension payloads', () => {
+        expect(
+            renderContentBlockText({
+                id: 'extension',
+                type: 'extension',
+                namespace: 'example',
+                version: '1',
+                payload: { secret: 'opaque' },
+            }),
+        ).toBe('');
+    });
+
+    it('recognizes only an own data-property envelope without executing getters', () => {
+        expect(isConversationDocumentFormat(emptyDocument())).toBe(true);
+        expect(isConversationDocumentFormat({ format: 'other' })).toBe(false);
+        expect(isConversationDocumentFormat(Object.create({ format: 'llumiverse.conversation' }))).toBe(false);
+        expect(
+            isConversationDocumentFormat({
+                get format() {
+                    throw new Error('must not execute');
+                },
+            }),
+        ).toBe(false);
+        // Envelope recognition is intentionally not schema validation.
+        expect(isConversationDocumentFormat({ format: 'llumiverse.conversation' })).toBe(true);
+    });
+});

--- a/conversation/test/roundtrip-inspection.test.ts
+++ b/conversation/test/roundtrip-inspection.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'vitest';
+import {
+    type ConversationDocument,
+    conversationDocumentFromJson,
+    conversationDocumentToJson,
+    getPendingToolCallIds,
+    inspectConversation,
+    validateConversationDocument,
+} from '../src/index.js';
+import {
+    emptyDocument,
+    generatedAgentTurn,
+    importedGeneration,
+    RECORDED_AT,
+    toolCallBlock,
+    toolResultTurn,
+    userTurn,
+} from './fixtures.js';
+
+function richDocument(): ConversationDocument {
+    const document = emptyDocument();
+    const user = userTurn('user', 'user-text');
+    user.blocks.push({ id: 'user-image', type: 'image', asset_id: 'image', caption: 'exact caption' });
+    const call = toolCallBlock('call-block', 'call');
+    call.definition_id = 'read-tool';
+    const agent = generatedAgentTurn('agent', 'generation', [
+        {
+            id: 'replay',
+            type: 'native_replay',
+            adapter: 'adapter',
+            protocol: 'protocol',
+            compatibility_scope: {
+                provider: 'provider',
+                protocol: 'protocol',
+                adapter_version: 'adapter-v1',
+            },
+            payload: { constructor: 'opaque', toString: 'signature:\\n[]{}' },
+            dependencies: {
+                turn_ids: ['user'],
+                block_ids: ['user-text'],
+                call_ids: [],
+                request_ids: [],
+            },
+        },
+        call,
+    ]);
+    const result = toolResultTurn('tool-result', 'call');
+    result.blocks[0].content.push({ id: 'result-json', type: 'json', value: { output: '  exact  ' } });
+    document.turns.push(user, agent, result);
+
+    const generation = importedGeneration('generation');
+    generation.usage = {
+        input_tokens: 2,
+        output_tokens: 3,
+        total_tokens: 5,
+        accounting_provenance: {
+            input_tokens: { method: 'reported', accounting_basis: 'provider-v1' },
+            output_tokens: { method: 'reported', accounting_basis: 'provider-v1' },
+            total_tokens: { method: 'derived', accounting_basis: 'provider-v1' },
+        },
+        reported_usage: [{ source: 'provider', payload: { input: 2, output: 3 } }],
+    };
+    document.generations.generation = generation;
+    document.assets.image = {
+        id: 'image',
+        kind: 'image',
+        mime_type: 'image/png',
+        storage: { type: 'inline_base64', data: 'AAEC/w==' },
+        provenance: { type: 'received', source_turn_id: 'user' },
+        byte_length: 4,
+        content_hash: 'sha256:image',
+        media: { width: 1, height: 1 },
+        created_at: RECORDED_AT,
+    };
+    document.tool_definitions['read-tool'] = {
+        id: 'read-tool',
+        name: 'read',
+        version: '1',
+        input_schema: {
+            type: 'object',
+            properties: { path: { type: 'string' } },
+            required: ['path'],
+            additionalProperties: false,
+        },
+        result_capabilities: ['text', 'json'],
+    };
+    document.execution_receipts.receipt = {
+        id: 'receipt',
+        call_id: 'call',
+        executor: 'application',
+        status: 'success',
+        result_turn_id: 'tool-result',
+        result_fingerprint: 'sha256:result',
+        recorded_at: RECORDED_AT,
+    };
+    document.context.entries = [
+        { id: 'context-user', type: 'source_turn', turn_id: 'user' },
+        { id: 'context-agent', type: 'source_turn', turn_id: 'agent' },
+        { id: 'context-tool', type: 'source_turn', turn_id: 'tool-result' },
+    ];
+    document.context.active_tool_definition_ids = ['read-tool'];
+    document.metadata = { constructor: { preserved: true }, toString: 'preserved too' };
+    return document;
+}
+
+describe('materialized JSON round trip', () => {
+    it('preserves media, tool exchanges, opaque replay payloads, and built-in-looking keys', () => {
+        const input = richDocument();
+        const text = conversationDocumentToJson(input);
+        const restored = conversationDocumentFromJson(text);
+
+        expect(restored).toEqual(input);
+        expect(Object.hasOwn(restored.metadata ?? {}, 'constructor')).toBe(true);
+        expect(restored.assets.image.storage).toEqual({ type: 'inline_base64', data: 'AAEC/w==' });
+        const replay = restored.turns[1]?.blocks[0];
+        expect(replay?.type).toBe('native_replay');
+        if (replay?.type === 'native_replay') {
+            expect(replay.payload).toEqual({ constructor: 'opaque', toString: 'signature:\\n[]{}' });
+        }
+    });
+
+    it('enforces the materialized JSON byte limit in both directions', () => {
+        const input = richDocument();
+        expect(() => conversationDocumentToJson(input, { json_input_limits: { max_bytes: 128 } })).toThrow();
+        const text = JSON.stringify(input);
+        expect(() => conversationDocumentFromJson(text, { json_input_limits: { max_bytes: 128 } })).toThrow();
+    });
+});
+
+describe('inspection and execution receipts', () => {
+    it('reports source/context counts and resolves completed calls', () => {
+        const document = richDocument();
+        expect(inspectConversation(document)).toEqual({
+            source_turn_count: 3,
+            context_turn_count: 3,
+            source_turns_by_kind: { user: 1, agent: 1, tool: 1, program: 0 },
+            context_turns_by_kind: { user: 1, agent: 1, tool: 1, program: 0 },
+            generation_count: 1,
+            pending_tool_call_ids: [],
+        });
+    });
+
+    it('uses terminal receipts after call/result history deletion and never queues provider calls', () => {
+        const document = emptyDocument();
+        document.execution_receipts.provider = {
+            id: 'provider',
+            call_id: 'removed-provider-call',
+            executor: 'provider',
+            status: 'success',
+            result_fingerprint: 'sha256:provider',
+            recorded_at: RECORDED_AT,
+        };
+        document.turns.push(
+            generatedAgentTurn('agent', 'generation', [toolCallBlock('provider-call', 'provider-pending', 'provider')]),
+        );
+        document.generations.generation = importedGeneration('generation');
+
+        expect(validateConversationDocument(document)).toMatchObject({ success: true });
+        expect(getPendingToolCallIds(document)).toEqual([]);
+    });
+
+    it('lets a provider receipt resolve its retained result after source-call deletion', () => {
+        const document = emptyDocument();
+        document.turns.push(toolResultTurn('provider-result', 'removed-provider-call'));
+        document.execution_receipts.provider = {
+            id: 'provider',
+            call_id: 'removed-provider-call',
+            executor: 'provider',
+            status: 'success',
+            result_turn_id: 'provider-result',
+            result_fingerprint: 'sha256:provider',
+            recorded_at: RECORDED_AT,
+        };
+
+        expect(validateConversationDocument(document)).toMatchObject({ success: true });
+    });
+
+    it('rejects a receipt status that contradicts its retained result', () => {
+        const document = richDocument();
+        document.execution_receipts.receipt.status = 'error';
+        const result = validateConversationDocument(document);
+        expect(result.success).toBe(false);
+        expect(result.diagnostics.some((diagnostic) => diagnostic.code === 'TOOL_RECEIPT_MISMATCH')).toBe(true);
+    });
+
+    it('rejects a call name that contradicts its pinned definition', () => {
+        const document = richDocument();
+        document.tool_definitions['read-tool'].name = 'write';
+        const result = validateConversationDocument(document);
+        expect(result.success).toBe(false);
+        expect(result.diagnostics.some((diagnostic) => diagnostic.code === 'TOOL_DEFINITION_MISMATCH')).toBe(true);
+    });
+});

--- a/conversation/test/runtime.test.ts
+++ b/conversation/test/runtime.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+import {
+    appendConversationRecords,
+    ConversationValidationError,
+    createConversationDocument,
+    createTextBlock,
+    createUserTurn,
+} from '../src/index.js';
+
+const firstRecordedAt = '2026-09-11T00:00:00.000Z';
+const retryRecordedAt = '2026-09-11T00:01:00.000Z';
+
+function userTurn(text: string, recordedAt = firstRecordedAt) {
+    return createUserTurn({
+        id: 'turn:user:1',
+        authority: 'ordinary',
+        status: 'completed',
+        timestamps: { recorded_at: recordedAt },
+        model_visibility: 'include',
+        provenance: { type: 'received' },
+        blocks: [createTextBlock({ id: 'block:user:1', text, format: 'plain' })],
+    });
+}
+
+describe('canonical ingestion runtime', () => {
+    it('recovers an old accepted operation after later context/tool changes and fresh retry timestamps', () => {
+        const initial = createConversationDocument({ id: 'conversation:1', created_at: firstRecordedAt });
+        const first = appendConversationRecords(
+            initial,
+            {
+                turns: [userTurn('hello')],
+                context_entries: [{ id: 'context:user:1', type: 'source_turn', turn_id: 'turn:user:1' }],
+                active_tool_definition_ids: [],
+            },
+            {
+                expected_revision: 0,
+                operation_id: 'operation:input:1',
+                payload_fingerprint: 'sha256:first',
+                recorded_at: firstRecordedAt,
+            },
+        );
+        const advanced = appendConversationRecords(
+            first.document,
+            {
+                tool_definitions: [
+                    {
+                        id: 'tool:lookup:v1',
+                        name: 'lookup',
+                        version: 'sha256:lookup-v1',
+                        input_schema: { type: 'object' },
+                    },
+                ],
+                active_tool_definition_ids: ['tool:lookup:v1'],
+            },
+            {
+                expected_revision: 1,
+                operation_id: 'operation:input:2',
+                payload_fingerprint: 'sha256:second',
+                recorded_at: retryRecordedAt,
+            },
+        );
+
+        const retried = appendConversationRecords(
+            advanced.document,
+            {
+                turns: [userTurn('hello', retryRecordedAt)],
+                context_entries: [{ id: 'context:user:1', type: 'source_turn', turn_id: 'turn:user:1' }],
+                active_tool_definition_ids: [],
+            },
+            {
+                expected_revision: 0,
+                operation_id: 'operation:input:1',
+                payload_fingerprint: 'sha256:first',
+                recorded_at: retryRecordedAt,
+            },
+        );
+
+        expect(retried.applied).toBe(false);
+        expect(retried.document).toEqual(advanced.document);
+        expect(retried.document.context.active_tool_definition_ids).toEqual(['tool:lookup:v1']);
+        expect(retried.accepted_turn_ids).toEqual(['turn:user:1']);
+    });
+
+    it('rejects changed semantic records even when IDs and a caller fingerprint are reused', () => {
+        const initial = createConversationDocument({ id: 'conversation:1', created_at: firstRecordedAt });
+        const accepted = appendConversationRecords(
+            initial,
+            { turns: [userTurn('original')] },
+            {
+                expected_revision: 0,
+                operation_id: 'operation:input:1',
+                payload_fingerprint: 'sha256:claimed',
+                recorded_at: firstRecordedAt,
+            },
+        );
+
+        expect(() =>
+            appendConversationRecords(
+                accepted.document,
+                { turns: [userTurn('changed')] },
+                {
+                    expected_revision: 0,
+                    operation_id: 'operation:input:1',
+                    payload_fingerprint: 'sha256:claimed',
+                    recorded_at: retryRecordedAt,
+                },
+            ),
+        ).toThrow('retry changes accepted turn turn:user:1');
+    });
+
+    it('preflights accessors before reading them and schema-validates strict options on retries', () => {
+        const initial = createConversationDocument({ id: 'conversation:1', created_at: firstRecordedAt });
+        let getterReads = 0;
+        const batch = Object.defineProperty({}, 'turns', {
+            enumerable: true,
+            get() {
+                getterReads += 1;
+                return [];
+            },
+        });
+
+        expect(() =>
+            appendConversationRecords(initial, batch as never, {
+                expected_revision: 0,
+                operation_id: 'operation:input:1',
+                payload_fingerprint: 'sha256:first',
+                recorded_at: firstRecordedAt,
+            }),
+        ).toThrow(ConversationValidationError);
+        expect(getterReads).toBe(0);
+
+        const accepted = appendConversationRecords(
+            initial,
+            {},
+            {
+                expected_revision: 0,
+                operation_id: 'operation:input:1',
+                payload_fingerprint: 'sha256:first',
+                recorded_at: firstRecordedAt,
+            },
+        );
+        expect(() =>
+            appendConversationRecords(accepted.document, {}, {
+                expected_revision: 0,
+                operation_id: 'operation:input:1',
+                payload_fingerprint: 'sha256:first',
+                recorded_at: retryRecordedAt,
+                extra: true,
+            } as never),
+        ).toThrow();
+    });
+});

--- a/conversation/test/semantic-compaction.test.ts
+++ b/conversation/test/semantic-compaction.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from 'vitest';
+import { type CompactionRecord, type UserTurn, validateConversationDocument } from '../src/index.js';
+import { emptyDocument, RECORDED_AT, textBlock, userTurn } from './fixtures.js';
+
+function replacementTurn(id: string, derivationId: string, sourceBlockId = 'source-a'): UserTurn {
+    const turn = userTurn(id, `${id}-text`);
+    turn.provenance = {
+        type: 'derived',
+        derivation_id: derivationId,
+        source_turn_ids: ['source'],
+        source_block_ids: [sourceBlockId],
+        source_hash: `sha256:${sourceBlockId}`,
+    };
+    return turn;
+}
+
+function compaction(id: string, replacementId: string, sourceBlockId = 'source-a'): CompactionRecord {
+    return {
+        id,
+        operation_id: `${id}-operation`,
+        strategy: { id: 'summarize', version: '1', configuration_fingerprint: 'sha256:config' },
+        source: {
+            turn_ids: ['source'],
+            block_ids: ['source-a'],
+            source_fingerprint: 'sha256:source',
+        },
+        replacement_turns: [replacementTurn(replacementId, id, sourceBlockId)],
+        fidelity: 'semantic',
+        retained_asset_ids: [],
+        generation_ids: [],
+        created_at: RECORDED_AT,
+    };
+}
+
+function partialCompactionDocument() {
+    const document = emptyDocument();
+    const source = userTurn('source', 'source-a');
+    source.blocks.push(textBlock('source-b'));
+    document.turns.push(source);
+    document.compactions.compaction = compaction('compaction', 'replacement');
+    document.context.entries = [
+        { id: 'replacement-entry', type: 'replacement_turn', compaction_id: 'compaction', turn_id: 'replacement' },
+        { id: 'direct-entry', type: 'source_turn', turn_id: 'source', block_ids: ['source-b'] },
+    ];
+    return document;
+}
+
+describe('partial compaction semantics', () => {
+    it('allows a replaced block and a disjoint direct block from the same turn', () => {
+        expect(validateConversationDocument(partialCompactionDocument())).toMatchObject({ success: true });
+    });
+
+    it('rejects direct selection of a block covered by an active replacement', () => {
+        const document = partialCompactionDocument();
+        document.context.entries[1] = {
+            id: 'direct-entry',
+            type: 'source_turn',
+            turn_id: 'source',
+            block_ids: ['source-a'],
+        };
+        const result = validateConversationDocument(document);
+        expect(result.success).toBe(false);
+        expect(result.diagnostics.some((diagnostic) => diagnostic.code === 'CONTEXT_DIRECT_REPLACEMENT_OVERLAP')).toBe(
+            true,
+        );
+    });
+
+    it('rejects duplicate direct selections', () => {
+        const document = partialCompactionDocument();
+        document.context.entries.push({
+            id: 'duplicate-direct',
+            type: 'source_turn',
+            turn_id: 'source',
+            block_ids: ['source-b'],
+        });
+        const result = validateConversationDocument(document);
+        expect(result.success).toBe(false);
+        expect(result.diagnostics.some((diagnostic) => diagnostic.code === 'CONTEXT_SELECTION_OVERLAP')).toBe(true);
+    });
+
+    it('rejects derived source blocks outside the compaction selection', () => {
+        const document = partialCompactionDocument();
+        document.compactions.compaction.replacement_turns[0] = replacementTurn('replacement', 'compaction', 'source-b');
+        const result = validateConversationDocument(document);
+        expect(result.success).toBe(false);
+        expect(result.diagnostics.some((diagnostic) => diagnostic.code === 'DERIVED_PROVENANCE_MISMATCH')).toBe(true);
+    });
+
+    it('rejects two active replacements whose source selections overlap', () => {
+        const document = partialCompactionDocument();
+        document.compactions.second = compaction('second', 'second-replacement');
+        document.compactions.second.supersedes_compaction_id = 'compaction';
+        document.context.entries.push({
+            id: 'second-entry',
+            type: 'replacement_turn',
+            compaction_id: 'second',
+            turn_id: 'second-replacement',
+        });
+        const result = validateConversationDocument(document);
+        expect(result.success).toBe(false);
+        expect(result.diagnostics.some((diagnostic) => diagnostic.code === 'CONTEXT_SELECTION_OVERLAP')).toBe(true);
+    });
+
+    it('rejects supersession and causal parent cycles', () => {
+        const document = partialCompactionDocument();
+        document.compactions.second = compaction('second', 'second-replacement');
+        document.compactions.compaction.supersedes_compaction_id = 'second';
+        document.compactions.second.supersedes_compaction_id = 'compaction';
+        const first = userTurn('first');
+        const second = userTurn('second-source');
+        first.parent_turn_id = second.id;
+        second.parent_turn_id = first.id;
+        document.turns.push(first, second);
+
+        const result = validateConversationDocument(document);
+        expect(result.success).toBe(false);
+        expect(result.diagnostics.some((diagnostic) => diagnostic.code === 'SUPERSEDES_CYCLE')).toBe(true);
+        expect(result.diagnostics.some((diagnostic) => diagnostic.code === 'PARENT_TURN_CYCLE')).toBe(true);
+    });
+
+    it('rejects authority promotion by a replacement', () => {
+        const document = partialCompactionDocument();
+        document.compactions.compaction.replacement_turns[0].authority = 'system';
+        const result = validateConversationDocument(document);
+        expect(result.success).toBe(false);
+        expect(result.diagnostics.some((diagnostic) => diagnostic.code === 'DERIVED_AUTHORITY_PROMOTED')).toBe(true);
+    });
+
+    it('rejects cycles between derived replacement provenances', () => {
+        const document = emptyDocument();
+        const first = compaction('first', 'first-replacement');
+        const second = compaction('second', 'second-replacement');
+        first.source = {
+            turn_ids: ['second-replacement'],
+            source_fingerprint: 'sha256:second-replacement',
+        };
+        second.source = {
+            turn_ids: ['first-replacement'],
+            source_fingerprint: 'sha256:first-replacement',
+        };
+        first.replacement_turns[0].provenance = {
+            type: 'derived',
+            derivation_id: 'first',
+            source_turn_ids: ['second-replacement'],
+            source_hash: 'sha256:second-replacement',
+        };
+        second.replacement_turns[0].provenance = {
+            type: 'derived',
+            derivation_id: 'second',
+            source_turn_ids: ['first-replacement'],
+            source_hash: 'sha256:first-replacement',
+        };
+        document.compactions = { first, second };
+
+        const result = validateConversationDocument(document);
+        expect(result.success).toBe(false);
+        expect(result.diagnostics.some((diagnostic) => diagnostic.code === 'DERIVED_PROVENANCE_CYCLE')).toBe(true);
+    });
+});
+
+describe('historical request receipts', () => {
+    it('allows retained receipt bindings whose transcript records were deleted', () => {
+        const document = emptyDocument();
+        document.generations.generation = {
+            id: 'generation',
+            record_source: 'imported',
+            status: 'completed',
+            timestamps: { recorded_at: RECORDED_AT },
+            source: { conversation_id: document.id, revision: 0 },
+            request_receipt: {
+                id: 'request-receipt',
+                request_id: 'request',
+                attempt_id: 'attempt',
+                source: { conversation_id: document.id, revision: 0 },
+                source_tail_turn_id: 'deleted-turn',
+                context_fingerprint: 'sha256:context',
+                tool_set_fingerprint: 'sha256:tools',
+                request_fingerprint: 'sha256:request',
+                target: {
+                    provider: 'provider',
+                    protocol: 'protocol',
+                    model: 'model',
+                    adapter_version: 'adapter-v1',
+                },
+                tool_definition_ids: ['deleted-tool'],
+                asset_versions: [{ asset_id: 'deleted-asset', content_hash: 'sha256:asset' }],
+                item_mappings: [{ canonical_id: 'deleted-block', native_id: 'native', kind: 'block' }],
+                recorded_at: RECORDED_AT,
+            },
+        };
+
+        expect(validateConversationDocument(document)).toMatchObject({ success: true });
+    });
+});

--- a/conversation/test/validation.test.ts
+++ b/conversation/test/validation.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it } from 'vitest';
+import {
+    ConversationTurnSchema,
+    createTextBlock,
+    parseConversationDocument,
+    ToolTurnSchema,
+    validateConversationDocument,
+} from '../src/index.js';
+import {
+    emptyDocument,
+    generatedAgentTurn,
+    importedGeneration,
+    RECORDED_AT,
+    toolCallBlock,
+    toolResultTurn,
+    userTurn,
+} from './fixtures.js';
+
+const provenance = (method: 'reported' | 'derived' = 'reported') => ({
+    method,
+    accounting_basis: 'provider-v1',
+});
+
+describe('conversation shape validation', () => {
+    it('rejects unknown fields on strict objects', () => {
+        const input = { ...emptyDocument(), unknown_field: true };
+        const result = validateConversationDocument(input);
+        expect(result.success).toBe(false);
+        expect(result.diagnostics[0]).toMatchObject({ code: 'SCHEMA_INVALID', stage: 'schema' });
+    });
+
+    it('enforces generated agent references in the emitted union shape', () => {
+        const turn = generatedAgentTurn('agent', 'generation');
+        Reflect.deleteProperty(turn, 'generation_id');
+        expect(ConversationTurnSchema.safeParse(turn).success).toBe(false);
+    });
+
+    it('permits imported generations without invented model metadata', () => {
+        const document = emptyDocument();
+        document.generations.imported = importedGeneration('imported');
+        expect(validateConversationDocument(document)).toMatchObject({ success: true });
+    });
+
+    it('requires one result per tool turn and excludes nested calls and results', () => {
+        const turn = toolResultTurn('result-turn', 'call');
+        expect(ToolTurnSchema.safeParse({ ...turn, blocks: [...turn.blocks, ...turn.blocks] }).success).toBe(false);
+        expect(
+            ToolTurnSchema.safeParse({
+                ...turn,
+                blocks: [{ ...turn.blocks[0], content: [toolCallBlock('nested-call', 'nested')] }],
+            }).success,
+        ).toBe(false);
+        expect(
+            ToolTurnSchema.safeParse({
+                ...turn,
+                blocks: [{ ...turn.blocks[0], content: [{ ...turn.blocks[0], id: 'nested-result' }] }],
+            }).success,
+        ).toBe(false);
+    });
+
+    it('rejects reserved __proto__ input rather than letting Zod rewrite it', () => {
+        const document = emptyDocument();
+        document.metadata = JSON.parse('{"__proto__":{"invalid":true}}');
+        const result = validateConversationDocument(document);
+        expect(result.success).toBe(false);
+        expect(result.diagnostics[0]?.code).toBe('JSON_RESERVED_PROPERTY_KEY');
+    });
+
+    it('bounds schema diagnostics for enormous unknown keys', () => {
+        const result = validateConversationDocument({ ...emptyDocument(), ['x'.repeat(100_000)]: true });
+        expect(result.success).toBe(false);
+        expect(JSON.stringify(result.diagnostics).length).toBeLessThan(5_000);
+    });
+});
+
+describe('identity and reference validation', () => {
+    it('accepts valid own map entries whose IDs resemble Object.prototype names', () => {
+        const document = emptyDocument();
+        Reflect.set(document.tool_definitions, 'constructor', {
+            id: 'constructor',
+            name: 'read',
+            version: '1',
+            input_schema: true,
+        });
+        document.context.active_tool_definition_ids = ['constructor'];
+
+        const result = validateConversationDocument(document);
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(Object.hasOwn(result.data.tool_definitions, 'constructor')).toBe(true);
+        }
+    });
+
+    it.each(['constructor', 'toString', 'hasOwnProperty'])(
+        'does not resolve absent %s through Object.prototype',
+        (id) => {
+            const document = emptyDocument();
+            document.turns.push(generatedAgentTurn('agent', id));
+            const result = validateConversationDocument(document);
+            expect(result.success).toBe(false);
+            expect(result.diagnostics.some((diagnostic) => diagnostic.code === 'REFERENCE_NOT_FOUND')).toBe(true);
+        },
+    );
+
+    it('rejects duplicate IDs across entity kinds', () => {
+        const document = emptyDocument();
+        document.turns.push(userTurn('same', 'same'));
+        const result = validateConversationDocument(document);
+        expect(result.success).toBe(false);
+        expect(result.diagnostics.some((diagnostic) => diagnostic.code === 'DUPLICATE_ID')).toBe(true);
+    });
+
+    it('rejects dangling media references', () => {
+        const document = emptyDocument();
+        const turn = userTurn('user');
+        turn.blocks = [{ id: 'image', type: 'image', asset_id: 'missing' }];
+        document.turns.push(turn);
+        const result = validateConversationDocument(document);
+        expect(result.success).toBe(false);
+        expect(result.diagnostics.some((diagnostic) => diagnostic.code === 'REFERENCE_NOT_FOUND')).toBe(true);
+    });
+});
+
+describe('usage accounting', () => {
+    it('requires canonical totals to equal a safe input plus output sum', () => {
+        const document = emptyDocument();
+        const generation = importedGeneration('generation');
+        generation.usage = {
+            input_tokens: 5,
+            output_tokens: 7,
+            total_tokens: 99,
+            accounting_provenance: {
+                input_tokens: provenance(),
+                output_tokens: provenance(),
+                total_tokens: provenance(),
+            },
+        };
+        document.generations.generation = generation;
+
+        const result = validateConversationDocument(document);
+        expect(result.success).toBe(false);
+        expect(result.diagnostics.some((diagnostic) => diagnostic.code === 'USAGE_TOTAL_INVALID')).toBe(true);
+    });
+
+    it('requires provenance for every normalized measurement without fabricating defaults', () => {
+        const document = emptyDocument();
+        const generation = importedGeneration('generation');
+        generation.usage = { input_tokens: 5 };
+        document.generations.generation = generation;
+
+        const result = validateConversationDocument(document);
+        expect(result.success).toBe(false);
+        expect(result.diagnostics.some((diagnostic) => diagnostic.code === 'ACCOUNTING_PROVENANCE_MISMATCH')).toBe(
+            true,
+        );
+    });
+
+    it('rejects derived new-input usage without a complete disjoint partition', () => {
+        const document = emptyDocument();
+        const generation = importedGeneration('generation');
+        generation.usage = {
+            input_new_tokens: 25,
+            accounting_provenance: { input_new_tokens: provenance('derived') },
+        };
+        document.generations.generation = generation;
+
+        const result = validateConversationDocument(document);
+        expect(result.success).toBe(false);
+        expect(result.diagnostics.some((diagnostic) => diagnostic.code === 'INPUT_PARTITION_INVALID')).toBe(true);
+    });
+
+    it('rejects a canonical total across incompatible accounting bases', () => {
+        const document = emptyDocument();
+        const generation = importedGeneration('generation');
+        generation.usage = {
+            input_tokens: 5,
+            output_tokens: 7,
+            total_tokens: 12,
+            accounting_provenance: {
+                input_tokens: { method: 'reported', accounting_basis: 'input-basis' },
+                output_tokens: { method: 'reported', accounting_basis: 'output-basis' },
+                total_tokens: { method: 'derived', accounting_basis: 'input-basis' },
+            },
+        };
+        document.generations.generation = generation;
+
+        const result = validateConversationDocument(document);
+        expect(result.success).toBe(false);
+        expect(result.diagnostics.some((diagnostic) => diagnostic.code === 'USAGE_TOTAL_INVALID')).toBe(true);
+    });
+
+    it('rejects an empty reported-usage collection', () => {
+        const document = emptyDocument();
+        const generation = importedGeneration('generation');
+        generation.usage = { reported_usage: [] };
+        document.generations.generation = generation;
+        expect(validateConversationDocument(document).success).toBe(false);
+    });
+
+    it('detects aggregate overflow even when each counter is safe', () => {
+        const document = emptyDocument();
+        const generation = importedGeneration('generation');
+        generation.usage = {
+            input_tokens: Number.MAX_SAFE_INTEGER,
+            output_tokens: 1,
+            accounting_provenance: {
+                input_tokens: provenance(),
+                output_tokens: provenance(),
+            },
+        };
+        document.generations.generation = generation;
+
+        const result = validateConversationDocument(document);
+        expect(result.success).toBe(false);
+        expect(result.diagnostics.some((diagnostic) => diagnostic.code === 'USAGE_OVERFLOW')).toBe(true);
+    });
+
+    it('accepts a consistent complete disjoint partition', () => {
+        const document = emptyDocument();
+        const generation = importedGeneration('generation');
+        generation.usage = {
+            input_tokens: 110,
+            output_tokens: 5,
+            total_tokens: 115,
+            input_new_tokens: 25,
+            cache_read_tokens: 75,
+            cache_write_tokens: 10,
+            input_partition: { type: 'complete_disjoint', cache_write_bucket: 'included' },
+            accounting_provenance: {
+                input_tokens: provenance(),
+                output_tokens: provenance(),
+                total_tokens: provenance('derived'),
+                input_new_tokens: provenance('derived'),
+                cache_read_tokens: provenance(),
+                cache_write_tokens: provenance(),
+            },
+        };
+        document.generations.generation = generation;
+        expect(validateConversationDocument(document)).toMatchObject({ success: true });
+    });
+});
+
+describe('builders', () => {
+    it('preflights builder inputs before spreading or reading accessor properties', () => {
+        let getterCalls = 0;
+        const input = Object.defineProperty({ id: 'text', text: 'value', format: 'plain' as const }, 'id', {
+            enumerable: true,
+            get() {
+                getterCalls += 1;
+                return 'text';
+            },
+        });
+
+        expect(() => createTextBlock(input)).toThrow();
+        expect(getterCalls).toBe(0);
+    });
+
+    it('returns isolated materialized values', () => {
+        const input = emptyDocument();
+        const parsed = parseConversationDocument(input);
+        parsed.turns.push(userTurn('later'));
+        expect(input.turns).toHaveLength(0);
+    });
+
+    it('preserves exact timestamp and text values', () => {
+        const block = createTextBlock({ id: 'text', text: '  punctuation: []{}\\n  ', format: 'plain' });
+        expect(block.text).toBe('  punctuation: []{}\\n  ');
+        expect(RECORDED_AT.endsWith('Z')).toBe(true);
+    });
+});

--- a/conversation/tsconfig.json
+++ b/conversation/tsconfig.json
@@ -1,0 +1,27 @@
+{
+    "compilerOptions": {
+        "target": "ES2024",
+        "lib": ["ES2024", "DOM"],
+        "module": "nodenext",
+        "moduleResolution": "nodenext",
+        "rootDir": "./src",
+        "outDir": "./lib",
+        "composite": true,
+        "declaration": true,
+        "declarationMap": true,
+        "sourceMap": true,
+        "useDefineForClassFields": true,
+        "forceConsistentCasingInFileNames": true,
+        "allowSyntheticDefaultImports": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "isolatedModules": true,
+        "strict": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "noFallthroughCasesInSwitch": true,
+        "useUnknownInCatchVariables": true
+    },
+    "include": ["src"],
+    "exclude": ["node_modules", "**/*.test.ts", "lib", "test"]
+}

--- a/conversation/tsconfig.test.json
+++ b/conversation/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "composite": false,
+        "declaration": true,
+        "noEmit": true,
+        "rootDir": "."
+    },
+    "include": ["src", "test"],
+    "exclude": ["node_modules", "lib"]
+}

--- a/core/package.json
+++ b/core/package.json
@@ -73,6 +73,7 @@
     },
     "dependencies": {
         "@llumiverse/common": "workspace:*",
+        "@llumiverse/conversation": "workspace:*",
         "@types/node": "catalog:",
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",

--- a/core/src/Driver.lifecycle.test.ts
+++ b/core/src/Driver.lifecycle.test.ts
@@ -12,6 +12,7 @@ import {
     PromptRole,
     type PromptSegment,
 } from '@llumiverse/common';
+import { createConversationDocument } from '@llumiverse/conversation';
 import { describe, expect, it, vi } from 'vitest';
 import { DEFAULT_COMPLETION_STREAM_START_TIMEOUT_MS } from './CompletionStream.js';
 import { AbstractDriver } from './Driver.js';
@@ -32,6 +33,8 @@ class LifecycleTestDriver extends AbstractDriver<DriverOptions, string> {
             yield { result: [{ type: 'text', value: 'first' }] } satisfies CompletionChunkObject;
         },
     };
+    requestTextCompletionCalls = 0;
+    requestTextCompletionStreamCalls = 0;
 
     constructor(
         private readonly cleanup: () => void,
@@ -45,6 +48,7 @@ class LifecycleTestDriver extends AbstractDriver<DriverOptions, string> {
         _options: ExecutionOptions,
         signal?: AbortSignal,
     ): Promise<Completion> {
+        this.requestTextCompletionCalls += 1;
         this.completionSignal = signal;
         if (this.waitForCompletionAbort) {
             return new Promise((_resolve, reject) => {
@@ -61,6 +65,7 @@ class LifecycleTestDriver extends AbstractDriver<DriverOptions, string> {
         _options: ExecutionOptions,
         signal?: AbortSignal,
     ): Promise<DriverCompletionStream> {
+        this.requestTextCompletionStreamCalls += 1;
         this.completionStreamSignal = signal;
         return this.completionStream;
     }
@@ -149,6 +154,24 @@ function holdStreamCancellation(driver: OverriddenStreamDriver): () => void {
 }
 
 describe('AbstractDriver lifecycle', () => {
+    it('rejects canonical input on unadopted drivers before invoking provider methods', async () => {
+        const driver = new LifecycleTestDriver(vi.fn());
+        const conversation = createConversationDocument({
+            id: 'conversation:unsupported',
+            created_at: '2026-09-11T00:00:00.000Z',
+        });
+        const canonicalOptions = { ...options, conversation };
+
+        await expect(driver.execute(segments, canonicalOptions)).rejects.toThrow(
+            'Provider lifecycle-test model test-model does not support canonical conversation input',
+        );
+        await expect(driver.stream(segments, canonicalOptions)).rejects.toThrow(
+            'Provider lifecycle-test model test-model does not support canonical conversation input',
+        );
+        expect(driver.requestTextCompletionCalls).toBe(0);
+        expect(driver.requestTextCompletionStreamCalls).toBe(0);
+    });
+
     it('defers destruction until an in-flight execution finishes', async () => {
         let resolveCompletion!: (completion: Completion) => void;
         const cleanup = vi.fn();

--- a/core/src/Driver.ts
+++ b/core/src/Driver.ts
@@ -27,6 +27,7 @@ import {
     type TrainingOptions,
     type TrainingPromptOptions,
 } from '@llumiverse/common';
+import { isConversationDocumentFormat } from '@llumiverse/conversation';
 import type { Agent } from 'undici';
 import {
     DEFAULT_COMPLETION_STREAM_START_TIMEOUT_MS,
@@ -165,6 +166,19 @@ export abstract class AbstractDriver<OptionsT extends DriverOptions = DriverOpti
         this.options = opts;
         this.logger = createLogger(opts.logger);
         this.installOperationGuards();
+    }
+
+    /** Whether this concrete model path has adopted canonical conversation input. */
+    protected supportsCanonicalConversation(_options: ExecutionOptions): boolean {
+        return false;
+    }
+
+    private assertConversationInputSupported(options: ExecutionOptions): void {
+        if (isConversationDocumentFormat(options.conversation) && !this.supportsCanonicalConversation(options)) {
+            throw new Error(
+                `Provider ${this.provider} model ${options.model} does not support canonical conversation input`,
+            );
+        }
     }
 
     /**
@@ -329,6 +343,7 @@ export abstract class AbstractDriver<OptionsT extends DriverOptions = DriverOpti
         options: ExecutionOptions,
         signal?: AbortSignal,
     ): Promise<ExecutionResponse<PromptT>> {
+        this.assertConversationInputSupported(options);
         const prompt = await this.createPrompt(segments, options);
         return await this._execute(prompt, options, signal).catch((error: unknown) => {
             // Don't wrap if already a LlumiverseError
@@ -348,6 +363,7 @@ export abstract class AbstractDriver<OptionsT extends DriverOptions = DriverOpti
         options: ExecutionOptions,
         signal?: AbortSignal,
     ): Promise<ExecutionResponse<PromptT>> {
+        this.assertConversationInputSupported(options);
         const httpScope = this.createExecutionHttpAgentScope(options, signal !== undefined);
         const abort = () => void httpScope.abort();
         if (signal?.aborted) abort();
@@ -409,6 +425,7 @@ export abstract class AbstractDriver<OptionsT extends DriverOptions = DriverOpti
         options: ExecutionOptions,
         signal?: AbortSignal,
     ): Promise<CompletionStream<PromptT>> {
+        this.assertConversationInputSupported(options);
         signal?.throwIfAborted();
         this.logger.debug(
             options,

--- a/core/src/conversation-utils.ts
+++ b/core/src/conversation-utils.ts
@@ -1,3 +1,5 @@
+import { isConversationDocumentFormat } from '@llumiverse/conversation';
+
 /**
  * Utilities for cleaning up conversation objects before storage.
  *
@@ -265,6 +267,14 @@ function base64ToUint8Array(base64: string): Uint8Array {
  * Get metadata from a conversation object, or return defaults.
  */
 export function getConversationMeta(conversation: unknown): ConversationMeta {
+    if (isConversationDocumentFormat(conversation)) {
+        const generations = Object.getOwnPropertyDescriptor(conversation, 'generations');
+        const value = generations && 'value' in generations ? generations.value : undefined;
+        return {
+            turnNumber:
+                typeof value === 'object' && value !== null && !Array.isArray(value) ? Object.keys(value).length : 0,
+        };
+    }
     if (typeof conversation === 'object' && conversation !== null) {
         const meta = (conversation as Record<string, unknown>)[META_KEY];
         if (meta && typeof meta === 'object') {
@@ -282,6 +292,7 @@ const ARRAY_WRAPPER_KEY = '_arrayConversation';
  * Arrays are wrapped in an object to preserve their type through JSON serialization.
  */
 export function setConversationMeta(conversation: unknown, meta: ConversationMeta): unknown {
+    if (isConversationDocumentFormat(conversation)) return conversation;
     if (Array.isArray(conversation)) {
         // Wrap arrays in an object to preserve their array nature through JSON serialization
         return { [ARRAY_WRAPPER_KEY]: conversation, [META_KEY]: meta };
@@ -311,6 +322,7 @@ export function unwrapConversationArray<T = unknown>(conversation: unknown): T[]
  * Increment the turn number in a conversation and return the updated conversation.
  */
 export function incrementConversationTurn(conversation: unknown): unknown {
+    if (isConversationDocumentFormat(conversation)) return conversation;
     const meta = getConversationMeta(conversation);
     return setConversationMeta(conversation, { ...meta, turnNumber: meta.turnNumber + 1 });
 }
@@ -332,6 +344,7 @@ export function incrementConversationTurn(conversation: unknown): unknown {
  * @returns A new object with binary content handled appropriately
  */
 export function stripBinaryFromConversation(obj: unknown, options?: StripOptions): unknown {
+    if (isConversationDocumentFormat(obj)) return obj;
     const { keepForTurns = Infinity } = options ?? {};
     const currentTurn = options?.currentTurn ?? getConversationMeta(obj).turnNumber;
 
@@ -375,6 +388,7 @@ function serializeBinaryForStorage(obj: unknown): unknown {
  * Call this before sending conversation to API if images were preserved.
  */
 export function deserializeBinaryFromStorage(obj: unknown): unknown {
+    if (isConversationDocumentFormat(obj)) return obj;
     if (obj === null || obj === undefined) return obj;
 
     // Check for our serialized format
@@ -466,6 +480,7 @@ function stripBinaryFromConversationInternal(obj: unknown): unknown {
  * @returns A new object with image blocks replaced with text placeholders
  */
 export function stripBase64ImagesFromConversation(obj: unknown, options?: StripOptions): unknown {
+    if (isConversationDocumentFormat(obj)) return obj;
     const { keepForTurns = Infinity } = options ?? {};
     const currentTurn = options?.currentTurn ?? getConversationMeta(obj).turnNumber;
 
@@ -554,6 +569,7 @@ const CHARS_PER_TOKEN = 4;
  * @returns A new object with large text content truncated
  */
 export function truncateLargeTextInConversation(obj: unknown, options?: StripOptions): unknown {
+    if (isConversationDocumentFormat(obj)) return obj;
     const maxTokens = options?.textMaxTokens;
 
     // If no max tokens specified or 0, don't truncate
@@ -743,6 +759,7 @@ const HEARTBEAT_PLACEHOLDER = '[Heartbeat removed from conversation history]';
  * @returns A new object with old heartbeat messages replaced
  */
 export function stripHeartbeatsFromConversation(obj: unknown, options?: StripOptions): unknown {
+    if (isConversationDocumentFormat(obj)) return obj;
     const { keepForTurns = 1 } = options ?? {};
     const currentTurn = options?.currentTurn ?? getConversationMeta(obj).turnNumber;
 

--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -28,6 +28,7 @@
     "include": ["src"],
     "exclude": ["node_modules", "**/*.test.ts", "lib", "test"],
     "references": [
-        { "path": "../common" }
+        { "path": "../common" },
+        { "path": "../conversation" }
     ]
 }

--- a/drivers/package.json
+++ b/drivers/package.json
@@ -136,6 +136,7 @@
         "@google/genai": "^2.21.0",
         "@huggingface/inference": "^4.13.28",
         "@llumiverse/common": "workspace:*",
+        "@llumiverse/conversation": "workspace:*",
         "@llumiverse/core": "workspace:*",
         "@mistralai/mistralai": "^2.6.4",
         "@openrouter/sdk": "^1.2.93",

--- a/drivers/src/anthropic/index.ts
+++ b/drivers/src/anthropic/index.ts
@@ -37,6 +37,10 @@ export class AnthropicDriver extends AbstractDriver<AnthropicDriverOptions, Clau
     provider = Providers.anthropic;
     client: Anthropic;
 
+    protected supportsCanonicalConversation(_options: ExecutionOptions): boolean {
+        return true;
+    }
+
     constructor(opts: AnthropicDriverOptions) {
         super(opts);
         this.client = new Anthropic({

--- a/drivers/src/azure/azure_foundry.test.ts
+++ b/drivers/src/azure/azure_foundry.test.ts
@@ -1,9 +1,12 @@
 import type { TokenCredential } from '@azure/identity';
+import { parseConversationDocument } from '@llumiverse/conversation';
 import { PromptRole } from '@llumiverse/core';
 import type OpenAI from 'openai';
 import { describe, expect, it, vi } from 'vitest';
 import { exposePrivate } from '../../test/__helpers__/test-utils.js';
 import type { OpenAIChatCompletionsPayload } from '../openai/openai_chat_completions.js';
+import { prepareOpenAIChatCanonicalState } from '../openai/openai-chat-conversation-adapter.js';
+import { prepareOpenAIResponsesCanonicalState } from '../openai/openai-responses-conversation-adapter.js';
 import { AzureFoundryDriver, toAzureInferenceRequest } from './azure_foundry.js';
 
 const credential: TokenCredential = {
@@ -24,7 +27,207 @@ function createDriver(): AzureFoundryDriver {
     });
 }
 
+function canonicalOptions(model: string, id: string, operation = 'next') {
+    return {
+        model,
+        conversation_runtime: {
+            conversation_id: id,
+            request_id: `${id}:${operation}:request`,
+            attempt_id: `${id}:${operation}:attempt`,
+            input_operation_id: `${id}:${operation}:input`,
+            response_operation_id: `${id}:${operation}:response`,
+            recorded_at: '2026-09-12T00:00:00.000Z',
+        },
+    };
+}
+
 describe('AzureFoundryDriver protocol composition', () => {
+    it('accepts canonical history through the parent Chat execution path', async () => {
+        const driver = createDriver();
+        driver.service = {
+            deployments: { get: vi.fn(async () => ({ modelPublisher: 'Meta' })) },
+        } as unknown as AzureFoundryDriver['service'];
+        const post = vi.fn(async () => ({
+            status: '200',
+            body: {
+                id: 'foundry-chat-canonical',
+                created: 1,
+                model: 'llama-deployment',
+                choices: [
+                    {
+                        index: 0,
+                        finish_reason: 'stop',
+                        message: { role: 'assistant', content: 'chat answer' },
+                    },
+                ],
+                usage: { prompt_tokens: 2, completion_tokens: 2, total_tokens: 4 },
+            },
+        }));
+        const inferenceAdapter = exposePrivate<FoundryInternals>(driver).inferenceProtocolDriver;
+        Object.defineProperty(inferenceAdapter, 'service', { value: { path: vi.fn(() => ({ post })) } });
+        const model = 'llama-deployment::llama';
+        const id = 'foundry-chat';
+        const state = await prepareOpenAIChatCanonicalState({
+            conversation: { _is_openai_chat_completions: true, messages: [{ role: 'user', content: 'prior' }] },
+            prompt: { _is_openai_chat_completions: true, messages: [] },
+            options: canonicalOptions(model, id, 'seed'),
+            provider: 'azure_foundry',
+        });
+
+        const completion = await driver.execute([{ role: PromptRole.user, content: 'next' }], {
+            ...canonicalOptions(model, id),
+            conversation: state.document,
+        });
+
+        expect(parseConversationDocument(completion.conversation).id).toBe(id);
+        expect(post).toHaveBeenCalledOnce();
+    });
+
+    it('preserves tool result status through Chat ingestion without sending private evidence', async () => {
+        const driver = createDriver();
+        driver.service = {
+            deployments: { get: vi.fn(async () => ({ modelPublisher: 'Meta' })) },
+        } as unknown as AzureFoundryDriver['service'];
+        const responses = [
+            {
+                id: 'foundry-tool-call',
+                created: 1,
+                model: 'llama-deployment',
+                choices: [
+                    {
+                        index: 0,
+                        finish_reason: 'tool_calls',
+                        message: {
+                            role: 'assistant',
+                            content: null,
+                            tool_calls: [
+                                {
+                                    id: 'call:lookup',
+                                    type: 'function',
+                                    function: { name: 'lookup', arguments: '{"city":"Tokyo"}' },
+                                },
+                            ],
+                        },
+                    },
+                ],
+                usage: { prompt_tokens: 2, completion_tokens: 2, total_tokens: 4 },
+            },
+            {
+                id: 'foundry-tool-result',
+                created: 2,
+                model: 'llama-deployment',
+                choices: [{ index: 0, finish_reason: 'stop', message: { role: 'assistant', content: 'unavailable' } }],
+                usage: { prompt_tokens: 4, completion_tokens: 1, total_tokens: 5 },
+            },
+        ];
+        const post = vi.fn(async (_request: unknown) => ({ status: '200', body: responses.shift() }));
+        const inferenceAdapter = exposePrivate<FoundryInternals>(driver).inferenceProtocolDriver;
+        Object.defineProperty(inferenceAdapter, 'service', { value: { path: vi.fn(() => ({ post })) } });
+        const model = 'llama-deployment::llama';
+        const id = 'foundry-tool-status';
+
+        const first = await driver.execute([{ role: PromptRole.user, content: 'Weather?' }], {
+            ...canonicalOptions(model, id, 'ask'),
+            tools: [{ name: 'lookup', input_schema: { type: 'object' } }],
+        });
+        const second = await driver.execute(
+            [
+                {
+                    role: PromptRole.tool,
+                    content: '{"error":"offline"}',
+                    tool_use_id: 'call:lookup',
+                    tool_result_status: 'error',
+                },
+            ],
+            {
+                ...canonicalOptions(model, id, 'answer'),
+                conversation: first.conversation,
+                tools: [{ name: 'lookup', input_schema: { type: 'object' } }],
+            },
+        );
+
+        const persisted = parseConversationDocument(second.conversation);
+        expect(persisted.turns.find((turn) => turn.kind === 'tool')?.blocks[0]).toMatchObject({
+            type: 'tool_result',
+            call_id: 'call:lookup',
+            status: 'error',
+        });
+        expect(JSON.stringify(post.mock.calls[1]?.[0])).not.toContain('tool_result_status');
+        expect(JSON.stringify(post.mock.calls[1]?.[0])).not.toContain('_llumiverse_tool_result_status');
+    });
+
+    it('accepts canonical history through the parent Responses streaming path', async () => {
+        const driver = createDriver();
+        const model = 'gpt-deployment::gpt-5';
+        const id = 'foundry-responses';
+        const response = {
+            id: 'foundry-response-canonical',
+            object: 'response',
+            created_at: 1,
+            model: 'gpt-deployment',
+            status: 'completed',
+            output: [
+                {
+                    id: 'message-canonical',
+                    type: 'message',
+                    role: 'assistant',
+                    status: 'completed',
+                    content: [{ type: 'output_text', text: 'response answer', annotations: [], logprobs: [] }],
+                },
+            ],
+            output_text: 'response answer',
+            error: null,
+            incomplete_details: null,
+            instructions: null,
+            metadata: {},
+            parallel_tool_calls: true,
+            temperature: 1,
+            tool_choice: 'auto',
+            tools: [],
+            top_p: 1,
+            usage: {
+                input_tokens: 2,
+                input_tokens_details: { cached_tokens: 0, cache_write_tokens: 0 },
+                output_tokens: 2,
+                output_tokens_details: { reasoning_tokens: 0 },
+                total_tokens: 4,
+            },
+        } satisfies OpenAI.Responses.Response;
+        const create = vi.fn((_request: OpenAI.Responses.ResponseCreateParamsStreaming, _options?: unknown) =>
+            Promise.resolve(
+                (async function* () {
+                    yield { type: 'response.completed', sequence_number: 1, response };
+                })(),
+            ),
+        );
+        driver.service = {
+            deployments: { get: vi.fn(async () => ({ modelPublisher: 'OpenAI' })) },
+            getOpenAIClient: vi.fn(() => ({ responses: { create } })),
+        } as unknown as AzureFoundryDriver['service'];
+        const state = await prepareOpenAIResponsesCanonicalState({
+            conversation: [{ type: 'message', role: 'user', content: 'prior' }],
+            prompt: [],
+            options: canonicalOptions(model, id, 'seed'),
+            provider: 'azure_foundry',
+        });
+
+        const stream = await driver.stream([{ role: PromptRole.user, content: 'next' }], {
+            ...canonicalOptions(model, id),
+            conversation: state.document,
+        });
+        for await (const _chunk of stream) {
+            // Consume the parent stream so terminal canonical finalization runs.
+        }
+
+        const conversation = parseConversationDocument(stream.completion?.conversation);
+        expect(conversation.id).toBe(id);
+        expect(Object.values(conversation.generations)).toEqual(
+            expect.arrayContaining([expect.objectContaining({ requested_model: model })]),
+        );
+        expect(create.mock.calls[0]?.[0]).toEqual(expect.objectContaining({ model: 'gpt-deployment', stream: true }));
+        expect(create).toHaveBeenCalledOnce();
+    });
+
     it('preserves required tool choice when adapting an OpenAI chat request', () => {
         const body = toAzureInferenceRequest(
             {

--- a/drivers/src/azure/azure_foundry.ts
+++ b/drivers/src/azure/azure_foundry.ts
@@ -186,6 +186,10 @@ export class AzureFoundryDriver extends AbstractDriver<AzureFoundryDriverOptions
     private readonly deploymentProtocols = new Map<string, 'responses' | 'chat_completions'>();
     readonly provider = Providers.azure_foundry;
 
+    protected supportsCanonicalConversation(_options: ExecutionOptions): boolean {
+        return true;
+    }
+
     OPENAI_API_VERSION = '2025-01-01-preview';
     INFERENCE_API_VERSION = '2024-05-01-preview';
 
@@ -517,6 +521,15 @@ export class AzureFoundryDriver extends AbstractDriver<AzureFoundryDriverOptions
 }
 
 function toAzureFoundryChatPrompt(items: ResponseInputItem[]): OpenAIChatCompletionsPrompt {
+    const toolResultStatuses = new Map<string, 'success' | 'error' | 'cancelled' | 'denied'>();
+    for (const item of items) {
+        if (item.type !== 'function_call_output') continue;
+        const status = (item as typeof item & { _llumiverse_tool_result_status?: unknown })
+            ._llumiverse_tool_result_status;
+        if (status === 'success' || status === 'error' || status === 'cancelled' || status === 'denied') {
+            toolResultStatuses.set(item.call_id, status);
+        }
+    }
     const messages = convertResponseItemsToChatMessages(items).map((message) => {
         switch (message.role) {
             case 'assistant':
@@ -536,6 +549,9 @@ function toAzureFoundryChatPrompt(items: ResponseInputItem[]): OpenAIChatComplet
                     role: message.role,
                     content: typeof message.content === 'string' ? message.content : '',
                     tool_call_id: message.tool_call_id,
+                    ...(message.tool_call_id === undefined || !toolResultStatuses.has(message.tool_call_id)
+                        ? {}
+                        : { tool_result_status: toolResultStatuses.get(message.tool_call_id) }),
                 };
             case 'user':
                 return {

--- a/drivers/src/bedrock-mantle/index.test.ts
+++ b/drivers/src/bedrock-mantle/index.test.ts
@@ -1,12 +1,14 @@
 import type Anthropic from '@anthropic-ai/sdk';
 import { getTokenProvider } from '@aws/bedrock-token-generator';
 import type { AwsCredentialIdentity } from '@aws-sdk/types';
+import { parseConversationDocument } from '@llumiverse/conversation';
 import { getBedrockMantleProtocol, PromptRole, type PromptSegment, Providers } from '@llumiverse/core';
 import type OpenAI from 'openai';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { BedrockDriver } from '../bedrock/index.js';
 import { OpenAIResponsesDriverBase } from '../openai/index.js';
 import type { OpenAIChatCompletionsPrompt } from '../openai/openai_chat_completions.js';
+import { prepareOpenAIResponsesCanonicalState } from '../openai/openai-responses-conversation-adapter.js';
 import { BedrockMantleDriver, isBedrockMantleModel } from './index.js';
 
 vi.mock('@aws/bedrock-token-generator', () => ({
@@ -64,6 +66,7 @@ function createResponse(): OpenAI.Responses.Response {
         instructions: null,
         metadata: null,
         model: 'openai.gpt-5.5',
+        status: 'completed',
         output: [
             {
                 id: 'msg-test',
@@ -79,6 +82,31 @@ function createResponse(): OpenAI.Responses.Response {
         tools: [],
         top_p: null,
     } satisfies OpenAI.Responses.Response;
+}
+
+async function canonicalResponsesConversation(id: string) {
+    return (
+        await prepareOpenAIResponsesCanonicalState({
+            conversation: [{ type: 'message', role: 'user', content: 'prior question' }],
+            prompt: [],
+            options: canonicalOptions('openai.gpt-5.5', id, 'seed'),
+            provider: Providers.bedrock_mantle,
+        })
+    ).document;
+}
+
+function canonicalOptions(model: string, id: string, operation = 'next') {
+    return {
+        model,
+        conversation_runtime: {
+            conversation_id: id,
+            request_id: `${id}:${operation}:request`,
+            attempt_id: `${id}:${operation}:attempt`,
+            input_operation_id: `${id}:${operation}:input`,
+            response_operation_id: `${id}:${operation}:response`,
+            recorded_at: '2026-09-12T00:00:00.000Z',
+        },
+    };
 }
 
 describe('Bedrock Mantle model routing', () => {
@@ -277,6 +305,41 @@ describe('BedrockMantleDriver model listing', () => {
 });
 
 describe('BedrockMantleDriver protocol execution', () => {
+    it('accepts canonical Responses history through parent execute and stream', async () => {
+        const driver = new BedrockMantleDriver({ region: 'us-west-2' });
+        const finalResponse = createResponse();
+        const create = vi.fn((request: OpenAI.Responses.ResponseCreateParams) => {
+            if (request.stream) {
+                return Promise.resolve(
+                    (async function* () {
+                        yield { type: 'response.completed', sequence_number: 1, response: finalResponse };
+                    })(),
+                );
+            }
+            return Promise.resolve(finalResponse);
+        });
+        const responsesDelegate = getObjectProperty(driver, 'responsesDelegate');
+        Reflect.set(responsesDelegate, 'service', { responses: { create } });
+
+        const blockingId = 'mantle-responses-blocking';
+        const blocking = await driver.execute(promptSegments, {
+            ...canonicalOptions('openai.gpt-5.5', blockingId),
+            conversation: await canonicalResponsesConversation(blockingId),
+        });
+        expect(parseConversationDocument(blocking.conversation).id).toBe(blockingId);
+
+        const streamId = 'mantle-responses-stream';
+        const stream = await driver.stream(promptSegments, {
+            ...canonicalOptions('openai.gpt-5.5', streamId),
+            conversation: await canonicalResponsesConversation(streamId),
+        });
+        for await (const _chunk of stream) {
+            // Consume the parent stream so terminal canonical finalization runs.
+        }
+        expect(parseConversationDocument(stream.completion?.conversation).id).toBe(streamId);
+        expect(create).toHaveBeenCalledTimes(2);
+    });
+
     it('rejects prompts that do not match the selected model protocol', () => {
         const driver = new BedrockMantleDriver({ region: 'us-west-2' });
         const chatPrompt = {

--- a/drivers/src/bedrock-mantle/index.ts
+++ b/drivers/src/bedrock-mantle/index.ts
@@ -109,7 +109,7 @@ export class BedrockMantleDriver extends AbstractDriver<BedrockMantleDriverOptio
 
     protected supportsCanonicalConversation(options: ExecutionOptions): boolean {
         const protocol = getBedrockMantleProtocol(options.model);
-        return protocol === 'chat_completions' || protocol === 'messages';
+        return protocol === 'responses' || protocol === 'chat_completions' || protocol === 'messages';
     }
 
     constructor(opts: BedrockMantleDriverOptions) {

--- a/drivers/src/bedrock-mantle/index.ts
+++ b/drivers/src/bedrock-mantle/index.ts
@@ -107,6 +107,11 @@ export class BedrockMantleDriver extends AbstractDriver<BedrockMantleDriverOptio
     private readonly anthropicService: AnthropicBedrockMantle;
     readonly provider = Providers.bedrock_mantle;
 
+    protected supportsCanonicalConversation(options: ExecutionOptions): boolean {
+        const protocol = getBedrockMantleProtocol(options.model);
+        return protocol === 'chat_completions' || protocol === 'messages';
+    }
+
     constructor(opts: BedrockMantleDriverOptions) {
         super(opts);
 

--- a/drivers/src/conversation/canonical-adapters.test.ts
+++ b/drivers/src/conversation/canonical-adapters.test.ts
@@ -1,0 +1,218 @@
+import type { MessageParam } from '@anthropic-ai/sdk/resources/messages.js';
+import type { ExecutionOptions } from '@llumiverse/common';
+import { parseConversationDocument } from '@llumiverse/conversation';
+import { describe, expect, it } from 'vitest';
+import type { OpenAIChatCompletionsPrompt } from '../openai/openai_chat_completions.js';
+import {
+    compileOpenAIChatCompletionsConversation,
+    exportLegacyOpenAIChatCompletionsConversation,
+    prepareOpenAIChatCanonicalState,
+} from '../openai/openai-chat-conversation-adapter.js';
+import type { ClaudePrompt } from '../shared/claude-messages.js';
+import {
+    compileClaudeMessagesConversation,
+    exportLegacyClaudeMessagesConversation,
+    prepareClaudeCanonicalState,
+} from '../shared/claude-messages-conversation-adapter.js';
+import { exportLegacyConversation } from './index.js';
+
+const recordedAt = '2026-09-11T00:00:00.000Z';
+
+function executionOptions(model: string, conversationId: string): ExecutionOptions {
+    return {
+        model,
+        conversation_runtime: {
+            conversation_id: conversationId,
+            request_id: `request:${conversationId}`,
+            attempt_id: `attempt:${conversationId}`,
+            input_operation_id: `input:${conversationId}`,
+            response_operation_id: `response:${conversationId}`,
+            recorded_at: recordedAt,
+        },
+    };
+}
+
+async function importOpenAI(history: OpenAIChatCompletionsPrompt, conversationId: string) {
+    return prepareOpenAIChatCanonicalState({
+        conversation: history,
+        prompt: { _is_openai_chat_completions: true, messages: [] },
+        options: executionOptions('gpt-test', conversationId),
+        provider: 'openai',
+    });
+}
+
+async function importClaude(history: ClaudePrompt, conversationId: string) {
+    return prepareClaudeCanonicalState({
+        conversation: history,
+        prompt: { messages: [] },
+        options: executionOptions('claude-test', conversationId),
+        provider: 'anthropic',
+    });
+}
+
+describe('canonical native adapter conformance', () => {
+    it('preserves OpenAI reasoning, raw tool arguments, image detail, and native call identities', async () => {
+        const history: OpenAIChatCompletionsPrompt = {
+            _is_openai_chat_completions: true,
+            messages: [
+                {
+                    role: 'user',
+                    content: [
+                        { type: 'text', text: 'look exactly' },
+                        { type: 'image_url', image_url: { url: 'data:image/png;base64,YWJj', detail: 'high' } },
+                    ],
+                },
+                {
+                    role: 'assistant',
+                    content: 'checking',
+                    reasoning_content: 'private reasoning',
+                    tool_calls: [
+                        {
+                            id: 'call-exact',
+                            type: 'function',
+                            function: { name: 'lookup', arguments: '{ "city" : "Tokyo" }' },
+                        },
+                    ],
+                },
+                { role: 'tool', tool_call_id: 'call-exact', content: 'sunny' },
+            ],
+        };
+        const state = await prepareOpenAIChatCanonicalState({
+            conversation: history,
+            prompt: { _is_openai_chat_completions: true, messages: [] },
+            options: {
+                ...executionOptions('gpt-test', 'openai-fidelity'),
+                tools: [{ name: 'lookup', input_schema: { type: 'object' } }],
+            },
+            provider: 'openai',
+        });
+
+        expect(parseConversationDocument(state.document)).toEqual(state.document);
+        expect(exportLegacyOpenAIChatCompletionsConversation(state.document).messages).toEqual(history.messages);
+        expect(exportLegacyConversation(state.document)).toEqual(
+            exportLegacyOpenAIChatCompletionsConversation(state.document),
+        );
+        const toolResult = state.document.turns.find((turn) => turn.kind === 'tool');
+        expect(toolResult?.blocks[0]).toMatchObject({ call_id: 'call-exact', status: 'unknown' });
+    });
+
+    it('preserves Claude signed and redacted blocks and marks imported status without evidence unknown', async () => {
+        const messages: MessageParam[] = [
+            { role: 'user', content: [{ type: 'text', text: 'question' }] },
+            {
+                role: 'assistant',
+                content: [
+                    { type: 'thinking', thinking: 'plan', signature: 'signed-plan' },
+                    { type: 'redacted_thinking', data: 'opaque-redaction' },
+                    { type: 'text', text: 'answer' },
+                    { type: 'tool_use', id: 'call-exact', name: 'lookup', input: { city: 'Tokyo' } },
+                ],
+            },
+            {
+                role: 'user',
+                content: [{ type: 'tool_result', tool_use_id: 'call-exact', content: 'sunny' }],
+            },
+        ];
+        const history = { messages } as ClaudePrompt;
+        const state = await prepareClaudeCanonicalState({
+            conversation: history,
+            prompt: { messages: [] },
+            options: {
+                ...executionOptions('claude-test', 'claude-fidelity'),
+                tools: [{ name: 'lookup', input_schema: { type: 'object' } }],
+            },
+            provider: 'anthropic',
+        });
+
+        const projection = exportLegacyClaudeMessagesConversation(state.document);
+        expect(projection.messages[1]).toEqual(messages[1]);
+        const toolResult = state.document.turns.find((turn) => turn.kind === 'tool');
+        expect(toolResult?.blocks[0]).toMatchObject({ call_id: 'call-exact', status: 'unknown' });
+    });
+
+    it('transfers plain text and image media across protocols without losing payload bytes', async () => {
+        const claude = await importClaude(
+            {
+                messages: [
+                    {
+                        role: 'user',
+                        content: [
+                            { type: 'text', text: 'caption' },
+                            {
+                                type: 'image',
+                                source: { type: 'base64', media_type: 'image/png', data: 'YWJj' },
+                            },
+                        ],
+                    },
+                ],
+            },
+            'cross-media',
+        );
+
+        const openAIProjection = compileOpenAIChatCompletionsConversation(claude.document).conversation;
+        expect(openAIProjection.messages).toEqual([
+            {
+                role: 'user',
+                content: [
+                    { type: 'text', text: 'caption' },
+                    { type: 'image_url', image_url: { url: 'data:image/png;base64,YWJj' } },
+                ],
+            },
+        ]);
+        expect(compileClaudeMessagesConversation(claude.document).conversation.messages[0]).toEqual({
+            role: 'user',
+            content: [
+                { type: 'text', text: 'caption' },
+                { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'YWJj' } },
+            ],
+        });
+    });
+
+    it('fails closed for protected foreign replay and visible unsupported media', async () => {
+        const openAI = await importOpenAI(
+            {
+                _is_openai_chat_completions: true,
+                messages: [{ role: 'assistant', content: 'answer', reasoning_content: 'provider reasoning' }],
+            },
+            'foreign-openai-replay',
+        );
+        expect(() => compileClaudeMessagesConversation(openAI.document)).toThrow(
+            'cannot discard protected openai.chat.completions replay',
+        );
+
+        const claudeThinking = await importClaude(
+            {
+                messages: [
+                    {
+                        role: 'assistant',
+                        content: [{ type: 'thinking', thinking: 'plan', signature: 'signature' }],
+                    },
+                ],
+            },
+            'foreign-claude-replay',
+        );
+        expect(() => compileOpenAIChatCompletionsConversation(claudeThinking.document)).toThrow(
+            'cannot discard protected anthropic.messages replay',
+        );
+
+        const claudeDocument = await importClaude(
+            {
+                messages: [
+                    {
+                        role: 'user',
+                        content: [
+                            {
+                                type: 'document',
+                                source: { type: 'base64', media_type: 'application/pdf', data: 'YWJj' },
+                            },
+                        ],
+                    },
+                ],
+            },
+            'unsupported-document',
+        );
+        expect(() => compileOpenAIChatCompletionsConversation(claudeDocument.document)).toThrow(
+            'cannot project canonical document block',
+        );
+    });
+});

--- a/drivers/src/conversation/canonical-runtime.ts
+++ b/drivers/src/conversation/canonical-runtime.ts
@@ -108,7 +108,10 @@ export function canonicalConversationTurnNumber(document: ConversationDocument):
     return Number.isSafeInteger(total) ? total : Number.MAX_SAFE_INTEGER;
 }
 
-export function selectedCanonicalTurns(document: ConversationDocument): ConversationTurn[] {
+export function selectedCanonicalTurns(
+    document: ConversationDocument,
+    options?: { allow_interrupted_with_replay_protocol?: string },
+): ConversationTurn[] {
     const turnsById = new Map(document.turns.map((turn) => [turn.id, turn]));
     const selected: ConversationTurn[] = [];
     for (const entry of document.context.entries) {
@@ -117,7 +120,16 @@ export function selectedCanonicalTurns(document: ConversationDocument): Conversa
             throw new Error(`Conversation context entry ${entry.id} references missing turn ${entry.turn_id}`);
         }
         if (turn.model_visibility === 'exclude') continue;
-        if (turn.status !== 'completed') {
+        const selectedBlockIds = entry.block_ids === undefined ? undefined : new Set(entry.block_ids);
+        const hasSelectedInterruptedReplay =
+            turn.status === 'interrupted' &&
+            turn.blocks.some(
+                (block) =>
+                    block.type === 'native_replay' &&
+                    block.protocol === options?.allow_interrupted_with_replay_protocol &&
+                    (selectedBlockIds === undefined || selectedBlockIds.has(block.id)),
+            );
+        if (turn.status !== 'completed' && !hasSelectedInterruptedReplay) {
             throw new Error(
                 `Conversation context turn ${turn.id} has status ${turn.status}, which ${'cannot be represented by a completed native history message'}`,
             );

--- a/drivers/src/conversation/canonical-runtime.ts
+++ b/drivers/src/conversation/canonical-runtime.ts
@@ -1,0 +1,345 @@
+import type {
+    ConversationRuntimeContext,
+    ExecutionOptions,
+    ToolDefinition as LegacyToolDefinition,
+} from '@llumiverse/common';
+import {
+    type Asset,
+    appendConversationRecords,
+    type ContextEntry,
+    type ConversationDocument,
+    ConversationRuntimeContextSchema,
+    type ConversationTurn,
+    createConversationDocument,
+    deriveConversationId,
+    type ExecutedGeneration,
+    type ExecutionReceipt,
+    fingerprintJson,
+    type GeneratedAgentTurn,
+    type GenerationUsage,
+    isConversationDocumentFormat,
+    isGeneratedAgentTurn,
+    type JsonObject,
+    type JsonValue,
+    type NativeItemMapping,
+    parseConversationDocument,
+    type RequestReceipt,
+    type ToolDefinition,
+} from '@llumiverse/conversation';
+
+export interface ResolvedConversationRuntimeContext extends ConversationRuntimeContext {
+    conversation_id: string;
+    purpose: string;
+}
+
+export interface CanonicalPromptRecords {
+    turns: ConversationTurn[];
+    assets: Asset[];
+    context_entries: ContextEntry[];
+    item_mappings: NativeItemMapping[];
+    execution_receipts?: ExecutionReceipt[];
+}
+
+export interface CanonicalPreparedState<NativeConversation> {
+    document: ConversationDocument;
+    native_conversation: NativeConversation;
+    receipt: RequestReceipt;
+    runtime: ResolvedConversationRuntimeContext;
+    generation_id: string;
+    response_turn_id: string;
+    tool_definitions: ToolDefinition[];
+    accepted_response?: {
+        turn: GeneratedAgentTurn;
+        generation: ExecutedGeneration;
+    };
+}
+
+function randomIdentity(prefix: string): string {
+    return `${prefix}_${globalThis.crypto.randomUUID()}`;
+}
+
+export function resolveConversationRuntime(options: ExecutionOptions): ResolvedConversationRuntimeContext {
+    const supplied = options.conversation_runtime;
+    if (supplied !== undefined) {
+        const parsed = ConversationRuntimeContextSchema.parse(supplied);
+        return {
+            ...parsed,
+            conversation_id: parsed.conversation_id ?? randomIdentity('conversation'),
+            purpose: parsed.purpose ?? 'conversation',
+        };
+    }
+
+    const recordedAt = new Date().toISOString();
+    return {
+        conversation_id: randomIdentity('conversation'),
+        request_id: randomIdentity('request'),
+        attempt_id: randomIdentity('attempt'),
+        input_operation_id: randomIdentity('input'),
+        response_operation_id: randomIdentity('response'),
+        recorded_at: recordedAt,
+        started_at: recordedAt,
+        purpose: 'conversation',
+    };
+}
+
+export function newCanonicalConversation(runtime: ResolvedConversationRuntimeContext): ConversationDocument {
+    return createConversationDocument({
+        id: runtime.conversation_id,
+        created_at: runtime.recorded_at,
+    });
+}
+
+export function parseCanonicalConversation(input: unknown): ConversationDocument | undefined {
+    return isConversationDocumentFormat(input) ? parseConversationDocument(input) : undefined;
+}
+
+/** Preserve legacy retention age while canonical generations take over the interaction counter. */
+export function canonicalConversationTurnNumber(document: ConversationDocument): number {
+    let importedTurnNumber = 0;
+    for (const turn of document.turns) {
+        if (turn.provenance.type === 'imported') {
+            importedTurnNumber = Math.max(importedTurnNumber, turn.provenance.source_history_turn_number ?? 0);
+        }
+    }
+    const executedGenerations = Object.values(document.generations).filter(
+        (generation) => generation.record_source === 'executed',
+    ).length;
+    const total = importedTurnNumber + executedGenerations;
+    return Number.isSafeInteger(total) ? total : Number.MAX_SAFE_INTEGER;
+}
+
+export function selectedCanonicalTurns(document: ConversationDocument): ConversationTurn[] {
+    const turnsById = new Map(document.turns.map((turn) => [turn.id, turn]));
+    const selected: ConversationTurn[] = [];
+    for (const entry of document.context.entries) {
+        const turn = turnsById.get(entry.turn_id);
+        if (turn === undefined) {
+            throw new Error(`Conversation context entry ${entry.id} references missing turn ${entry.turn_id}`);
+        }
+        if (turn.model_visibility === 'exclude') continue;
+        if (turn.status !== 'completed') {
+            throw new Error(
+                `Conversation context turn ${turn.id} has status ${turn.status}, which ${'cannot be represented by a completed native history message'}`,
+            );
+        }
+        if (entry.block_ids === undefined) {
+            selected.push(turn);
+            continue;
+        }
+        const blockIds = new Set(entry.block_ids);
+        const selectedIds = new Set(turn.blocks.filter((block) => blockIds.has(block.id)).map((block) => block.id));
+        const missingId = entry.block_ids.find((id) => !selectedIds.has(id));
+        if (missingId !== undefined) {
+            throw new Error(`Conversation context entry ${entry.id} references missing block ${missingId}`);
+        }
+        switch (turn.kind) {
+            case 'user':
+                selected.push({
+                    ...turn,
+                    blocks: turn.blocks.filter((block) => blockIds.has(block.id)),
+                });
+                break;
+            case 'agent':
+                selected.push({
+                    ...turn,
+                    blocks: turn.blocks.filter((block) => blockIds.has(block.id)),
+                });
+                break;
+            case 'program':
+                selected.push({
+                    ...turn,
+                    blocks: turn.blocks.filter((block) => blockIds.has(block.id)),
+                });
+                break;
+            case 'tool': {
+                const blocks = turn.blocks.filter((block) => blockIds.has(block.id));
+                if (blocks.length !== 1) {
+                    throw new Error(`Conversation context entry ${entry.id} cannot omit a tool result block`);
+                }
+                selected.push({ ...turn, blocks });
+                break;
+            }
+        }
+    }
+    return selected;
+}
+
+function jsonSchemaValue(tool: LegacyToolDefinition): JsonObject | boolean {
+    return structuredClone(tool.input_schema) as JsonObject;
+}
+
+export async function canonicalToolDefinitions(
+    tools: readonly LegacyToolDefinition[] | undefined,
+): Promise<ToolDefinition[]> {
+    const definitions: ToolDefinition[] = [];
+    for (const tool of tools ?? []) {
+        const versionHash = await fingerprintJson({
+            name: tool.name,
+            description: tool.description ?? null,
+            input_schema: jsonSchemaValue(tool),
+        });
+        definitions.push({
+            id: await deriveConversationId('tool_definition', tool.name, versionHash),
+            name: tool.name,
+            version: versionHash,
+            ...(tool.description === undefined ? {} : { description: tool.description }),
+            input_schema: jsonSchemaValue(tool),
+        });
+    }
+    return definitions;
+}
+
+export async function appendCanonicalPrompt(
+    document: ConversationDocument,
+    records: CanonicalPromptRecords,
+    runtime: ResolvedConversationRuntimeContext,
+    tools: readonly LegacyToolDefinition[] | undefined,
+    semanticPayload: JsonValue,
+): Promise<{ document: ConversationDocument; tool_definitions: ToolDefinition[] }> {
+    const toolDefinitions = await canonicalToolDefinitions(tools);
+    const payloadFingerprint = await fingerprintJson({
+        prompt: semanticPayload,
+        tools: toolDefinitions,
+    });
+    const appended = appendConversationRecords(
+        document,
+        {
+            turns: records.turns,
+            assets: records.assets,
+            tool_definitions: toolDefinitions,
+            context_entries: records.context_entries,
+            ...(records.execution_receipts === undefined ? {} : { execution_receipts: records.execution_receipts }),
+            active_tool_definition_ids: toolDefinitions.map((tool) => tool.id),
+        },
+        {
+            expected_revision: document.revision,
+            operation_id: runtime.input_operation_id,
+            payload_fingerprint: payloadFingerprint,
+            recorded_at: runtime.recorded_at,
+        },
+    );
+    return { document: appended.document, tool_definitions: toolDefinitions };
+}
+
+export async function createRequestReceipt(
+    document: ConversationDocument,
+    runtime: ResolvedConversationRuntimeContext,
+    target: { provider: string; protocol: string; model: string; adapter_version: string; options?: JsonObject },
+    nativePayload: JsonValue,
+    itemMappings: readonly NativeItemMapping[],
+    toolDefinitions: readonly ToolDefinition[],
+): Promise<RequestReceipt> {
+    const contextFingerprint = await fingerprintJson(document.context);
+    const toolSetFingerprint = await fingerprintJson(toolDefinitions);
+    const requestFingerprint = await fingerprintJson(nativePayload);
+    return {
+        id: await deriveConversationId('request_receipt', runtime.request_id, runtime.attempt_id),
+        request_id: runtime.request_id,
+        attempt_id: runtime.attempt_id,
+        source: { conversation_id: document.id, revision: document.revision },
+        ...(document.turns.length === 0 ? {} : { source_tail_turn_id: document.turns.at(-1)?.id }),
+        context_fingerprint: contextFingerprint,
+        tool_set_fingerprint: toolSetFingerprint,
+        request_fingerprint: requestFingerprint,
+        target: {
+            provider: target.provider,
+            protocol: target.protocol,
+            model: target.model,
+            adapter_version: target.adapter_version,
+            ...(target.options === undefined ? {} : { options: target.options }),
+        },
+        tool_definition_ids: toolDefinitions.map((tool) => tool.id),
+        asset_versions: Object.values(document.assets).flatMap((asset) =>
+            asset.content_hash === undefined ? [] : [{ asset_id: asset.id, content_hash: asset.content_hash }],
+        ),
+        item_mappings: [...itemMappings],
+        recorded_at: runtime.recorded_at,
+    };
+}
+
+export async function canonicalResponseIdentities(runtime: ResolvedConversationRuntimeContext): Promise<{
+    generation_id: string;
+    response_turn_id: string;
+}> {
+    const generationId = await deriveConversationId('generation', runtime.request_id, runtime.attempt_id);
+    return {
+        generation_id: generationId,
+        response_turn_id: await deriveConversationId('turn', runtime.response_operation_id, 'response', '0'),
+    };
+}
+
+export function acceptedCanonicalResponse(
+    document: ConversationDocument,
+    responseOperationId: string,
+): CanonicalPreparedState<unknown>['accepted_response'] {
+    const receipt = Object.hasOwn(document.operation_receipts, responseOperationId)
+        ? document.operation_receipts[responseOperationId]
+        : undefined;
+    if (receipt === undefined) return undefined;
+    if (receipt.accepted_turn_ids?.length !== 1 || receipt.accepted_generation_ids?.length !== 1) {
+        throw new Error(`Accepted response operation ${responseOperationId} has no recoverable record identities`);
+    }
+    const turn = document.turns.find((candidate) => candidate.id === receipt.accepted_turn_ids?.[0]);
+    const generation = document.generations[receipt.accepted_generation_ids[0]];
+    if (
+        turn === undefined ||
+        !isGeneratedAgentTurn(turn) ||
+        generation?.record_source !== 'executed' ||
+        turn.generation_id !== generation.id
+    ) {
+        throw new Error(`Accepted response operation ${responseOperationId} cannot resolve its generated response`);
+    }
+    return { turn, generation };
+}
+
+export async function createExecutedGeneration(input: {
+    id: string;
+    runtime: ResolvedConversationRuntimeContext;
+    receipt: RequestReceipt;
+    provider: string;
+    protocol: string;
+    adapter_version: string;
+    requested_model: string;
+    resolved_model?: string;
+    provider_response_id?: string;
+    finish_reason?: string;
+    usage?: GenerationUsage;
+}): Promise<ExecutedGeneration> {
+    const completedAt = input.runtime.completed_at ?? new Date().toISOString();
+    return {
+        id: input.id,
+        record_source: 'executed',
+        request_id: input.runtime.request_id,
+        attempt_id: input.runtime.attempt_id,
+        ...(input.provider_response_id === undefined ? {} : { provider_response_id: input.provider_response_id }),
+        purpose: input.runtime.purpose,
+        requested_model: input.requested_model,
+        ...(input.resolved_model === undefined ? {} : { resolved_model: input.resolved_model }),
+        provider: input.provider,
+        protocol: input.protocol,
+        adapter_version: input.adapter_version,
+        status: 'completed',
+        ...(input.finish_reason === undefined ? {} : { finish_reason: input.finish_reason }),
+        timestamps: {
+            recorded_at: completedAt,
+            ...(input.runtime.started_at === undefined ? {} : { started_at: input.runtime.started_at }),
+            completed_at: completedAt,
+        },
+        source: input.receipt.source,
+        context_fingerprint: input.receipt.context_fingerprint,
+        tool_set_fingerprint: input.receipt.tool_set_fingerprint,
+        ...(input.usage === undefined ? {} : { usage: input.usage }),
+        request_receipt: input.receipt,
+    };
+}
+
+export function jsonClone<T extends JsonValue>(value: T): T {
+    return structuredClone(value);
+}
+
+/** Project an internally-built provider payload onto its actual JSON transport representation. */
+export function providerJsonValue(value: unknown): JsonValue {
+    const text = JSON.stringify(value);
+    if (text === undefined) throw new TypeError('Provider payload has no JSON representation');
+    return JSON.parse(text) as JsonValue;
+}

--- a/drivers/src/conversation/index.ts
+++ b/drivers/src/conversation/index.ts
@@ -1,0 +1,65 @@
+import { type ConversationDocument, parseConversationDocument } from '@llumiverse/conversation';
+import {
+    exportLegacyOpenAIChatCompletionsConversation,
+    OPENAI_CHAT_COMPLETIONS_PROTOCOL,
+} from '../openai/openai-chat-conversation-adapter.js';
+import {
+    CLAUDE_MESSAGES_PROTOCOL,
+    exportLegacyClaudeMessagesConversation,
+} from '../shared/claude-messages-conversation-adapter.js';
+
+export {
+    exportLegacyOpenAIChatCompletionsConversation,
+    OPENAI_CHAT_COMPLETIONS_ADAPTER_VERSION,
+    OPENAI_CHAT_COMPLETIONS_PROTOCOL,
+} from '../openai/openai-chat-conversation-adapter.js';
+export {
+    CLAUDE_MESSAGES_ADAPTER_VERSION,
+    CLAUDE_MESSAGES_PROTOCOL,
+    exportLegacyClaudeMessagesConversation,
+} from '../shared/claude-messages-conversation-adapter.js';
+
+export type CanonicalNativeConversationProtocol =
+    | typeof OPENAI_CHAT_COMPLETIONS_PROTOCOL
+    | typeof CLAUDE_MESSAGES_PROTOCOL;
+
+export type LegacyConversationProjection =
+    | ReturnType<typeof exportLegacyOpenAIChatCompletionsConversation>
+    | ReturnType<typeof exportLegacyClaudeMessagesConversation>;
+
+function latestSupportedProtocol(document: ConversationDocument): CanonicalNativeConversationProtocol | undefined {
+    for (let index = document.turns.length - 1; index >= 0; index -= 1) {
+        const turn = document.turns[index];
+        if (turn.kind === 'agent' && 'generation_id' in turn && typeof turn.generation_id === 'string') {
+            const generation = Object.hasOwn(document.generations, turn.generation_id)
+                ? document.generations[turn.generation_id]
+                : undefined;
+            if (generation?.protocol === OPENAI_CHAT_COMPLETIONS_PROTOCOL) return OPENAI_CHAT_COMPLETIONS_PROTOCOL;
+            if (generation?.protocol === CLAUDE_MESSAGES_PROTOCOL) return CLAUDE_MESSAGES_PROTOCOL;
+        }
+        if (turn.provenance.type === 'imported') {
+            if (turn.provenance.source === OPENAI_CHAT_COMPLETIONS_PROTOCOL) return OPENAI_CHAT_COMPLETIONS_PROTOCOL;
+            if (turn.provenance.source === CLAUDE_MESSAGES_PROTOCOL) return CLAUDE_MESSAGES_PROTOCOL;
+        }
+    }
+    return undefined;
+}
+
+/**
+ * Read-only projection for legacy API clients while internal execution persists canonical history.
+ * An explicit protocol is required when the document has no supported generation/import provenance.
+ */
+export function exportLegacyConversation(
+    input: ConversationDocument,
+    protocol?: CanonicalNativeConversationProtocol,
+): LegacyConversationProjection {
+    const document = parseConversationDocument(input);
+    const resolvedProtocol = protocol ?? latestSupportedProtocol(document);
+    if (resolvedProtocol === OPENAI_CHAT_COMPLETIONS_PROTOCOL) {
+        return exportLegacyOpenAIChatCompletionsConversation(document);
+    }
+    if (resolvedProtocol === CLAUDE_MESSAGES_PROTOCOL) {
+        return exportLegacyClaudeMessagesConversation(document);
+    }
+    throw new TypeError('Canonical conversation has no supported native protocol provenance; provide a protocol');
+}

--- a/drivers/src/conversation/index.ts
+++ b/drivers/src/conversation/index.ts
@@ -4,6 +4,10 @@ import {
     OPENAI_CHAT_COMPLETIONS_PROTOCOL,
 } from '../openai/openai-chat-conversation-adapter.js';
 import {
+    exportLegacyOpenAIResponsesConversation,
+    OPENAI_RESPONSES_PROTOCOL,
+} from '../openai/openai-responses-conversation-adapter.js';
+import {
     CLAUDE_MESSAGES_PROTOCOL,
     exportLegacyClaudeMessagesConversation,
 } from '../shared/claude-messages-conversation-adapter.js';
@@ -14,6 +18,11 @@ export {
     OPENAI_CHAT_COMPLETIONS_PROTOCOL,
 } from '../openai/openai-chat-conversation-adapter.js';
 export {
+    exportLegacyOpenAIResponsesConversation,
+    OPENAI_RESPONSES_ADAPTER_VERSION,
+    OPENAI_RESPONSES_PROTOCOL,
+} from '../openai/openai-responses-conversation-adapter.js';
+export {
     CLAUDE_MESSAGES_ADAPTER_VERSION,
     CLAUDE_MESSAGES_PROTOCOL,
     exportLegacyClaudeMessagesConversation,
@@ -21,10 +30,12 @@ export {
 
 export type CanonicalNativeConversationProtocol =
     | typeof OPENAI_CHAT_COMPLETIONS_PROTOCOL
+    | typeof OPENAI_RESPONSES_PROTOCOL
     | typeof CLAUDE_MESSAGES_PROTOCOL;
 
 export type LegacyConversationProjection =
     | ReturnType<typeof exportLegacyOpenAIChatCompletionsConversation>
+    | ReturnType<typeof exportLegacyOpenAIResponsesConversation>
     | ReturnType<typeof exportLegacyClaudeMessagesConversation>;
 
 function latestSupportedProtocol(document: ConversationDocument): CanonicalNativeConversationProtocol | undefined {
@@ -35,10 +46,12 @@ function latestSupportedProtocol(document: ConversationDocument): CanonicalNativ
                 ? document.generations[turn.generation_id]
                 : undefined;
             if (generation?.protocol === OPENAI_CHAT_COMPLETIONS_PROTOCOL) return OPENAI_CHAT_COMPLETIONS_PROTOCOL;
+            if (generation?.protocol === OPENAI_RESPONSES_PROTOCOL) return OPENAI_RESPONSES_PROTOCOL;
             if (generation?.protocol === CLAUDE_MESSAGES_PROTOCOL) return CLAUDE_MESSAGES_PROTOCOL;
         }
         if (turn.provenance.type === 'imported') {
             if (turn.provenance.source === OPENAI_CHAT_COMPLETIONS_PROTOCOL) return OPENAI_CHAT_COMPLETIONS_PROTOCOL;
+            if (turn.provenance.source === OPENAI_RESPONSES_PROTOCOL) return OPENAI_RESPONSES_PROTOCOL;
             if (turn.provenance.source === CLAUDE_MESSAGES_PROTOCOL) return CLAUDE_MESSAGES_PROTOCOL;
         }
     }
@@ -57,6 +70,9 @@ export function exportLegacyConversation(
     const resolvedProtocol = protocol ?? latestSupportedProtocol(document);
     if (resolvedProtocol === OPENAI_CHAT_COMPLETIONS_PROTOCOL) {
         return exportLegacyOpenAIChatCompletionsConversation(document);
+    }
+    if (resolvedProtocol === OPENAI_RESPONSES_PROTOCOL) {
+        return exportLegacyOpenAIResponsesConversation(document);
     }
     if (resolvedProtocol === CLAUDE_MESSAGES_PROTOCOL) {
         return exportLegacyClaudeMessagesConversation(document);

--- a/drivers/src/conversation/openai-responses-conformance.test.ts
+++ b/drivers/src/conversation/openai-responses-conformance.test.ts
@@ -1,0 +1,205 @@
+import type { ExecutionOptions } from '@llumiverse/common';
+import { parseConversationDocument } from '@llumiverse/conversation';
+import type OpenAI from 'openai';
+import { describe, expect, it } from 'vitest';
+import {
+    compileOpenAIResponsesConversation,
+    exportLegacyOpenAIResponsesConversation,
+    prepareOpenAIResponsesCanonicalState,
+} from '../openai/openai-responses-conversation-adapter.js';
+import { compileClaudeMessagesConversation } from '../shared/claude-messages-conversation-adapter.js';
+import { selectedCanonicalTurns } from './canonical-runtime.js';
+
+const recordedAt = '2026-09-12T00:00:00.000Z';
+
+function options(id: string): ExecutionOptions {
+    return {
+        model: 'gpt-test',
+        tools: [{ name: 'lookup', input_schema: { type: 'object' } }],
+        conversation_runtime: {
+            conversation_id: id,
+            request_id: `${id}:request`,
+            attempt_id: `${id}:attempt`,
+            input_operation_id: `${id}:input`,
+            response_operation_id: `${id}:response`,
+            recorded_at: recordedAt,
+        },
+    };
+}
+
+function importHistory(history: OpenAI.Responses.ResponseInputItem[], id: string) {
+    return prepareOpenAIResponsesCanonicalState({
+        conversation: history,
+        prompt: [],
+        options: options(id),
+        provider: 'openai',
+    });
+}
+
+const protectedHistory: OpenAI.Responses.ResponseInputItem[] = [
+    { role: 'user', content: 'Find the weather in Tokyo.' },
+    {
+        type: 'reasoning',
+        id: 'reasoning-exact',
+        summary: [{ type: 'summary_text', text: 'Check the forecast.' }],
+        encrypted_content: 'opaque-encrypted-state',
+        status: 'completed',
+    },
+    {
+        type: 'function_call',
+        id: 'item-exact',
+        call_id: 'call-exact',
+        name: 'lookup',
+        arguments: '{ "city" : "Tokyo", "optional" : null }',
+        status: 'completed',
+    },
+    {
+        type: 'function_call_output',
+        call_id: 'call-exact',
+        output: [
+            { type: 'input_text', text: 'Clear skies.' },
+            { type: 'input_image', image_url: 'data:image/png;base64,YWJj', detail: 'high' },
+            { type: 'input_file', file_data: 'data:application/pdf;base64,YWJj', filename: 'forecast.pdf' },
+        ],
+    },
+    {
+        type: 'message',
+        id: 'message-exact',
+        role: 'assistant',
+        status: 'completed',
+        content: [
+            {
+                type: 'output_text',
+                text: 'Clear skies in Tokyo.',
+                annotations: [
+                    {
+                        type: 'url_citation',
+                        start_index: 0,
+                        end_index: 11,
+                        title: 'Forecast',
+                        url: 'https://example.com/forecast',
+                    },
+                ],
+                logprobs: [],
+            },
+        ],
+    },
+];
+
+describe('OpenAI Responses independent canonical conformance', () => {
+    it('round trips native identities, raw arguments, rich tool output, and protected replay through JSON', async () => {
+        const original = structuredClone(protectedHistory);
+        const state = await importHistory(protectedHistory, 'responses-fidelity');
+        const persisted = parseConversationDocument(JSON.parse(JSON.stringify(state.document)));
+
+        expect(exportLegacyOpenAIResponsesConversation(persisted)).toEqual(original);
+        expect(protectedHistory).toEqual(original);
+        const result = persisted.turns.find((turn) => turn.kind === 'tool');
+        expect(result?.blocks[0]).toMatchObject({ call_id: 'call-exact', status: 'unknown' });
+        expect(
+            result?.blocks[0].content.filter((block) => block.type !== 'native_replay').map((block) => block.type),
+        ).toEqual(['text', 'image', 'document']);
+    });
+
+    it('compiles selected context without deleting unselected source history or mutating the document', async () => {
+        const state = await importHistory(
+            [
+                { role: 'user', content: 'Older question.' },
+                { role: 'user', content: 'Current question.' },
+            ],
+            'responses-context',
+        );
+        const document = structuredClone(state.document);
+        const lastTurn = document.turns.at(-1);
+        if (!lastTurn) throw new Error('Expected imported user turn');
+        document.context.entries = document.context.entries.filter((entry) => entry.turn_id === lastTurn.id);
+        const before = structuredClone(document);
+
+        const projected = compileOpenAIResponsesConversation(document, { provider: 'openai', model: 'gpt-test' });
+        expect(JSON.stringify(projected.conversation)).toContain('Current question.');
+        expect(JSON.stringify(projected.conversation)).not.toContain('Older question.');
+        expect(document).toEqual(before);
+        expect(document.turns).toHaveLength(2);
+    });
+
+    it('rejects protected replay outside its provider or model scope and on a different protocol', async () => {
+        const { document } = await importHistory(protectedHistory, 'responses-protected');
+
+        expect(() => compileOpenAIResponsesConversation(document, { provider: 'xai', model: 'gpt-test' })).toThrow();
+        expect(() =>
+            compileOpenAIResponsesConversation(document, { provider: 'openai', model: 'other-model' }),
+        ).toThrow();
+        expect(() =>
+            compileClaudeMessagesConversation(document, { provider: 'anthropic', model: 'claude-test' }),
+        ).toThrow(/replay/);
+    });
+
+    it('permits a model change for ordinary response text without dropping native message fields', async () => {
+        const history: OpenAI.Responses.ResponseInputItem[] = [
+            { role: 'user', content: 'Hello.' },
+            {
+                type: 'message',
+                id: 'ordinary-message',
+                role: 'assistant',
+                status: 'completed',
+                content: [{ type: 'output_text', text: 'Hello back.', annotations: [], logprobs: [] }],
+            },
+        ];
+        const { document } = await importHistory(history, 'responses-model-change');
+        const projected = compileOpenAIResponsesConversation(document, { provider: 'openai', model: 'other-model' });
+
+        expect(projected.conversation).toEqual(history);
+    });
+
+    it('does not restore omitted semantic blocks from an opaque replay payload', async () => {
+        const state = await importHistory(protectedHistory, 'responses-partial-replay');
+        const document = structuredClone(state.document);
+        const turn = document.turns.find(
+            (candidate) => candidate.kind === 'agent' && candidate.blocks.some((block) => block.type === 'reasoning'),
+        );
+        const replay = turn?.blocks.find((block) => block.type === 'native_replay');
+        const entry = document.context.entries.find((candidate) => candidate.turn_id === turn?.id);
+        if (!turn || !replay || !entry) throw new Error('Expected selected protected reasoning turn');
+        entry.block_ids = [replay.id];
+
+        expect(() => compileOpenAIResponsesConversation(document, { provider: 'openai', model: 'gpt-test' })).toThrow();
+    });
+
+    it('rejects stale native replay after tool-result media changes', async () => {
+        const state = await importHistory(protectedHistory, 'responses-changed-media');
+        const document = structuredClone(state.document);
+        const asset = Object.values(document.assets).find((candidate) => candidate.kind === 'image');
+        if (!asset) throw new Error('Expected imported tool-result image');
+        asset.storage = { type: 'inline_base64', data: 'ZGlmZmVyZW50' };
+
+        expect(() => compileOpenAIResponsesConversation(document, { provider: 'openai', model: 'gpt-test' })).toThrow();
+    });
+
+    it('does not silently replace a changed canonical tool-result association with the native call ID', async () => {
+        const state = await importHistory(protectedHistory, 'responses-changed-call');
+        const document = structuredClone(state.document);
+        const turn = document.turns.find((candidate) => candidate.kind === 'tool');
+        if (!turn) throw new Error('Expected imported tool result');
+        turn.blocks[0].call_id = 'another-call';
+
+        expect(() => compileOpenAIResponsesConversation(document, { provider: 'openai', model: 'gpt-test' })).toThrow();
+    });
+
+    it('allows interrupted history only through an adapter that can replay its exact native state', async () => {
+        const history: OpenAI.Responses.ResponseInputItem[] = [
+            { role: 'user', content: 'Continue the explanation.' },
+            {
+                type: 'message',
+                id: 'partial-message',
+                role: 'assistant',
+                status: 'incomplete',
+                content: [{ type: 'output_text', text: 'First,', annotations: [], logprobs: [] }],
+            },
+        ];
+        const { document } = await importHistory(history, 'responses-interrupted');
+
+        expect(document.turns.at(-1)?.status).toBe('interrupted');
+        expect(() => selectedCanonicalTurns(document)).toThrow(/interrupted/);
+        expect(compileOpenAIResponsesConversation(document).conversation).toEqual(history);
+    });
+});

--- a/drivers/src/index.ts
+++ b/drivers/src/index.ts
@@ -2,6 +2,7 @@ export * from './anthropic/index.js';
 export * from './azure/azure_foundry.js';
 export * from './bedrock/index.js';
 export * from './bedrock-mantle/index.js';
+export * from './conversation/index.js';
 export * from './groq/index.js';
 export * from './huggingface_ie.js';
 export * from './mistral/index.js';

--- a/drivers/src/openai/error-handling.test.ts
+++ b/drivers/src/openai/error-handling.test.ts
@@ -223,7 +223,7 @@ describe('OpenAIResponsesDriverBase prompt caching', () => {
                 content: [
                     {
                         type: 'input_image' as const,
-                        image_url: 'data:image/jpeg;base64,source',
+                        image_url: 'data:image/jpeg;base64,c291cmNl',
                         detail: 'auto' as const,
                     },
                     { type: 'input_text' as const, text: 'stable document blocks' },
@@ -247,7 +247,7 @@ describe('OpenAIResponsesDriverBase prompt caching', () => {
                         content: [
                             {
                                 type: 'input_image',
-                                image_url: 'data:image/jpeg;base64,source',
+                                image_url: 'data:image/jpeg;base64,c291cmNl',
                                 detail: 'auto',
                             },
                             {
@@ -310,7 +310,7 @@ describe('OpenAIResponsesDriverBase prompt caching', () => {
                 content: [
                     {
                         type: 'input_image' as const,
-                        image_url: 'data:image/jpeg;base64,source',
+                        image_url: 'data:image/jpeg;base64,c291cmNl',
                         detail: 'auto' as const,
                     },
                     { type: 'input_text' as const, text: 'stable document blocks' },
@@ -345,7 +345,7 @@ describe('OpenAIResponsesDriverBase prompt caching', () => {
                         content: [
                             {
                                 type: 'input_image',
-                                image_url: 'data:image/jpeg;base64,source',
+                                image_url: 'data:image/jpeg;base64,c291cmNl',
                                 detail: 'auto',
                             },
                             {
@@ -356,7 +356,10 @@ describe('OpenAIResponsesDriverBase prompt caching', () => {
                         ],
                     },
                     prompt[2],
-                    prompt[3],
+                    {
+                        role: 'user',
+                        content: `IMPORTANT: only answer using JSON. <response_schema>${JSON.stringify(resultSchema)}</response_schema>`,
+                    },
                 ],
                 text: { format: { type: 'json_object' } },
             }),

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -1,3 +1,4 @@
+import { isConversationDocumentFormat } from '@llumiverse/conversation';
 import {
     type AIModel,
     type Completion,
@@ -40,11 +41,20 @@ import {
 } from '@llumiverse/core';
 import type OpenAI from 'openai';
 import type { AzureOpenAI } from 'openai';
+import { canonicalConversationTurnNumber } from '../conversation/canonical-runtime.js';
 import { resolveModelListingMetadata } from '../shared/model-listing.js';
 import { createToolChoiceConfigurationError } from '../shared/tool-choice-error.js';
 import { mergeOpenAIExtraBody, type OpenAIExtraBody } from './extra_body.js';
 import { OpenAICompatibleDriverBase } from './openai_compatible.js';
 import { formatOpenAILikeMultimodalPrompt } from './openai_format.js';
+import {
+    appendOpenAIResponsesCanonicalResponse,
+    compileOpenAIResponsesConversation,
+    decodeOpenAIResponsesCanonicalResponse,
+    finalizeOpenAIResponsesPreparedRequest,
+    type PreparedOpenAIResponsesConversation,
+    prepareOpenAIResponsesCanonicalState,
+} from './openai-responses-conversation-adapter.js';
 import { formatOpenAISchema } from './schema.js';
 
 // Response API types
@@ -114,7 +124,7 @@ type OpenAIFunctionItem = ResponseInputItem & {
     type?: string;
     name?: string;
     arguments?: string;
-    output?: string;
+    output?: unknown;
 };
 type OpenAIPromptCacheConfig = {
     input: ResponseInputItem[];
@@ -225,6 +235,134 @@ const supportFineTunning = new Set([
 
 export interface OpenAIResponsesDriverBaseOptions extends DriverOptions {}
 
+function projectCanonicalResponsesHistory(
+    prepared: Omit<PreparedOpenAIResponsesConversation, 'payload' | 'receipt' | 'diagnostics'>,
+    options: ExecutionOptions,
+): { conversation: ResponseInputItem[]; current_items: ResponseInputItem[] } {
+    const currentTurn = canonicalConversationTurnNumber(prepared.document);
+    const preserveSubtree = (value: unknown): boolean => {
+        if (!value || typeof value !== 'object') return false;
+        const encryptedContent = (value as { encrypted_content?: unknown }).encrypted_content;
+        return typeof encryptedContent === 'string' && encryptedContent.length > 0;
+    };
+    const stripOptions = {
+        keepForTurns: options.stripImagesAfterTurns ?? Infinity,
+        currentTurn,
+        textMaxTokens: options.stripTextMaxTokens,
+        preserveSubtree,
+    };
+    const prior = prepared.native_conversation.slice(0, prepared.prior_native_item_count);
+    let projectedPrior = stripBase64ImagesFromConversation(prior, stripOptions);
+    projectedPrior = truncateLargeTextInConversation(projectedPrior, stripOptions);
+    projectedPrior = stripHeartbeatsFromConversation(projectedPrior, {
+        keepForTurns: options.stripHeartbeatsAfterTurns ?? 1,
+        currentTurn,
+        preserveSubtree,
+    });
+    const currentItems = prepared.native_conversation.slice(prepared.prior_native_item_count);
+    return { conversation: [...(projectedPrior as ResponseInputItem[]), ...currentItems], current_items: currentItems };
+}
+
+function withoutCanonicalIngestionFields(items: ResponseInputItem[]): ResponseInputItem[] {
+    return items.map((item) => {
+        if (!('type' in item) || item.type !== 'function_call_output') return item;
+        const clone = { ...item } as Record<string, unknown>;
+        delete clone._llumiverse_tool_result_status;
+        return clone as unknown as ResponseInputItem;
+    });
+}
+
+function canonicalResponsesUsage(
+    prepared: Omit<PreparedOpenAIResponsesConversation, 'payload' | 'receipt' | 'diagnostics'>,
+): ExecutionTokenUsage | undefined {
+    const usage = prepared.accepted_response?.generation.usage;
+    if (usage === undefined) return undefined;
+    // The long-standing Responses Completion projection defines prompt_new as all non-cache-read
+    // input. Canonical accounting additionally separates cache writes, so its input_new_tokens can
+    // be smaller. Keep the existing outward convention stable when replaying an accepted response.
+    const legacyPromptNew =
+        usage.input_tokens === undefined ? usage.input_new_tokens : usage.input_tokens - (usage.cache_read_tokens ?? 0);
+    return {
+        ...(usage.input_tokens === undefined ? {} : { prompt: usage.input_tokens }),
+        ...(usage.output_tokens === undefined ? {} : { result: usage.output_tokens }),
+        ...(usage.total_tokens === undefined ? {} : { total: usage.total_tokens }),
+        ...(usage.cache_read_tokens === undefined ? {} : { prompt_cached: usage.cache_read_tokens }),
+        ...(usage.cache_write_tokens === undefined ? {} : { prompt_cache_write: usage.cache_write_tokens }),
+        ...(legacyPromptNew === undefined ? {} : { prompt_new: legacyPromptNew }),
+    };
+}
+
+function canonicalResponsesServiceTier(
+    prepared: Omit<PreparedOpenAIResponsesConversation, 'payload' | 'receipt' | 'diagnostics'>,
+): string | undefined {
+    const metadata = prepared.accepted_response?.generation.metadata?.openai_responses;
+    if (metadata === null || typeof metadata !== 'object' || Array.isArray(metadata)) return undefined;
+    const serviceTier = metadata.service_tier;
+    return typeof serviceTier === 'string' ? serviceTier : undefined;
+}
+
+function acceptedResponsesItems(
+    prepared: Omit<PreparedOpenAIResponsesConversation, 'payload' | 'receipt' | 'diagnostics'>,
+): OpenAI.Responses.ResponseOutputItem[] {
+    const accepted = prepared.accepted_response;
+    if (accepted === undefined) throw new Error('No accepted OpenAI Responses response is available');
+    const projection = compileOpenAIResponsesConversation(prepared.document, {
+        provider: prepared.provider,
+        model: prepared.requested_model,
+    });
+    const turnMappings = projection.mappings.flatMap((mapping) => {
+        if (mapping.kind !== 'turn') return [];
+        const match = /^items\/(\d+)$/.exec(mapping.native_id);
+        return match === null ? [] : [{ turn_id: mapping.canonical_id, index: Number(match[1]) }];
+    });
+    const start = turnMappings.find((mapping) => mapping.turn_id === accepted.turn.id)?.index;
+    if (start === undefined)
+        throw new Error(`Accepted OpenAI Responses turn ${accepted.turn.id} has no native projection`);
+    const end =
+        turnMappings.map((mapping) => mapping.index).find((index) => index > start) ?? projection.conversation.length;
+    return projection.conversation.slice(start, end) as OpenAI.Responses.ResponseOutputItem[];
+}
+
+function recoverOpenAIResponsesCompletion(
+    prepared: Omit<PreparedOpenAIResponsesConversation, 'payload' | 'receipt' | 'diagnostics'>,
+    options: ExecutionOptions,
+    includeThoughts: boolean,
+): Completion {
+    const accepted = prepared.accepted_response;
+    if (accepted === undefined) throw new Error('No accepted OpenAI Responses response is available');
+    if (options.include_original_response) {
+        throw new Error('An idempotently recovered OpenAI Responses response cannot reconstruct original_response');
+    }
+    const items = acceptedResponsesItems(prepared);
+    const toolUse = collectTools(items);
+    const finishReason = toolUse?.length
+        ? 'tool_use'
+        : accepted.generation.finish_reason === 'max_output_tokens'
+          ? 'length'
+          : accepted.generation.finish_reason;
+    return {
+        result: extractCompletionResults(items, includeThoughts),
+        tool_use: toolUse,
+        token_usage: canonicalResponsesUsage(prepared),
+        service_tier: canonicalResponsesServiceTier(prepared),
+        finish_reason: finishReason,
+        conversation: prepared.document,
+    };
+}
+
+function recoveredOpenAIResponsesStream(completion: Completion): DriverCompletionStream {
+    const stream = (async function* (): AsyncIterable<CompletionChunkObject> {
+        yield {
+            result: completion.result,
+            tool_use: completion.tool_use,
+            token_usage: completion.token_usage,
+            finish_reason: completion.finish_reason,
+            service_tier: completion.service_tier,
+        };
+    })();
+    return Object.assign(stream, { finalizeConversation: () => completion.conversation });
+}
+
 /** Reusable Responses text protocol shared by OpenAI-compatible transports. */
 export class OpenAIResponsesProtocol {
     constructor(
@@ -250,24 +388,36 @@ export class OpenAIResponsesProtocol {
             driver.logger.debug({ options: options.model_options }, 'Unexpected option id');
         }
 
-        // Include conversation history (same as non-streaming)
-        // Fix orphaned function_call items (can occur when agent is stopped mid-tool-execution)
-        let conversation = fixOrphanedToolResults(fixOrphanedToolUse(updateConversation(options.conversation, prompt)));
+        const canonicalState = await prepareOpenAIResponsesCanonicalState({
+            conversation: options.conversation,
+            prompt,
+            options,
+            provider: driver.provider,
+        });
 
         const toolDefs = getToolDefinitions(options.tools);
         const useTools = Boolean(toolDefs?.length && supportsToolUse(options.model, driver.provider, true));
 
+        const model_options = options.model_options as OpenAIRequestOptions | undefined;
+        assertOpenAIResponseToolChoiceAvailable(model_options, useTools, options.model, driver.provider, 'stream');
+        const includeThoughts = model_options?.include_thoughts !== false;
+        if (canonicalState.accepted_response !== undefined) {
+            return recoveredOpenAIResponsesStream(
+                recoverOpenAIResponsesCompletion(canonicalState, options, includeThoughts),
+            );
+        }
+        const projection = projectCanonicalResponsesHistory(canonicalState, options);
+        let conversation = projection.conversation;
+        const currentItems = projection.current_items;
+        convertRoles(currentItems, options.model);
+        insert_image_detail(currentItems, model_options?.image_detail ?? 'auto');
+        conversation = fixOrphanedToolResults(fixOrphanedToolUse(withoutCanonicalIngestionFields(conversation)));
+
         // When no tools are provided but conversation contains function_call/function_call_output
-        // items (e.g. checkpoint summary calls), convert them to text to avoid API errors
+        // items (e.g. checkpoint summary calls), convert them to text to avoid API errors.
         if (!useTools) {
             conversation = convertOpenAIFunctionItemsToText(conversation);
         }
-
-        convertRoles(prompt, options.model);
-
-        const model_options = options.model_options as OpenAIRequestOptions | undefined;
-        assertOpenAIResponseToolChoiceAvailable(model_options, useTools, options.model, driver.provider, 'stream');
-        insert_image_detail(prompt, model_options?.image_detail ?? 'auto');
 
         let parsedSchema: JSONSchema | undefined;
         let strictMode = false;
@@ -288,7 +438,6 @@ export class OpenAIResponsesProtocol {
             isReasoningModel,
             supportsOpenAICurrentTurnReasoning(driver.provider, options.model),
         );
-        const includeThoughts = model_options?.include_thoughts !== false;
         const promptCacheKey = model_options?.prompt_cache_key ?? options.prompt_cache_key;
         const promptCacheRetention = model_options?.prompt_cache_retention;
 
@@ -324,14 +473,19 @@ export class OpenAIResponsesProtocol {
             },
             model_options?.extra_body,
         );
+        const prepared = await finalizeOpenAIResponsesPreparedRequest(
+            { ...canonicalState, native_conversation: conversation },
+            request,
+        );
         const requestOptions = this.resolveRequestOptions(options, signal);
         const stream = requestOptions
             ? await driver.service.responses.create(request, requestOptions)
             : await driver.service.responses.create(request);
 
-        return mapResponseStream(stream, includeThoughts, (response) =>
-            finalizeOpenAIResponsesConversation(conversation, response.output, options),
-        );
+        return mapResponseStream(stream, includeThoughts, async (response) => {
+            const decoded = await decodeOpenAIResponsesCanonicalResponse({ response, prepared });
+            return appendOpenAIResponsesCanonicalResponse(prepared, decoded);
+        });
     }
 
     async requestTextCompletion(
@@ -350,17 +504,26 @@ export class OpenAIResponsesProtocol {
             driver.logger.debug({ options: options.model_options }, 'Unexpected option id');
         }
 
-        convertRoles(prompt, options.model);
-
+        const canonicalState = await prepareOpenAIResponsesCanonicalState({
+            conversation: options.conversation,
+            prompt,
+            options,
+            provider: driver.provider,
+        });
         const model_options = options.model_options as OpenAIRequestOptions | undefined;
-        insert_image_detail(prompt, model_options?.image_detail ?? 'auto');
-
         const toolDefs = getToolDefinitions(options.tools);
         const useTools = Boolean(toolDefs?.length && supportsToolUse(options.model, driver.provider));
         assertOpenAIResponseToolChoiceAvailable(model_options, useTools, options.model, driver.provider, 'execute');
-
-        // Fix orphaned function_call items (can occur when agent is stopped mid-tool-execution)
-        let conversation = fixOrphanedToolResults(fixOrphanedToolUse(updateConversation(options.conversation, prompt)));
+        const includeThoughts = model_options?.include_thoughts !== false;
+        if (canonicalState.accepted_response !== undefined) {
+            return recoverOpenAIResponsesCompletion(canonicalState, options, includeThoughts);
+        }
+        const projection = projectCanonicalResponsesHistory(canonicalState, options);
+        let conversation = projection.conversation;
+        const currentItems = projection.current_items;
+        convertRoles(currentItems, options.model);
+        insert_image_detail(currentItems, model_options?.image_detail ?? 'auto');
+        conversation = fixOrphanedToolResults(fixOrphanedToolUse(withoutCanonicalIngestionFields(conversation)));
 
         // When no tools are provided but conversation contains function_call/function_call_output
         // items (e.g. checkpoint summary calls), convert them to text to avoid API errors
@@ -422,6 +585,10 @@ export class OpenAIResponsesProtocol {
             },
             model_options?.extra_body,
         );
+        const prepared = await finalizeOpenAIResponsesPreparedRequest(
+            { ...canonicalState, native_conversation: conversation },
+            request,
+        );
         const requestOptions = this.resolveRequestOptions(options, signal);
         const res = requestOptions
             ? await driver.service.responses.create(request, requestOptions)
@@ -432,9 +599,13 @@ export class OpenAIResponsesProtocol {
             completion.original_response = res;
         }
 
-        completion.conversation = res.output.length
-            ? finalizeOpenAIResponsesConversation(conversation, res.output, options)
-            : updateConversation(conversation, createAssistantMessageFromCompletion(completion));
+        const fallbackItems = res.output.length === 0 ? createAssistantMessageFromCompletion(completion) : undefined;
+        const decoded = await decodeOpenAIResponsesCanonicalResponse({
+            response: res,
+            prepared,
+            fallback_items: fallbackItems,
+        });
+        completion.conversation = appendOpenAIResponsesCanonicalResponse(prepared, decoded);
 
         return completion;
     }
@@ -460,6 +631,10 @@ export abstract class OpenAIResponsesDriverBase extends OpenAICompatibleDriverBa
         this.responsesProtocol = new OpenAIResponsesProtocol((options, signal) =>
             this.getDriverRequestOptions(options, signal),
         );
+    }
+
+    protected supportsCanonicalConversation(_options: ExecutionOptions): boolean {
+        return true;
     }
 
     protected async formatPrompt(segments: PromptSegment[], options: PromptOptions): Promise<ResponseInputItem[]> {
@@ -542,6 +717,9 @@ export abstract class OpenAIResponsesDriverBase extends OpenAICompatibleDriverBa
         toolUse: unknown[] | undefined,
         options: ExecutionOptions,
     ): ResponseInputItem[] | undefined {
+        if (isConversationDocumentFormat(options.conversation)) {
+            throw new Error('OpenAI Responses canonical streaming requires an authoritative terminal response');
+        }
         // Build assistant message from accumulated CompletionResult[]
         const completionResults = result as CompletionResult[];
 
@@ -1176,8 +1354,9 @@ export function convertOpenAIFunctionItemsToText(items: ResponseInputItem[]): Re
             };
         }
         if (typed.type === 'function_call_output') {
-            const output = typed.output || 'No output';
-            const truncated = output.length > 500 ? `${output.substring(0, 500)}...` : output;
+            const output = typed.output ?? 'No output';
+            const outputText = typeof output === 'string' ? output : (JSON.stringify(output) ?? String(output));
+            const truncated = outputText.length > 500 ? `${outputText.substring(0, 500)}...` : outputText;
             return {
                 role: 'user' as const,
                 content: `[Tool result: ${truncated}]`,
@@ -1222,35 +1401,6 @@ function updateConversation(conversation: unknown, items: ResponseInputItem[]): 
     const unwrapped = unwrapConversationArray<ResponseInputItem>(conversation);
     const convArray = unwrapped ?? (conversation as ResponseInputItem[]);
     return [...convArray, ...items];
-}
-
-function finalizeOpenAIResponsesConversation(
-    conversation: ResponseInputItem[],
-    output: OpenAI.Responses.ResponseOutputItem[],
-    options: ExecutionOptions,
-): ResponseInputItem[] {
-    let completed = updateConversation(conversation, output as ResponseInputItem[]);
-    completed = incrementConversationTurn(completed) as ResponseInputItem[];
-    const currentTurn = getConversationMeta(completed).turnNumber;
-    const preserveSubtree = (value: unknown): boolean => {
-        if (!value || typeof value !== 'object') return false;
-        const encryptedContent = (value as { encrypted_content?: unknown }).encrypted_content;
-        return typeof encryptedContent === 'string' && encryptedContent.length > 0;
-    };
-    const stripOptions = {
-        keepForTurns: options.stripImagesAfterTurns ?? Infinity,
-        currentTurn,
-        textMaxTokens: options.stripTextMaxTokens,
-        preserveSubtree,
-    };
-    let processed = stripBase64ImagesFromConversation(completed, stripOptions);
-    processed = truncateLargeTextInConversation(processed, stripOptions);
-    processed = stripHeartbeatsFromConversation(processed, {
-        keepForTurns: options.stripHeartbeatsAfterTurns ?? 1,
-        currentTurn,
-        preserveSubtree,
-    });
-    return processed as ResponseInputItem[];
 }
 
 export function collectTools(output?: OpenAI.Responses.ResponseOutputItem[]): ToolUse<unknown>[] | undefined {

--- a/drivers/src/openai/openai-chat-conversation-adapter.ts
+++ b/drivers/src/openai/openai-chat-conversation-adapter.ts
@@ -1,0 +1,1005 @@
+import type { ExecutionOptions } from '@llumiverse/common';
+import {
+    type AgentContentBlock,
+    type Asset,
+    appendConversationRecords,
+    appendDecodedConversationResponse,
+    type ConversationDocument,
+    type ConversationTurn,
+    type DecodedConversationResponse,
+    deriveConversationId,
+    type ExecutedGeneration,
+    type ExecutionReceipt,
+    fingerprintJson,
+    type GenerationUsage,
+    type ImportedTurnProvenance,
+    type JsonObject,
+    type JsonValue,
+    type NativeItemMapping,
+    type NestedToolResultContentBlock,
+    type PreparedConversationRequest,
+    type ProgramContentBlock,
+    parseConversationDocument,
+    preflightJsonInput,
+    type ToolDefinition,
+    type ToolResultBlock,
+    type UserContentBlock,
+} from '@llumiverse/conversation';
+import {
+    acceptedCanonicalResponse,
+    appendCanonicalPrompt,
+    type CanonicalPreparedState,
+    canonicalResponseIdentities,
+    canonicalToolDefinitions,
+    createExecutedGeneration,
+    createRequestReceipt,
+    newCanonicalConversation,
+    parseCanonicalConversation,
+    providerJsonValue,
+    type ResolvedConversationRuntimeContext,
+    resolveConversationRuntime,
+    selectedCanonicalTurns,
+} from '../conversation/canonical-runtime.js';
+import type {
+    OpenAIChatCompletionsContentPart,
+    OpenAIChatCompletionsImageUrlPart,
+    OpenAIChatCompletionsMessage,
+    OpenAIChatCompletionsPayload,
+    OpenAIChatCompletionsPrompt,
+    OpenAIChatCompletionsResponse,
+} from './openai_chat_completions.js';
+
+export const OPENAI_CHAT_COMPLETIONS_PROTOCOL = 'openai.chat.completions' as const;
+export const OPENAI_CHAT_COMPLETIONS_ADAPTER_VERSION = '2026-09-11.canonical.1' as const;
+
+type SourceKind = 'imported' | 'received';
+
+type OpenAIReplayPayload = JsonObject & {
+    type: 'openai_chat_assistant_fields';
+    reasoning_content?: string | null;
+    reasoning?: string | null;
+    tool_arguments?: Array<{ call_id: string; raw: string }>;
+};
+
+export interface PreparedOpenAIChatConversation
+    extends CanonicalPreparedState<OpenAIChatCompletionsPrompt>,
+        PreparedConversationRequest<OpenAIChatCompletionsPayload> {
+    provider: string;
+    prior_native_message_count: number;
+}
+
+function ownValue(value: object, key: string): unknown {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    return descriptor && 'value' in descriptor ? descriptor.value : undefined;
+}
+
+function isOpenAIContentPart(value: unknown): value is OpenAIChatCompletionsContentPart {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+    const type = ownValue(value, 'type');
+    if (type === 'text') return typeof ownValue(value, 'text') === 'string';
+    if (type !== 'image_url') return false;
+    const imageUrl = ownValue(value, 'image_url');
+    if (typeof imageUrl !== 'object' || imageUrl === null || Array.isArray(imageUrl)) return false;
+    const url = ownValue(imageUrl, 'url');
+    const detail = ownValue(imageUrl, 'detail');
+    return (
+        typeof url === 'string' && (detail === undefined || detail === 'auto' || detail === 'low' || detail === 'high')
+    );
+}
+
+function isOpenAIToolCall(value: unknown): boolean {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+    const fn = ownValue(value, 'function');
+    return (
+        typeof ownValue(value, 'id') === 'string' &&
+        ownValue(value, 'type') === 'function' &&
+        typeof fn === 'object' &&
+        fn !== null &&
+        !Array.isArray(fn) &&
+        typeof ownValue(fn, 'name') === 'string' &&
+        typeof ownValue(fn, 'arguments') === 'string'
+    );
+}
+
+function isOpenAIMessage(value: unknown): value is OpenAIChatCompletionsMessage {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+    const role = ownValue(value, 'role');
+    if (role !== 'system' && role !== 'developer' && role !== 'user' && role !== 'assistant' && role !== 'tool') {
+        return false;
+    }
+    const content = ownValue(value, 'content');
+    if (
+        content !== undefined &&
+        content !== null &&
+        typeof content !== 'string' &&
+        !(Array.isArray(content) && content.every(isOpenAIContentPart))
+    ) {
+        return false;
+    }
+    const toolCallId = ownValue(value, 'tool_call_id');
+    if (toolCallId !== undefined && typeof toolCallId !== 'string') return false;
+    const toolResultStatus = ownValue(value, 'tool_result_status');
+    if (
+        toolResultStatus !== undefined &&
+        toolResultStatus !== 'success' &&
+        toolResultStatus !== 'error' &&
+        toolResultStatus !== 'cancelled' &&
+        toolResultStatus !== 'denied'
+    ) {
+        return false;
+    }
+    const toolCalls = ownValue(value, 'tool_calls');
+    if (toolCalls !== undefined && !(Array.isArray(toolCalls) && toolCalls.every(isOpenAIToolCall))) return false;
+    return role !== 'tool' || typeof toolCallId === 'string';
+}
+
+export function isOpenAIChatCompletionsHistory(
+    value: unknown,
+    explicitProtocol?: typeof OPENAI_CHAT_COMPLETIONS_PROTOCOL,
+): value is OpenAIChatCompletionsPrompt | OpenAIChatCompletionsMessage[] {
+    const preflight = preflightJsonInput(value);
+    if (!preflight.success) return false;
+    if (Array.isArray(value)) {
+        return explicitProtocol === OPENAI_CHAT_COMPLETIONS_PROTOCOL && value.every(isOpenAIMessage);
+    }
+    if (typeof value !== 'object' || value === null) return false;
+    const messages = ownValue(value, 'messages');
+    const discriminator = ownValue(value, '_is_openai_chat_completions');
+    return discriminator === true && Array.isArray(messages) && messages.every(isOpenAIMessage);
+}
+
+function historyMessages(
+    history: OpenAIChatCompletionsPrompt | OpenAIChatCompletionsMessage[],
+): OpenAIChatCompletionsMessage[] {
+    return Array.isArray(history) ? history : history.messages;
+}
+
+function sourceHistoryTurnNumber(
+    history: OpenAIChatCompletionsPrompt | OpenAIChatCompletionsMessage[],
+): number | undefined {
+    if (Array.isArray(history)) return undefined;
+    const metadata = ownValue(history, '_llumiverse_meta');
+    if (typeof metadata !== 'object' || metadata === null || Array.isArray(metadata)) return undefined;
+    const turnNumber = ownValue(metadata, 'turnNumber');
+    return typeof turnNumber === 'number' && Number.isSafeInteger(turnNumber) && turnNumber >= 0
+        ? turnNumber
+        : undefined;
+}
+
+async function entityId(kind: string, scope: string, ...position: Array<string | number>): Promise<string> {
+    return deriveConversationId(kind, scope, ...position.map(String));
+}
+
+function importedProvenance(index: number, sourceHistoryTurnNumber?: number): ImportedTurnProvenance {
+    return {
+        type: 'imported' as const,
+        source: OPENAI_CHAT_COMPLETIONS_PROTOCOL,
+        native_id: {
+            protocol: OPENAI_CHAT_COMPLETIONS_PROTOCOL,
+            scope: 'history',
+            value: `messages/${index}`,
+        },
+        ...(sourceHistoryTurnNumber === undefined ? {} : { source_history_turn_number: sourceHistoryTurnNumber }),
+        missing_metadata: ['actor_id', 'timestamps', 'exchange'],
+    };
+}
+
+function receivedProvenance() {
+    return { type: 'received' as const };
+}
+
+function isProgramContentBlock(block: AgentContentBlock): block is ProgramContentBlock {
+    return block.type !== 'tool_call';
+}
+
+function isUserContentBlock(block: AgentContentBlock): block is UserContentBlock {
+    return block.type !== 'tool_call' && block.type !== 'reasoning' && block.type !== 'native_replay';
+}
+
+function isNestedToolResultContentBlock(block: AgentContentBlock): block is NestedToolResultContentBlock {
+    return block.type !== 'tool_call';
+}
+
+function replayPayload(message: OpenAIChatCompletionsMessage): OpenAIReplayPayload | undefined {
+    const toolArguments = message.tool_calls?.map((call) => ({ call_id: call.id, raw: call.function.arguments }));
+    if (
+        message.reasoning_content === undefined &&
+        message.reasoning === undefined &&
+        (toolArguments === undefined || toolArguments.length === 0)
+    ) {
+        return undefined;
+    }
+    return {
+        type: 'openai_chat_assistant_fields',
+        ...(message.reasoning_content === undefined ? {} : { reasoning_content: message.reasoning_content }),
+        ...(message.reasoning === undefined ? {} : { reasoning: message.reasoning }),
+        ...(toolArguments === undefined || toolArguments.length === 0 ? {} : { tool_arguments: toolArguments }),
+    };
+}
+
+function parseToolArguments(
+    raw: string,
+): { type: 'json'; value: JsonValue } | { type: 'invalid'; raw: string; error: string } {
+    try {
+        return { type: 'json', value: JSON.parse(raw) as JsonValue };
+    } catch (error: unknown) {
+        return { type: 'invalid', raw, error: error instanceof Error ? error.message : String(error) };
+    }
+}
+
+function dataImage(url: string): { mime_type: string; data: string } | undefined {
+    const match = /^data:([^;,]+);base64,(.*)$/s.exec(url);
+    return match ? { mime_type: match[1], data: match[2] } : undefined;
+}
+
+async function imageRecord(input: {
+    part: OpenAIChatCompletionsImageUrlPart;
+    turn_id: string;
+    scope: string;
+    message_index: number;
+    block_index: number;
+    source: SourceKind;
+    recorded_at: string;
+}): Promise<{ block: UserContentBlock; asset: Asset }> {
+    const blockId = await entityId('block', input.scope, input.message_index, input.block_index);
+    const assetId = await entityId('asset', input.scope, input.message_index, input.block_index);
+    const parsed = dataImage(input.part.image_url.url);
+    const storage = parsed
+        ? { type: 'inline_base64' as const, data: parsed.data }
+        : {
+              type: 'external' as const,
+              resolver: 'url',
+              locator: {
+                  url: input.part.image_url.url,
+                  ...(input.part.image_url.detail === undefined ? {} : { detail: input.part.image_url.detail }),
+              },
+          };
+    const asset: Asset = {
+        id: assetId,
+        kind: 'image',
+        mime_type: parsed?.mime_type ?? 'application/octet-stream',
+        storage,
+        provenance:
+            input.source === 'imported'
+                ? { type: 'imported', source: OPENAI_CHAT_COMPLETIONS_PROTOCOL }
+                : { type: 'received', source_turn_id: input.turn_id },
+        content_hash: await fingerprintJson({ mime_type: parsed?.mime_type ?? null, storage }),
+        created_at: input.recorded_at,
+        ...(input.part.image_url.detail === undefined
+            ? {}
+            : {
+                  metadata: {
+                      openai_chat_completions: { image_detail: input.part.image_url.detail },
+                  },
+              }),
+    };
+    return { block: { id: blockId, type: 'image', asset_id: assetId }, asset };
+}
+
+async function messageRecords(input: {
+    message: OpenAIChatCompletionsMessage;
+    message_index: number;
+    scope: string;
+    source: SourceKind;
+    runtime: ResolvedConversationRuntimeContext;
+    provider: string;
+    tool_definitions: readonly ToolDefinition[];
+    source_history_turn_number?: number;
+}): Promise<{
+    turns: ConversationTurn[];
+    assets: Asset[];
+    mappings: NativeItemMapping[];
+    execution_receipts: ExecutionReceipt[];
+}> {
+    const { message, message_index: messageIndex, scope, source, runtime } = input;
+    const turnId = await entityId('turn', scope, messageIndex);
+    const blocks: AgentContentBlock[] = [];
+    const assets: Asset[] = [];
+    const mappings: NativeItemMapping[] = [
+        { canonical_id: turnId, native_id: `messages/${messageIndex}`, kind: 'turn' },
+    ];
+    const executionReceipts: ExecutionReceipt[] = [];
+
+    const content = message.content;
+    const parts: OpenAIChatCompletionsContentPart[] =
+        typeof content === 'string'
+            ? [{ type: 'text', text: content }]
+            : Array.isArray(content)
+              ? content
+              : content === null
+                ? []
+                : [];
+    for (let blockIndex = 0; blockIndex < parts.length; blockIndex += 1) {
+        const part = parts[blockIndex];
+        if (part.type === 'text') {
+            const blockId = await entityId('block', scope, messageIndex, blockIndex);
+            blocks.push({ id: blockId, type: 'text', text: part.text, format: 'plain' });
+            mappings.push({
+                canonical_id: blockId,
+                native_id: `messages/${messageIndex}/content/${blockIndex}`,
+                kind: 'block',
+            });
+        } else if (part.type === 'image_url') {
+            const converted = await imageRecord({
+                part,
+                turn_id: turnId,
+                scope,
+                message_index: messageIndex,
+                block_index: blockIndex,
+                source,
+                recorded_at: runtime.recorded_at,
+            });
+            blocks.push(converted.block);
+            assets.push(converted.asset);
+            mappings.push({
+                canonical_id: converted.block.id,
+                native_id: `messages/${messageIndex}/content/${blockIndex}`,
+                kind: 'block',
+            });
+        }
+    }
+
+    if (message.role === 'assistant') {
+        const reasoningValues = [message.reasoning_content, message.reasoning].filter(
+            (value): value is string => typeof value === 'string',
+        );
+        for (let reasoningIndex = 0; reasoningIndex < reasoningValues.length; reasoningIndex += 1) {
+            const blockId = await entityId('reasoning', scope, messageIndex, reasoningIndex);
+            blocks.push({
+                id: blockId,
+                type: 'reasoning',
+                text: reasoningValues[reasoningIndex],
+                representation: 'text',
+            });
+            mappings.push({
+                canonical_id: blockId,
+                native_id: `messages/${messageIndex}/reasoning/${reasoningIndex}`,
+                kind: 'block',
+            });
+        }
+        for (let callIndex = 0; callIndex < (message.tool_calls?.length ?? 0); callIndex += 1) {
+            const call = message.tool_calls?.[callIndex];
+            if (call === undefined) continue;
+            const blockId = await entityId('block', scope, messageIndex, 'tool_call', callIndex);
+            const definition = input.tool_definitions.find((candidate) => candidate.name === call.function.name);
+            blocks.push({
+                id: blockId,
+                type: 'tool_call',
+                call_id: call.id,
+                tool_name: call.function.name,
+                ...(definition === undefined ? {} : { definition_id: definition.id }),
+                executor: 'application',
+                arguments: parseToolArguments(call.function.arguments),
+                native_id: {
+                    protocol: OPENAI_CHAT_COMPLETIONS_PROTOCOL,
+                    scope: runtime.request_id,
+                    value: call.id,
+                },
+            });
+            mappings.push(
+                { canonical_id: blockId, native_id: `messages/${messageIndex}/tool_calls/${callIndex}`, kind: 'block' },
+                { canonical_id: call.id, native_id: call.id, kind: 'call' },
+            );
+        }
+        const replay = replayPayload(message);
+        if (replay !== undefined) {
+            const blockId = await entityId('replay', scope, messageIndex);
+            const dependencyBlocks = blocks.map((block) => block.id);
+            const callIds = blocks.flatMap((block) => (block.type === 'tool_call' ? [block.call_id] : []));
+            blocks.push({
+                id: blockId,
+                type: 'native_replay',
+                adapter: OPENAI_CHAT_COMPLETIONS_ADAPTER_VERSION,
+                protocol: OPENAI_CHAT_COMPLETIONS_PROTOCOL,
+                compatibility_scope: {
+                    provider: input.provider,
+                    protocol: OPENAI_CHAT_COMPLETIONS_PROTOCOL,
+                    adapter_version: OPENAI_CHAT_COMPLETIONS_ADAPTER_VERSION,
+                },
+                payload: replay,
+                dependencies: {
+                    turn_ids: [turnId],
+                    block_ids: dependencyBlocks,
+                    call_ids: callIds,
+                    request_ids: [],
+                },
+            });
+            mappings.push({
+                canonical_id: blockId,
+                native_id: `messages/${messageIndex}/assistant_fields`,
+                kind: 'block',
+            });
+        }
+    }
+
+    const common = {
+        id: turnId,
+        status: 'completed' as const,
+        timestamps: { recorded_at: runtime.recorded_at },
+        model_visibility: 'include' as const,
+        provenance:
+            source === 'imported'
+                ? importedProvenance(messageIndex, input.source_history_turn_number)
+                : receivedProvenance(),
+    };
+    if (message.role === 'system' || message.role === 'developer') {
+        return {
+            turns: [
+                {
+                    ...common,
+                    kind: 'program',
+                    authority: message.role === 'system' ? 'system' : 'developer',
+                    blocks: blocks.filter(isProgramContentBlock),
+                },
+            ],
+            assets,
+            mappings,
+            execution_receipts: executionReceipts,
+        };
+    }
+    if (message.role === 'assistant') {
+        const turn: ConversationTurn =
+            source === 'imported'
+                ? {
+                      ...common,
+                      kind: 'agent',
+                      authority: 'ordinary',
+                      blocks,
+                      provenance: importedProvenance(messageIndex, input.source_history_turn_number),
+                  }
+                : {
+                      ...common,
+                      kind: 'agent',
+                      authority: 'ordinary',
+                      blocks,
+                      provenance: receivedProvenance(),
+                  };
+        return { turns: [turn], assets, mappings, execution_receipts: executionReceipts };
+    }
+    if (message.role === 'tool') {
+        if (!message.tool_call_id) throw new Error('OpenAI Chat tool message is missing tool_call_id');
+        const resultBlockId = await entityId('block', scope, messageIndex, 'tool_result');
+        const resultBlock: ToolResultBlock = {
+            id: resultBlockId,
+            type: 'tool_result',
+            call_id: message.tool_call_id,
+            status: message.tool_result_status ?? 'unknown',
+            content: blocks.filter(isNestedToolResultContentBlock),
+            native_id: {
+                protocol: OPENAI_CHAT_COMPLETIONS_PROTOCOL,
+                scope: runtime.request_id,
+                value: message.tool_call_id,
+            },
+        };
+        if (message.tool_result_status !== undefined) {
+            executionReceipts.push({
+                id: await entityId('execution_receipt', scope, message.tool_call_id),
+                call_id: message.tool_call_id,
+                executor: 'application',
+                status: message.tool_result_status,
+                result_turn_id: turnId,
+                result_fingerprint: await fingerprintJson(resultBlock),
+                recorded_at: runtime.recorded_at,
+            });
+        }
+        mappings.push(
+            { canonical_id: resultBlockId, native_id: `messages/${messageIndex}`, kind: 'block' },
+            { canonical_id: message.tool_call_id, native_id: message.tool_call_id, kind: 'call' },
+        );
+        return {
+            turns: [{ ...common, kind: 'tool', authority: 'ordinary', blocks: [resultBlock] }],
+            assets,
+            mappings,
+            execution_receipts: executionReceipts,
+        };
+    }
+    return {
+        turns: [{ ...common, kind: 'user', authority: 'ordinary', blocks: blocks.filter(isUserContentBlock) }],
+        assets,
+        mappings,
+        execution_receipts: executionReceipts,
+    };
+}
+
+async function messagesToRecords(input: {
+    messages: readonly OpenAIChatCompletionsMessage[];
+    scope: string;
+    source: SourceKind;
+    runtime: ResolvedConversationRuntimeContext;
+    provider: string;
+    tool_definitions: readonly ToolDefinition[];
+    source_history_turn_number?: number;
+}): Promise<{
+    turns: ConversationTurn[];
+    assets: Asset[];
+    mappings: NativeItemMapping[];
+    execution_receipts: ExecutionReceipt[];
+}> {
+    const turns: ConversationTurn[] = [];
+    const assets: Asset[] = [];
+    const mappings: NativeItemMapping[] = [];
+    const executionReceipts: ExecutionReceipt[] = [];
+    for (let index = 0; index < input.messages.length; index += 1) {
+        const converted = await messageRecords({
+            message: input.messages[index],
+            message_index: index,
+            scope: input.scope,
+            source: input.source,
+            runtime: input.runtime,
+            provider: input.provider,
+            tool_definitions: input.tool_definitions,
+            ...(input.source_history_turn_number === undefined
+                ? {}
+                : { source_history_turn_number: input.source_history_turn_number }),
+        });
+        turns.push(...converted.turns);
+        assets.push(...converted.assets);
+        mappings.push(...converted.mappings);
+        executionReceipts.push(...converted.execution_receipts);
+    }
+    return { turns, assets, mappings, execution_receipts: executionReceipts };
+}
+
+function blockReplay(
+    turn: ConversationTurn,
+    target?: { provider?: string; model?: string },
+): OpenAIReplayPayload | undefined {
+    const replayBlocks = turn.blocks.filter((block) => block.type === 'native_replay');
+    const replay = replayBlocks.find((block) => block.protocol === OPENAI_CHAT_COMPLETIONS_PROTOCOL);
+    const foreign = replayBlocks.find((block) => block.protocol !== OPENAI_CHAT_COMPLETIONS_PROTOCOL);
+    if (foreign !== undefined) {
+        throw new TypeError(`OpenAI Chat cannot discard protected ${foreign.protocol} replay block ${foreign.id}`);
+    }
+    if (replay === undefined) return undefined;
+    if (typeof replay.payload !== 'object' || replay.payload === null || Array.isArray(replay.payload)) {
+        throw new TypeError(`OpenAI Chat replay block ${replay.id} has an unsupported payload`);
+    }
+    if (
+        replay.adapter !== OPENAI_CHAT_COMPLETIONS_ADAPTER_VERSION ||
+        replay.compatibility_scope.protocol !== OPENAI_CHAT_COMPLETIONS_PROTOCOL ||
+        replay.compatibility_scope.adapter_version !== OPENAI_CHAT_COMPLETIONS_ADAPTER_VERSION ||
+        (target?.provider !== undefined && replay.compatibility_scope.provider !== target.provider) ||
+        (target?.model !== undefined &&
+            replay.compatibility_scope.model !== undefined &&
+            replay.compatibility_scope.model !== target.model)
+    ) {
+        throw new TypeError(`OpenAI Chat replay block ${replay.id} is outside its compatibility scope`);
+    }
+    if (replay.payload.type !== 'openai_chat_assistant_fields') {
+        throw new TypeError(`OpenAI Chat replay block ${replay.id} has an unsupported payload`);
+    }
+    return replay.payload as OpenAIReplayPayload;
+}
+
+function assetPart(asset: Asset): OpenAIChatCompletionsImageUrlPart {
+    const metadata = asset.metadata?.openai_chat_completions;
+    const detail =
+        typeof metadata === 'object' && metadata !== null && !Array.isArray(metadata)
+            ? metadata.image_detail
+            : undefined;
+    const imageDetail = detail === 'auto' || detail === 'low' || detail === 'high' ? detail : undefined;
+    if (asset.storage.type === 'inline_base64') {
+        return {
+            type: 'image_url',
+            image_url: {
+                url: `data:${asset.mime_type};base64,${asset.storage.data}`,
+                ...(imageDetail === undefined ? {} : { detail: imageDetail }),
+            },
+        };
+    }
+    if (asset.storage.type === 'external' && typeof asset.storage.locator.url === 'string') {
+        const locatorDetail = asset.storage.locator.detail;
+        return {
+            type: 'image_url',
+            image_url: {
+                url: asset.storage.locator.url,
+                ...(locatorDetail === 'auto' || locatorDetail === 'low' || locatorDetail === 'high'
+                    ? { detail: locatorDetail }
+                    : imageDetail === undefined
+                      ? {}
+                      : { detail: imageDetail }),
+            },
+        };
+    }
+    throw new Error(`OpenAI Chat cannot resolve image asset ${asset.id}`);
+}
+
+function contentParts(turn: ConversationTurn, document: ConversationDocument): OpenAIChatCompletionsContentPart[] {
+    const parts: OpenAIChatCompletionsContentPart[] = [];
+    for (const block of turn.blocks) {
+        if (block.type === 'text') parts.push({ type: 'text', text: block.text });
+        else if (block.type === 'json') parts.push({ type: 'text', text: JSON.stringify(block.value) });
+        else if (block.type === 'image') {
+            const asset = document.assets[block.asset_id];
+            if (asset === undefined) throw new Error(`OpenAI Chat content references missing asset ${block.asset_id}`);
+            parts.push(assetPart(asset));
+        } else if (
+            block.type !== 'tool_call' &&
+            block.type !== 'reasoning' &&
+            block.type !== 'native_replay' &&
+            (block.type !== 'extension' || block.model_projection !== 'excluded')
+        ) {
+            throw new TypeError(`OpenAI Chat cannot project canonical ${block.type} block ${block.id}`);
+        }
+    }
+    return parts;
+}
+
+function messageContent(parts: OpenAIChatCompletionsContentPart[]): string | OpenAIChatCompletionsContentPart[] | null {
+    if (parts.length === 0) return null;
+    if (parts.length === 1 && parts[0].type === 'text') return parts[0].text;
+    return parts;
+}
+
+function compileTurn(
+    turn: ConversationTurn,
+    document: ConversationDocument,
+    target?: { provider?: string; model?: string },
+): OpenAIChatCompletionsMessage[] {
+    if (turn.kind === 'tool') {
+        const result = turn.blocks[0];
+        const nested = result.content.flatMap((block): OpenAIChatCompletionsContentPart[] => {
+            if (block.type === 'text') return [{ type: 'text', text: block.text }];
+            if (block.type === 'json') return [{ type: 'text', text: JSON.stringify(block.value) }];
+            if (block.type === 'image') {
+                const asset = document.assets[block.asset_id];
+                if (asset === undefined)
+                    throw new Error(`OpenAI Chat tool result references missing asset ${block.asset_id}`);
+                return [assetPart(asset)];
+            }
+            if (block.type === 'extension' && block.model_projection === 'excluded') return [];
+            throw new TypeError(`OpenAI Chat cannot project canonical ${block.type} inside a tool result`);
+        });
+        return [{ role: 'tool', tool_call_id: result.call_id, content: messageContent(nested) }];
+    }
+
+    const replay = blockReplay(turn, target);
+    const parts = contentParts(turn, document);
+    const message: OpenAIChatCompletionsMessage = {
+        role:
+            turn.kind === 'agent'
+                ? 'assistant'
+                : turn.kind === 'program' && turn.authority === 'system'
+                  ? 'system'
+                  : turn.kind === 'program' && turn.authority === 'developer'
+                    ? 'developer'
+                    : 'user',
+        content: messageContent(parts),
+    };
+    if (turn.kind === 'agent') {
+        const rawArguments = new Map(replay?.tool_arguments?.map((value) => [value.call_id, value.raw]) ?? []);
+        const calls = turn.blocks.flatMap((block) =>
+            block.type === 'tool_call'
+                ? [
+                      {
+                          id: block.call_id,
+                          type: 'function' as const,
+                          function: {
+                              name: block.tool_name,
+                              arguments:
+                                  rawArguments.get(block.call_id) ??
+                                  (block.arguments.type === 'invalid'
+                                      ? block.arguments.raw
+                                      : JSON.stringify(block.arguments.value)),
+                          },
+                      },
+                  ]
+                : [],
+        );
+        if (calls.length > 0) message.tool_calls = calls;
+        if (replay?.reasoning_content !== undefined) message.reasoning_content = replay.reasoning_content;
+        if (replay?.reasoning !== undefined) message.reasoning = replay.reasoning;
+        if (replay === undefined) {
+            const reasoning = turn.blocks
+                .filter((block) => block.type === 'reasoning')
+                .map((block) => block.text)
+                .join('');
+            if (reasoning) message.reasoning_content = reasoning;
+        }
+    }
+    return [message];
+}
+
+export function compileOpenAIChatCompletionsConversation(
+    document: ConversationDocument,
+    target?: { provider?: string; model?: string },
+): {
+    conversation: OpenAIChatCompletionsPrompt;
+    mappings: NativeItemMapping[];
+} {
+    const messages: OpenAIChatCompletionsMessage[] = [];
+    const mappings: NativeItemMapping[] = [];
+    for (const turn of selectedCanonicalTurns(document)) {
+        const compiled = compileTurn(turn, document, target);
+        const messageIndex = messages.length;
+        messages.push(...compiled);
+        mappings.push({ canonical_id: turn.id, native_id: `messages/${messageIndex}`, kind: 'turn' });
+        for (const block of turn.blocks) {
+            mappings.push({
+                canonical_id: block.id,
+                native_id: `messages/${messageIndex}/blocks/${block.id}`,
+                kind: 'block',
+            });
+            if (block.type === 'tool_call') {
+                mappings.push({ canonical_id: block.call_id, native_id: block.call_id, kind: 'call' });
+            }
+        }
+    }
+    return { conversation: { _is_openai_chat_completions: true, messages }, mappings };
+}
+
+export async function prepareOpenAIChatCanonicalState(input: {
+    conversation: unknown;
+    prompt: OpenAIChatCompletionsPrompt;
+    options: ExecutionOptions;
+    provider: string;
+}): Promise<Omit<PreparedOpenAIChatConversation, 'payload' | 'receipt' | 'diagnostics'>> {
+    const runtime = resolveConversationRuntime(input.options);
+    let document = parseCanonicalConversation(input.conversation);
+    const toolDefinitions = await canonicalToolDefinitions(input.options.tools);
+    const importedMappings: NativeItemMapping[] = [];
+    if (document === undefined) {
+        document = newCanonicalConversation(runtime);
+        if (input.conversation !== undefined && input.conversation !== null) {
+            if (!isOpenAIChatCompletionsHistory(input.conversation, OPENAI_CHAT_COMPLETIONS_PROTOCOL)) {
+                throw new TypeError('Conversation is neither canonical nor registered OpenAI Chat Completions history');
+            }
+            const imported = await messagesToRecords({
+                messages: historyMessages(input.conversation),
+                scope: `${runtime.conversation_id}:legacy`,
+                source: 'imported',
+                runtime,
+                provider: input.provider,
+                tool_definitions: toolDefinitions,
+                ...(sourceHistoryTurnNumber(input.conversation) === undefined
+                    ? {}
+                    : { source_history_turn_number: sourceHistoryTurnNumber(input.conversation) }),
+            });
+            const importedEntries = await Promise.all(
+                imported.turns.map(async (turn, index) => ({
+                    id: await entityId('context', `${runtime.conversation_id}:legacy`, index),
+                    type: 'source_turn' as const,
+                    turn_id: turn.id,
+                })),
+            );
+            const importedFingerprint = await fingerprintJson(providerJsonValue(input.conversation));
+            document = appendConversationRecords(
+                document,
+                {
+                    turns: imported.turns,
+                    assets: imported.assets,
+                    tool_definitions: toolDefinitions,
+                    context_entries: importedEntries,
+                },
+                {
+                    expected_revision: document.revision,
+                    operation_id: await entityId('import', runtime.conversation_id, OPENAI_CHAT_COMPLETIONS_PROTOCOL),
+                    payload_fingerprint: importedFingerprint,
+                    recorded_at: runtime.recorded_at,
+                },
+            ).document;
+            importedMappings.push(...imported.mappings);
+        }
+    } else if (
+        runtime.conversation_id !== document.id &&
+        input.options.conversation_runtime?.conversation_id !== undefined
+    ) {
+        throw new Error('conversation_runtime.conversation_id does not match the canonical document');
+    }
+
+    const target = { provider: input.provider, model: input.options.model };
+    const priorNativeMessageCount = compileOpenAIChatCompletionsConversation(document, target).conversation.messages
+        .length;
+    const promptRecords = await messagesToRecords({
+        messages: input.prompt.messages,
+        scope: runtime.input_operation_id,
+        source: 'received',
+        runtime: { ...runtime, conversation_id: document.id },
+        provider: input.provider,
+        tool_definitions: toolDefinitions,
+    });
+    const contextEntries = await Promise.all(
+        promptRecords.turns.map(async (turn, index) => ({
+            id: await entityId('context', runtime.input_operation_id, index),
+            type: 'source_turn' as const,
+            turn_id: turn.id,
+        })),
+    );
+    const appended = await appendCanonicalPrompt(
+        document,
+        { ...promptRecords, context_entries: contextEntries, item_mappings: promptRecords.mappings },
+        { ...runtime, conversation_id: document.id },
+        input.options.tools,
+        providerJsonValue(input.prompt),
+    );
+    const compiled = compileOpenAIChatCompletionsConversation(appended.document, target);
+    const acceptedResponse = acceptedCanonicalResponse(appended.document, runtime.response_operation_id);
+    const identities =
+        acceptedResponse === undefined
+            ? await canonicalResponseIdentities(runtime)
+            : { generation_id: acceptedResponse.generation.id, response_turn_id: acceptedResponse.turn.id };
+    return {
+        document: appended.document,
+        native_conversation: compiled.conversation,
+        runtime: { ...runtime, conversation_id: document.id },
+        generation_id: identities.generation_id,
+        response_turn_id: identities.response_turn_id,
+        tool_definitions: appended.tool_definitions,
+        provider: input.provider,
+        prior_native_message_count: priorNativeMessageCount,
+        ...(acceptedResponse === undefined ? {} : { accepted_response: acceptedResponse }),
+    };
+}
+
+export async function finalizeOpenAIChatPreparedRequest(
+    state: Omit<PreparedOpenAIChatConversation, 'payload' | 'receipt' | 'diagnostics'>,
+    payload: OpenAIChatCompletionsPayload,
+): Promise<PreparedOpenAIChatConversation> {
+    const compiled = compileOpenAIChatCompletionsConversation(state.document, {
+        provider: state.provider,
+        model: payload.model,
+    });
+    const receipt = await createRequestReceipt(
+        state.document,
+        state.runtime,
+        {
+            provider: state.provider,
+            protocol: OPENAI_CHAT_COMPLETIONS_PROTOCOL,
+            model: payload.model,
+            adapter_version: OPENAI_CHAT_COMPLETIONS_ADAPTER_VERSION,
+        },
+        providerJsonValue(payload),
+        compiled.mappings,
+        state.tool_definitions,
+    );
+    return { ...state, payload, receipt, diagnostics: [] };
+}
+
+function safeUsageNumber(value: unknown): number | undefined {
+    return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 ? value : undefined;
+}
+
+function openAIUsage(response: OpenAIChatCompletionsResponse): GenerationUsage | undefined {
+    const native = response.usage;
+    if (native === undefined) return undefined;
+    const input = safeUsageNumber(native.prompt_tokens);
+    const output = safeUsageNumber(native.completion_tokens);
+    const reasoningCandidate = safeUsageNumber(native.completion_tokens_details?.reasoning_tokens);
+    const reasoning =
+        reasoningCandidate !== undefined && (output === undefined || reasoningCandidate <= output)
+            ? reasoningCandidate
+            : undefined;
+    const cachedCandidate = safeUsageNumber(native.prompt_tokens_details?.cached_tokens);
+    const cached =
+        input !== undefined && cachedCandidate !== undefined && cachedCandidate <= input ? cachedCandidate : undefined;
+    const basis = 'openai_chat_tokens';
+    const total =
+        input !== undefined && output !== undefined && Number.isSafeInteger(input + output)
+            ? input + output
+            : undefined;
+    const newInput = input !== undefined && cached !== undefined ? input - cached : undefined;
+    return {
+        ...(input === undefined ? {} : { input_tokens: input }),
+        ...(output === undefined ? {} : { output_tokens: output }),
+        ...(reasoning === undefined ? {} : { reasoning_tokens: reasoning }),
+        ...(total === undefined ? {} : { total_tokens: total }),
+        ...(cached === undefined ? {} : { cache_read_tokens: cached }),
+        ...(newInput === undefined || newInput < 0 ? {} : { input_new_tokens: newInput }),
+        accounting_provenance: {
+            ...(input === undefined ? {} : { input_tokens: { method: 'reported', accounting_basis: basis } }),
+            ...(output === undefined ? {} : { output_tokens: { method: 'reported', accounting_basis: basis } }),
+            ...(reasoning === undefined ? {} : { reasoning_tokens: { method: 'reported', accounting_basis: basis } }),
+            ...(total === undefined ? {} : { total_tokens: { method: 'derived', accounting_basis: basis } }),
+            ...(cached === undefined ? {} : { cache_read_tokens: { method: 'reported', accounting_basis: basis } }),
+            ...(newInput === undefined || newInput < 0
+                ? {}
+                : { input_new_tokens: { method: 'derived', accounting_basis: basis } }),
+        },
+        ...(newInput === undefined || newInput < 0
+            ? {}
+            : { input_partition: { type: 'complete_disjoint', cache_write_bucket: 'inapplicable' } }),
+        reported_usage: [
+            {
+                source: 'provider',
+                protocol: OPENAI_CHAT_COMPLETIONS_PROTOCOL,
+                accounting_basis: basis,
+                payload: providerJsonValue(native),
+            },
+        ],
+    };
+}
+
+export async function decodeOpenAIChatCanonicalResponse(
+    response: OpenAIChatCompletionsResponse,
+    prepared: PreparedOpenAIChatConversation,
+    finishReason: string | undefined,
+): Promise<DecodedConversationResponse> {
+    const choice = response.choices[0];
+    if (choice?.message === undefined) throw new Error('OpenAI Chat response has no first message');
+    const runtime = { ...prepared.runtime, recorded_at: prepared.runtime.completed_at ?? new Date().toISOString() };
+    const records = await messageRecords({
+        message: {
+            role: 'assistant',
+            content: choice.message.content,
+            reasoning_content: choice.message.reasoning_content,
+            reasoning: choice.message.reasoning,
+            tool_calls: choice.message.tool_calls?.flatMap((call) => (call.type === 'function' ? [call] : [])),
+        },
+        message_index: 0,
+        scope: prepared.runtime.response_operation_id,
+        source: 'received',
+        runtime,
+        provider: prepared.provider,
+        tool_definitions: prepared.tool_definitions,
+    });
+    const received = records.turns[0];
+    if (received?.kind !== 'agent') throw new Error('OpenAI Chat response did not decode to an agent turn');
+    const turn: ConversationTurn = {
+        ...received,
+        id: prepared.response_turn_id,
+        status: finishReason === 'length' ? 'interrupted' : 'completed',
+        timestamps: {
+            recorded_at: runtime.recorded_at,
+            ...(prepared.runtime.started_at === undefined ? {} : { started_at: prepared.runtime.started_at }),
+            completed_at: runtime.recorded_at,
+        },
+        provenance: { type: 'generated' },
+        generation_id: prepared.generation_id,
+    };
+    const remappedBlocks = turn.blocks.map((block) => {
+        if (block.type !== 'native_replay') return block;
+        return {
+            ...block,
+            dependencies: {
+                ...block.dependencies,
+                turn_ids: [turn.id],
+                request_ids: [prepared.receipt.request_id],
+            },
+        };
+    });
+    const finalTurn = { ...turn, blocks: remappedBlocks } as ConversationTurn;
+    const generation: ExecutedGeneration = await createExecutedGeneration({
+        id: prepared.generation_id,
+        runtime: prepared.runtime,
+        receipt: prepared.receipt,
+        provider: prepared.provider,
+        protocol: OPENAI_CHAT_COMPLETIONS_PROTOCOL,
+        adapter_version: OPENAI_CHAT_COMPLETIONS_ADAPTER_VERSION,
+        requested_model: prepared.payload.model,
+        resolved_model: response.model,
+        provider_response_id: response.id,
+        finish_reason: finishReason,
+        usage: openAIUsage(response),
+    });
+    return {
+        turns: [finalTurn],
+        generation,
+        assets: records.assets.map((asset) => ({
+            ...asset,
+            provenance: { type: 'generated', generation_id: generation.id, source_turn_id: finalTurn.id },
+        })),
+        diagnostics: [],
+        payload_fingerprint: await fingerprintJson(providerJsonValue(response)),
+    };
+}
+
+export function appendOpenAIChatCanonicalResponse(
+    prepared: PreparedOpenAIChatConversation,
+    decoded: DecodedConversationResponse,
+): ConversationDocument {
+    return appendDecodedConversationResponse(prepared, decoded, {
+        operation_id: prepared.runtime.response_operation_id,
+        recorded_at: decoded.generation.timestamps.recorded_at,
+    }).document;
+}
+
+/** Read-only compatibility projection for versioned legacy API responses. */
+export function exportLegacyOpenAIChatCompletionsConversation(
+    document: ConversationDocument,
+): OpenAIChatCompletionsPrompt {
+    return compileOpenAIChatCompletionsConversation(parseConversationDocument(document)).conversation;
+}
+
+export function assertCanonicalOpenAIConversation(value: unknown): ConversationDocument {
+    return parseConversationDocument(value);
+}

--- a/drivers/src/openai/openai-responses-conversation-adapter.ts
+++ b/drivers/src/openai/openai-responses-conversation-adapter.ts
@@ -1,0 +1,1425 @@
+import type { ExecutionOptions } from '@llumiverse/common';
+import {
+    type AgentContentBlock,
+    type Asset,
+    appendConversationRecords,
+    appendDecodedConversationResponse,
+    type ContentBlock,
+    type ConversationDocument,
+    type ConversationTurn,
+    type DecodedConversationResponse,
+    deriveConversationId,
+    type ExecutedGeneration,
+    type ExecutionReceipt,
+    fingerprintJson,
+    type GenerationUsage,
+    type ImportedTurnProvenance,
+    type JsonObject,
+    type JsonValue,
+    type NativeItemMapping,
+    type NestedToolResultContentBlock,
+    type PreparedConversationRequest,
+    type ProgramContentBlock,
+    parseConversationDocument,
+    preflightJsonInput,
+    type ToolDefinition,
+    type ToolResultBlock,
+    type UserContentBlock,
+} from '@llumiverse/conversation';
+import type OpenAI from 'openai';
+import {
+    acceptedCanonicalResponse,
+    appendCanonicalPrompt,
+    type CanonicalPreparedState,
+    canonicalResponseIdentities,
+    canonicalToolDefinitions,
+    createExecutedGeneration,
+    createRequestReceipt,
+    newCanonicalConversation,
+    parseCanonicalConversation,
+    providerJsonValue,
+    type ResolvedConversationRuntimeContext,
+    resolveConversationRuntime,
+    selectedCanonicalTurns,
+} from '../conversation/canonical-runtime.js';
+
+export const OPENAI_RESPONSES_PROTOCOL = 'openai.responses' as const;
+export const OPENAI_RESPONSES_ADAPTER_VERSION = '2026-09-12.canonical.1' as const;
+
+export type OpenAIResponsesInputItem = OpenAI.Responses.ResponseInputItem;
+export type OpenAIResponsesPayload =
+    | OpenAI.Responses.ResponseCreateParamsNonStreaming
+    | OpenAI.Responses.ResponseCreateParamsStreaming;
+
+type SourceKind = 'imported' | 'received';
+type CanonicalToolResultStatus = 'success' | 'error' | 'cancelled' | 'denied';
+
+export type CanonicalOpenAIResponsesFunctionCallOutput = OpenAI.Responses.ResponseInputItem.FunctionCallOutput & {
+    /** Internal ingestion evidence. Removed before provider transport. */
+    _llumiverse_tool_result_status?: CanonicalToolResultStatus;
+};
+
+interface ReplayTextEntry extends JsonObject {
+    kind: 'text' | 'reasoning';
+    block_id: string;
+    item_index: number;
+    content_index: number;
+}
+
+interface ReplayToolCallEntry extends JsonObject {
+    kind: 'tool_call';
+    block_id: string;
+    item_index: number;
+}
+
+interface ReplayAssetEntry extends JsonObject {
+    kind: 'asset';
+    block_id: string;
+    asset_id: string;
+    item_index: number;
+    content_index: number;
+}
+
+type ReplaySemanticEntry = ReplayTextEntry | ReplayToolCallEntry | ReplayAssetEntry;
+
+interface OpenAIResponsesReplayPayload extends JsonObject {
+    type: 'openai_responses_items';
+    items: JsonValue[];
+    semantic_entries: ReplaySemanticEntry[];
+}
+
+interface ConvertedRecords {
+    turns: ConversationTurn[];
+    assets: Asset[];
+    mappings: NativeItemMapping[];
+    execution_receipts: ExecutionReceipt[];
+}
+
+export interface PreparedOpenAIResponsesConversation
+    extends CanonicalPreparedState<OpenAIResponsesInputItem[]>,
+        PreparedConversationRequest<OpenAIResponsesPayload> {
+    provider: string;
+    requested_model: string;
+    prior_native_item_count: number;
+}
+
+function ownValue(value: object, key: string): unknown {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    return descriptor && 'value' in descriptor ? descriptor.value : undefined;
+}
+
+function isResponseHistoryItem(value: unknown): value is OpenAIResponsesInputItem {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+    const role = ownValue(value, 'role');
+    if (role === 'user' || role === 'system' || role === 'developer' || role === 'assistant') {
+        return typeof ownValue(value, 'content') === 'string' || Array.isArray(ownValue(value, 'content'));
+    }
+    return typeof ownValue(value, 'type') === 'string';
+}
+
+function wrappedHistoryItems(value: unknown): OpenAIResponsesInputItem[] | undefined {
+    if (Array.isArray(value)) return value.every(isResponseHistoryItem) ? value : undefined;
+    if (typeof value !== 'object' || value === null) return undefined;
+    const items = ownValue(value, '_arrayConversation');
+    return Array.isArray(items) && items.every(isResponseHistoryItem) ? items : undefined;
+}
+
+export function isOpenAIResponsesHistory(
+    value: unknown,
+    explicitProtocol?: typeof OPENAI_RESPONSES_PROTOCOL,
+): value is OpenAIResponsesInputItem[] | { _arrayConversation: OpenAIResponsesInputItem[] } {
+    if (explicitProtocol !== OPENAI_RESPONSES_PROTOCOL || !preflightJsonInput(value).success) return false;
+    return wrappedHistoryItems(value) !== undefined;
+}
+
+function sourceHistoryTurnNumber(value: unknown): number | undefined {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined;
+    const metadata = ownValue(value, '_llumiverse_meta');
+    if (typeof metadata !== 'object' || metadata === null || Array.isArray(metadata)) return undefined;
+    const turnNumber = ownValue(metadata, 'turnNumber');
+    return typeof turnNumber === 'number' && Number.isSafeInteger(turnNumber) && turnNumber >= 0
+        ? turnNumber
+        : undefined;
+}
+
+async function entityId(kind: string, scope: string, ...position: Array<string | number>): Promise<string> {
+    return deriveConversationId(kind, scope, ...position.map(String));
+}
+
+function importedProvenance(nativePath: string, sourceTurnNumber?: number): ImportedTurnProvenance {
+    return {
+        type: 'imported',
+        source: OPENAI_RESPONSES_PROTOCOL,
+        native_id: { protocol: OPENAI_RESPONSES_PROTOCOL, scope: 'history', value: nativePath },
+        ...(sourceTurnNumber === undefined ? {} : { source_history_turn_number: sourceTurnNumber }),
+        missing_metadata: ['actor_id', 'timestamps', 'exchange'],
+    };
+}
+
+function turnProvenance(source: SourceKind, nativePath: string, sourceTurnNumber?: number) {
+    return source === 'imported' ? importedProvenance(nativePath, sourceTurnNumber) : ({ type: 'received' } as const);
+}
+
+function parseToolArguments(
+    raw: string,
+): { type: 'json'; value: JsonValue } | { type: 'invalid'; raw: string; error: string } {
+    try {
+        return { type: 'json', value: JSON.parse(raw) as JsonValue };
+    } catch (error: unknown) {
+        return { type: 'invalid', raw, error: error instanceof Error ? error.message : String(error) };
+    }
+}
+
+function dataUrl(value: string): { mime_type: string; data: string } | undefined {
+    const match = /^data:([^;,]+);base64,(.*)$/s.exec(value);
+    return match ? { mime_type: match[1], data: match[2] } : undefined;
+}
+
+function contentKind(part: Record<string, unknown>): 'image' | 'document' {
+    return part.type === 'input_image' ? 'image' : 'document';
+}
+
+async function mediaBlock(input: {
+    part: Record<string, unknown>;
+    turn_id: string;
+    scope: string;
+    native_path: string;
+    source: SourceKind;
+    recorded_at: string;
+    provider: string;
+}): Promise<{ block: UserContentBlock; asset: Asset }> {
+    const { part } = input;
+    const kind = contentKind(part);
+    const blockId = await entityId('block', input.scope, input.native_path);
+    const assetId = await entityId('asset', input.scope, input.native_path);
+    const imageUrl = typeof part.image_url === 'string' ? part.image_url : undefined;
+    const fileUrl = typeof part.file_url === 'string' ? part.file_url : undefined;
+    const fileId = typeof part.file_id === 'string' ? part.file_id : undefined;
+    const fileData = typeof part.file_data === 'string' ? part.file_data : undefined;
+    const inline = dataUrl(imageUrl ?? fileData ?? '');
+    let storage: Asset['storage'];
+    let mimeType: string;
+    if (inline !== undefined) {
+        storage = { type: 'inline_base64', data: inline.data };
+        mimeType = inline.mime_type;
+    } else if (imageUrl !== undefined || fileUrl !== undefined) {
+        const url = imageUrl ?? fileUrl;
+        if (url === undefined) throw new TypeError('OpenAI Responses media URL is missing');
+        storage = { type: 'external', resolver: 'url', locator: { url } };
+        mimeType = kind === 'image' ? 'application/octet-stream' : 'application/pdf';
+    } else if (fileId !== undefined) {
+        storage = { type: 'external', resolver: 'openai_file', locator: { file_id: fileId } };
+        mimeType = 'application/octet-stream';
+    } else {
+        throw new TypeError(`OpenAI Responses ${String(part.type)} content has no supported source`);
+    }
+    const metadata: JsonObject = {
+        source_field:
+            imageUrl !== undefined
+                ? 'image_url'
+                : fileData !== undefined
+                  ? 'file_data'
+                  : fileUrl !== undefined
+                    ? 'file_url'
+                    : 'file_id',
+        ...(fileId === undefined ? {} : { provider: input.provider }),
+        ...(typeof part.detail === 'string' ? { detail: part.detail } : {}),
+        ...(typeof part.filename === 'string' ? { filename: part.filename } : {}),
+    };
+    const asset: Asset = {
+        id: assetId,
+        kind,
+        mime_type: mimeType,
+        storage,
+        provenance:
+            input.source === 'imported'
+                ? { type: 'imported', source: OPENAI_RESPONSES_PROTOCOL }
+                : { type: 'received', source_turn_id: input.turn_id },
+        content_hash: await fingerprintJson({ mime_type: mimeType, storage }),
+        created_at: input.recorded_at,
+        metadata: { openai_responses: metadata },
+    };
+    return {
+        block: { id: blockId, type: kind, asset_id: assetId } as UserContentBlock,
+        asset,
+    };
+}
+
+async function contentBlocks(input: {
+    content: unknown;
+    turn_id: string;
+    scope: string;
+    native_path: string;
+    source: SourceKind;
+    recorded_at: string;
+    provider: string;
+}): Promise<{ blocks: UserContentBlock[]; assets: Asset[] }> {
+    const blocks: UserContentBlock[] = [];
+    const assets: Asset[] = [];
+    const parts: unknown[] =
+        typeof input.content === 'string'
+            ? [{ type: 'input_text', text: input.content }]
+            : Array.isArray(input.content)
+              ? input.content
+              : [];
+    for (let index = 0; index < parts.length; index += 1) {
+        const part = parts[index];
+        if (typeof part !== 'object' || part === null || Array.isArray(part)) {
+            throw new TypeError(`OpenAI Responses content ${input.native_path}/${index} is not an object`);
+        }
+        const record = part as Record<string, unknown>;
+        if ((record.type === 'input_text' || record.type === 'output_text') && typeof record.text === 'string') {
+            blocks.push({
+                id: await entityId('block', input.scope, input.native_path, index),
+                type: 'text',
+                text: record.text,
+                format: 'plain',
+            });
+            continue;
+        }
+        if (record.type === 'input_image' || record.type === 'input_file') {
+            const converted = await mediaBlock({
+                part: record,
+                turn_id: input.turn_id,
+                scope: input.scope,
+                native_path: `${input.native_path}/${index}`,
+                source: input.source,
+                recorded_at: input.recorded_at,
+                provider: input.provider,
+            });
+            blocks.push(converted.block);
+            assets.push(converted.asset);
+            continue;
+        }
+        throw new TypeError(`OpenAI Responses content type ${String(record.type)} is not supported`);
+    }
+    return { blocks, assets };
+}
+
+async function ordinaryMessageRecords(input: {
+    item: Record<string, unknown>;
+    item_index: number;
+    scope: string;
+    source: SourceKind;
+    runtime: ResolvedConversationRuntimeContext;
+    provider: string;
+    source_history_turn_number?: number;
+}): Promise<ConvertedRecords> {
+    const nativePath = `items/${input.item_index}`;
+    const turnId = await entityId('turn', input.scope, input.item_index);
+    const converted = await contentBlocks({
+        content: input.item.content,
+        turn_id: turnId,
+        scope: input.scope,
+        native_path: `${nativePath}/content`,
+        source: input.source,
+        recorded_at: input.runtime.recorded_at,
+        provider: input.provider,
+    });
+    const role = input.item.role;
+    const common = {
+        id: turnId,
+        status: input.item.status === 'incomplete' ? ('interrupted' as const) : ('completed' as const),
+        timestamps: { recorded_at: input.runtime.recorded_at },
+        model_visibility: 'include' as const,
+        provenance: turnProvenance(input.source, nativePath, input.source_history_turn_number),
+    };
+    let turn: ConversationTurn;
+    if (role === 'system' || role === 'developer') {
+        turn = { ...common, kind: 'program', authority: role, blocks: converted.blocks as ProgramContentBlock[] };
+    } else {
+        turn = { ...common, kind: 'user', authority: 'ordinary', blocks: converted.blocks };
+    }
+    return {
+        turns: [turn],
+        assets: converted.assets,
+        mappings: [
+            { canonical_id: turnId, native_id: nativePath, kind: 'turn' },
+            ...converted.blocks.map((block, index) => ({
+                canonical_id: block.id,
+                native_id: `${nativePath}/content/${index}`,
+                kind: 'block' as const,
+            })),
+        ],
+        execution_receipts: [],
+    };
+}
+
+function findToolDefinition(definitions: readonly ToolDefinition[], name: string): ToolDefinition | undefined {
+    return definitions.find((candidate) => candidate.name === name);
+}
+
+async function assistantItemsRecords(input: {
+    items: readonly Record<string, unknown>[];
+    first_item_index: number;
+    scope: string;
+    source: SourceKind;
+    runtime: ResolvedConversationRuntimeContext;
+    provider: string;
+    model: string;
+    tool_definitions: readonly ToolDefinition[];
+    source_history_turn_number?: number;
+}): Promise<ConvertedRecords> {
+    const nativePath = `items/${input.first_item_index}`;
+    const turnId = await entityId('turn', input.scope, input.first_item_index);
+    const blocks: AgentContentBlock[] = [];
+    const assets: Asset[] = [];
+    const semanticEntries: ReplaySemanticEntry[] = [];
+    const mappings: NativeItemMapping[] = [{ canonical_id: turnId, native_id: nativePath, kind: 'turn' }];
+    for (let localIndex = 0; localIndex < input.items.length; localIndex += 1) {
+        const item = input.items[localIndex];
+        const itemIndex = input.first_item_index + localIndex;
+        const type = item.type;
+        if (type === 'message' || item.role === 'assistant') {
+            const content = Array.isArray(item.content)
+                ? item.content
+                : typeof item.content === 'string'
+                  ? [{ type: 'output_text', text: item.content }]
+                  : [];
+            for (let contentIndex = 0; contentIndex < content.length; contentIndex += 1) {
+                const part = content[contentIndex];
+                if (typeof part !== 'object' || part === null || Array.isArray(part)) continue;
+                const record = part as Record<string, unknown>;
+                if (record.type === 'output_text' && typeof record.text === 'string') {
+                    const blockId = await entityId('block', input.scope, itemIndex, 'content', contentIndex);
+                    blocks.push({ id: blockId, type: 'text', text: record.text, format: 'plain' });
+                    semanticEntries.push({
+                        kind: 'text',
+                        block_id: blockId,
+                        item_index: localIndex,
+                        content_index: contentIndex,
+                    });
+                    mappings.push({
+                        canonical_id: blockId,
+                        native_id: `items/${itemIndex}/content/${contentIndex}`,
+                        kind: 'block',
+                    });
+                }
+            }
+        } else if (type === 'reasoning') {
+            const values: Array<{ text: string; representation: 'summary' | 'text'; content_index: number }> = [];
+            if (Array.isArray(item.summary)) {
+                for (let index = 0; index < item.summary.length; index += 1) {
+                    const summary = item.summary[index];
+                    if (typeof summary === 'object' && summary !== null && !Array.isArray(summary)) {
+                        const text = ownValue(summary, 'text');
+                        if (typeof text === 'string')
+                            values.push({ text, representation: 'summary', content_index: index });
+                    }
+                }
+            }
+            if (Array.isArray(item.content)) {
+                for (let index = 0; index < item.content.length; index += 1) {
+                    const content = item.content[index];
+                    if (typeof content === 'object' && content !== null && !Array.isArray(content)) {
+                        const text = ownValue(content, 'text');
+                        if (typeof text === 'string')
+                            values.push({ text, representation: 'text', content_index: index });
+                    }
+                }
+            }
+            for (let index = 0; index < values.length; index += 1) {
+                const value = values[index];
+                const blockId = await entityId('reasoning', input.scope, itemIndex, index);
+                blocks.push({ id: blockId, type: 'reasoning', text: value.text, representation: value.representation });
+                semanticEntries.push({
+                    kind: 'reasoning',
+                    block_id: blockId,
+                    item_index: localIndex,
+                    content_index: value.content_index,
+                });
+                mappings.push({
+                    canonical_id: blockId,
+                    native_id: `items/${itemIndex}/reasoning/${index}`,
+                    kind: 'block',
+                });
+            }
+        } else if (type === 'function_call') {
+            const callId = item.call_id;
+            const name = item.name;
+            const raw = item.arguments;
+            if (typeof callId !== 'string' || typeof name !== 'string' || typeof raw !== 'string') {
+                throw new TypeError(`OpenAI Responses function call at ${nativePath} is incomplete`);
+            }
+            const blockId = await entityId('block', input.scope, itemIndex, 'tool_call');
+            const definition = findToolDefinition(input.tool_definitions, name);
+            blocks.push({
+                id: blockId,
+                type: 'tool_call',
+                call_id: callId,
+                tool_name: name,
+                ...(definition === undefined ? {} : { definition_id: definition.id }),
+                executor: 'application',
+                arguments: parseToolArguments(raw),
+                native_id: {
+                    protocol: OPENAI_RESPONSES_PROTOCOL,
+                    scope: input.runtime.request_id,
+                    value: typeof item.id === 'string' ? item.id : callId,
+                },
+            });
+            semanticEntries.push({ kind: 'tool_call', block_id: blockId, item_index: localIndex });
+            mappings.push(
+                { canonical_id: blockId, native_id: `items/${itemIndex}`, kind: 'block' },
+                { canonical_id: callId, native_id: callId, kind: 'call' },
+            );
+        } else if (type === 'image_generation_call' && typeof item.result === 'string') {
+            const blockId = await entityId('block', input.scope, itemIndex, 'image');
+            const assetId = await entityId('asset', input.scope, itemIndex, 'image');
+            const parsed = dataUrl(item.result);
+            const storage: Asset['storage'] = {
+                type: 'inline_base64',
+                data: parsed?.data ?? item.result,
+            };
+            const asset: Asset = {
+                id: assetId,
+                kind: 'image',
+                mime_type: parsed?.mime_type ?? 'image/png',
+                storage,
+                provenance:
+                    input.source === 'imported'
+                        ? { type: 'imported', source: OPENAI_RESPONSES_PROTOCOL }
+                        : { type: 'received', source_turn_id: turnId },
+                content_hash: await fingerprintJson({ mime_type: parsed?.mime_type ?? 'image/png', storage }),
+                created_at: input.runtime.recorded_at,
+            };
+            blocks.push({ id: blockId, type: 'image', asset_id: assetId });
+            assets.push(asset);
+            semanticEntries.push({
+                kind: 'asset',
+                block_id: blockId,
+                asset_id: assetId,
+                item_index: localIndex,
+                content_index: 0,
+            });
+            mappings.push({ canonical_id: blockId, native_id: `items/${itemIndex}`, kind: 'block' });
+        }
+    }
+    const replayId = await entityId('replay', input.scope, input.first_item_index);
+    const requiresModelScope = input.items.some((item) => {
+        const type = item.type;
+        return (
+            type === 'reasoning' || (type !== 'message' && type !== 'function_call' && type !== 'image_generation_call')
+        );
+    });
+    const replay: AgentContentBlock = {
+        id: replayId,
+        type: 'native_replay',
+        adapter: OPENAI_RESPONSES_ADAPTER_VERSION,
+        protocol: OPENAI_RESPONSES_PROTOCOL,
+        compatibility_scope: {
+            provider: input.provider,
+            protocol: OPENAI_RESPONSES_PROTOCOL,
+            ...(requiresModelScope ? { model: input.model } : {}),
+            adapter_version: OPENAI_RESPONSES_ADAPTER_VERSION,
+        },
+        payload: {
+            type: 'openai_responses_items',
+            items: providerJsonValue(input.items) as JsonValue[],
+            semantic_entries: semanticEntries,
+        },
+        dependencies: {
+            turn_ids: [turnId],
+            block_ids: blocks.map((block) => block.id),
+            call_ids: blocks.flatMap((block) => (block.type === 'tool_call' ? [block.call_id] : [])),
+            request_ids: [],
+        },
+    };
+    blocks.push(replay);
+    mappings.push({ canonical_id: replayId, native_id: `${nativePath}/replay`, kind: 'block' });
+    const common = {
+        id: turnId,
+        kind: 'agent' as const,
+        authority: 'ordinary' as const,
+        blocks,
+        status: input.items.some((item) => item.status === 'incomplete')
+            ? ('interrupted' as const)
+            : ('completed' as const),
+        timestamps: { recorded_at: input.runtime.recorded_at },
+        model_visibility: 'include' as const,
+    };
+    const turn: ConversationTurn =
+        input.source === 'imported'
+            ? {
+                  ...common,
+                  provenance: importedProvenance(nativePath, input.source_history_turn_number),
+              }
+            : { ...common, provenance: { type: 'received' } };
+    return { turns: [turn], assets, mappings, execution_receipts: [] };
+}
+
+async function toolResultRecords(input: {
+    item: CanonicalOpenAIResponsesFunctionCallOutput;
+    item_index: number;
+    scope: string;
+    source: SourceKind;
+    runtime: ResolvedConversationRuntimeContext;
+    provider: string;
+    source_history_turn_number?: number;
+}): Promise<ConvertedRecords> {
+    const nativePath = `items/${input.item_index}`;
+    const turnId = await entityId('turn', input.scope, input.item_index);
+    const converted = await contentBlocks({
+        content: input.item.output,
+        turn_id: turnId,
+        scope: input.scope,
+        native_path: `${nativePath}/output`,
+        source: input.source,
+        recorded_at: input.runtime.recorded_at,
+        provider: input.provider,
+    });
+    const resultId = await entityId('block', input.scope, input.item_index, 'tool_result');
+    const replayId = await entityId('replay', input.scope, input.item_index);
+    const nativeItem = providerJsonValue(input.item) as JsonObject;
+    delete nativeItem._llumiverse_tool_result_status;
+    const replay: NestedToolResultContentBlock = {
+        id: replayId,
+        type: 'native_replay',
+        adapter: OPENAI_RESPONSES_ADAPTER_VERSION,
+        protocol: OPENAI_RESPONSES_PROTOCOL,
+        compatibility_scope: {
+            provider: input.provider,
+            protocol: OPENAI_RESPONSES_PROTOCOL,
+            adapter_version: OPENAI_RESPONSES_ADAPTER_VERSION,
+        },
+        payload: {
+            type: 'openai_responses_items',
+            items: [nativeItem],
+            semantic_entries: converted.blocks.map((block, index) => ({
+                kind: block.type === 'text' ? 'text' : 'asset',
+                block_id: block.id,
+                ...(block.type === 'image' || block.type === 'document' ? { asset_id: block.asset_id } : {}),
+                item_index: 0,
+                content_index: index,
+            })) as ReplaySemanticEntry[],
+        },
+        dependencies: {
+            turn_ids: [turnId],
+            block_ids: converted.blocks.map((block) => block.id),
+            call_ids: [input.item.call_id],
+            request_ids: [],
+        },
+    };
+    const status = input.item._llumiverse_tool_result_status ?? 'unknown';
+    const resultBlock: ToolResultBlock = {
+        id: resultId,
+        type: 'tool_result',
+        call_id: input.item.call_id,
+        status,
+        content: [...(converted.blocks as NestedToolResultContentBlock[]), replay],
+        native_id: {
+            protocol: OPENAI_RESPONSES_PROTOCOL,
+            scope: input.runtime.request_id,
+            value: typeof input.item.id === 'string' ? input.item.id : input.item.call_id,
+        },
+    };
+    const executionReceipts: ExecutionReceipt[] = [];
+    if (status !== 'unknown') {
+        executionReceipts.push({
+            id: await entityId('execution_receipt', input.scope, input.item.call_id),
+            call_id: input.item.call_id,
+            executor: 'application',
+            status,
+            result_turn_id: turnId,
+            result_fingerprint: await fingerprintJson(resultBlock),
+            recorded_at: input.runtime.recorded_at,
+        });
+    }
+    const turn: ConversationTurn = {
+        id: turnId,
+        kind: 'tool',
+        authority: 'ordinary',
+        blocks: [resultBlock],
+        status: 'completed',
+        timestamps: { recorded_at: input.runtime.recorded_at },
+        model_visibility: 'include',
+        provenance: turnProvenance(input.source, nativePath, input.source_history_turn_number),
+    };
+    return {
+        turns: [turn],
+        assets: converted.assets,
+        mappings: [
+            { canonical_id: turnId, native_id: nativePath, kind: 'turn' },
+            { canonical_id: resultId, native_id: nativePath, kind: 'block' },
+            { canonical_id: input.item.call_id, native_id: input.item.call_id, kind: 'call' },
+        ],
+        execution_receipts: executionReceipts,
+    };
+}
+
+function isOrdinaryMessage(item: Record<string, unknown>): boolean {
+    return item.role === 'user' || item.role === 'system' || item.role === 'developer';
+}
+
+async function itemsToRecords(input: {
+    items: readonly OpenAIResponsesInputItem[];
+    scope: string;
+    source: SourceKind;
+    runtime: ResolvedConversationRuntimeContext;
+    provider: string;
+    model: string;
+    tool_definitions: readonly ToolDefinition[];
+    source_history_turn_number?: number;
+}): Promise<ConvertedRecords> {
+    const result: ConvertedRecords = { turns: [], assets: [], mappings: [], execution_receipts: [] };
+    const append = (records: ConvertedRecords) => {
+        result.turns.push(...records.turns);
+        result.assets.push(...records.assets);
+        result.mappings.push(...records.mappings);
+        result.execution_receipts.push(...records.execution_receipts);
+    };
+    let assistantItems: Record<string, unknown>[] = [];
+    let firstAssistantIndex = 0;
+    const flushAssistant = async () => {
+        if (assistantItems.length === 0) return;
+        append(
+            await assistantItemsRecords({
+                items: assistantItems,
+                first_item_index: firstAssistantIndex,
+                scope: input.scope,
+                source: input.source,
+                runtime: input.runtime,
+                provider: input.provider,
+                model: input.model,
+                tool_definitions: input.tool_definitions,
+                ...(input.source_history_turn_number === undefined
+                    ? {}
+                    : { source_history_turn_number: input.source_history_turn_number }),
+            }),
+        );
+        assistantItems = [];
+    };
+    for (let index = 0; index < input.items.length; index += 1) {
+        const item = input.items[index] as unknown as Record<string, unknown>;
+        if (item.type === 'function_call_output') {
+            await flushAssistant();
+            append(
+                await toolResultRecords({
+                    item: item as unknown as CanonicalOpenAIResponsesFunctionCallOutput,
+                    item_index: index,
+                    scope: input.scope,
+                    source: input.source,
+                    runtime: input.runtime,
+                    provider: input.provider,
+                    ...(input.source_history_turn_number === undefined
+                        ? {}
+                        : { source_history_turn_number: input.source_history_turn_number }),
+                }),
+            );
+        } else if (isOrdinaryMessage(item)) {
+            await flushAssistant();
+            append(
+                await ordinaryMessageRecords({
+                    item,
+                    item_index: index,
+                    scope: input.scope,
+                    source: input.source,
+                    runtime: input.runtime,
+                    provider: input.provider,
+                    ...(input.source_history_turn_number === undefined
+                        ? {}
+                        : { source_history_turn_number: input.source_history_turn_number }),
+                }),
+            );
+        } else {
+            if (assistantItems.length === 0) firstAssistantIndex = index;
+            assistantItems.push(item);
+        }
+    }
+    await flushAssistant();
+    return result;
+}
+
+function openAIResponsesMetadata(asset: Asset): JsonObject {
+    const value = asset.metadata?.openai_responses;
+    return typeof value === 'object' && value !== null && !Array.isArray(value) ? value : {};
+}
+
+function assetToInputPart(asset: Asset, target?: { provider?: string }): OpenAI.Responses.ResponseInputContent {
+    const metadata = openAIResponsesMetadata(asset);
+    const detail = metadata.detail;
+    const owningProvider = metadata.provider;
+    if (
+        asset.storage.type === 'external' &&
+        asset.storage.resolver === 'openai_file' &&
+        target?.provider !== undefined &&
+        owningProvider !== target.provider
+    ) {
+        throw new TypeError(`OpenAI Responses file asset ${asset.id} belongs to provider ${String(owningProvider)}`);
+    }
+    if (asset.kind === 'image') {
+        const value =
+            asset.storage.type === 'inline_base64'
+                ? `data:${asset.mime_type};base64,${asset.storage.data}`
+                : asset.storage.type === 'external' && asset.storage.resolver === 'url'
+                  ? asset.storage.locator.url
+                  : undefined;
+        const fileId =
+            asset.storage.type === 'external' && asset.storage.resolver === 'openai_file'
+                ? asset.storage.locator.file_id
+                : undefined;
+        if (typeof value !== 'string' && typeof fileId !== 'string') {
+            throw new TypeError(`OpenAI Responses cannot resolve image asset ${asset.id}`);
+        }
+        return {
+            type: 'input_image',
+            detail: detail === 'low' || detail === 'high' || detail === 'original' ? detail : 'auto',
+            ...(typeof value === 'string' ? { image_url: value } : { file_id: fileId as string }),
+        };
+    }
+    if (asset.kind !== 'document') {
+        throw new TypeError(`OpenAI Responses cannot project ${asset.kind} asset ${asset.id}`);
+    }
+    const filename = typeof metadata.filename === 'string' ? metadata.filename : undefined;
+    if (asset.storage.type === 'inline_base64') {
+        return {
+            type: 'input_file',
+            file_data: `data:${asset.mime_type};base64,${asset.storage.data}`,
+            ...(detail === 'low' || detail === 'high' || detail === 'auto' ? { detail } : {}),
+            ...(filename === undefined ? {} : { filename }),
+        };
+    }
+    if (asset.storage.type === 'external' && asset.storage.resolver === 'url') {
+        const url = asset.storage.locator.url;
+        if (typeof url !== 'string') throw new TypeError(`OpenAI Responses document asset ${asset.id} has no URL`);
+        return {
+            type: 'input_file',
+            file_url: url,
+            ...(detail === 'low' || detail === 'high' || detail === 'auto' ? { detail } : {}),
+            ...(filename === undefined ? {} : { filename }),
+        };
+    }
+    if (asset.storage.type === 'external' && asset.storage.resolver === 'openai_file') {
+        const fileId = asset.storage.locator.file_id;
+        if (typeof fileId !== 'string')
+            throw new TypeError(`OpenAI Responses document asset ${asset.id} has no file ID`);
+        return {
+            type: 'input_file',
+            file_id: fileId,
+            ...(detail === 'low' || detail === 'high' || detail === 'auto' ? { detail } : {}),
+            ...(filename === undefined ? {} : { filename }),
+        };
+    }
+    throw new TypeError(`OpenAI Responses cannot resolve document asset ${asset.id}`);
+}
+
+function ordinaryBlockToPart(
+    block: ContentBlock,
+    document: ConversationDocument,
+    target?: { provider?: string },
+): OpenAI.Responses.ResponseInputContent {
+    if (block.type === 'text') return { type: 'input_text', text: block.text };
+    if (block.type === 'json') return { type: 'input_text', text: JSON.stringify(block.value) };
+    if (block.type === 'image' || block.type === 'document') {
+        const asset = document.assets[block.asset_id];
+        if (asset === undefined) throw new Error(`OpenAI Responses content references missing asset ${block.asset_id}`);
+        return assetToInputPart(asset, target);
+    }
+    throw new TypeError(`OpenAI Responses cannot project canonical ${block.type} block ${block.id}`);
+}
+
+function rawReplayPayload(block: Extract<ContentBlock, { type: 'native_replay' }>): OpenAIResponsesReplayPayload {
+    const payload = block.payload;
+    if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) {
+        throw new TypeError(`OpenAI Responses replay block ${block.id} has an unsupported payload`);
+    }
+    if (
+        payload.type !== 'openai_responses_items' ||
+        !Array.isArray(payload.items) ||
+        !Array.isArray(payload.semantic_entries)
+    ) {
+        throw new TypeError(`OpenAI Responses replay block ${block.id} has an unsupported payload`);
+    }
+    return payload as unknown as OpenAIResponsesReplayPayload;
+}
+
+function assertReplayScope(
+    block: Extract<ContentBlock, { type: 'native_replay' }>,
+    target?: { provider?: string; model?: string },
+): void {
+    if (
+        block.adapter !== OPENAI_RESPONSES_ADAPTER_VERSION ||
+        block.protocol !== OPENAI_RESPONSES_PROTOCOL ||
+        block.compatibility_scope.protocol !== OPENAI_RESPONSES_PROTOCOL ||
+        block.compatibility_scope.adapter_version !== OPENAI_RESPONSES_ADAPTER_VERSION ||
+        (target?.provider !== undefined && block.compatibility_scope.provider !== target.provider) ||
+        (target?.model !== undefined &&
+            block.compatibility_scope.model !== undefined &&
+            block.compatibility_scope.model !== target.model)
+    ) {
+        throw new TypeError(`OpenAI Responses replay block ${block.id} is outside its compatibility scope`);
+    }
+}
+
+function rawAt(payload: OpenAIResponsesReplayPayload, entry: ReplaySemanticEntry): Record<string, unknown> {
+    const item = payload.items[entry.item_index];
+    if (typeof item !== 'object' || item === null || Array.isArray(item)) {
+        throw new TypeError('OpenAI Responses replay semantic entry references a non-object item');
+    }
+    return item as Record<string, unknown>;
+}
+
+function stableJson(value: unknown): string {
+    if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`;
+    if (typeof value === 'object' && value !== null) {
+        const record = value as Record<string, unknown>;
+        return `{${Object.keys(record)
+            .sort()
+            .map((key) => `${JSON.stringify(key)}:${stableJson(record[key])}`)
+            .join(',')}}`;
+    }
+    return JSON.stringify(value) ?? 'undefined';
+}
+
+function assertReplaySemantics(
+    turn: ConversationTurn,
+    document: ConversationDocument,
+    block: Extract<ContentBlock, { type: 'native_replay' }>,
+    payload: OpenAIResponsesReplayPayload,
+    target?: { provider?: string },
+): void {
+    if (turn.kind === 'tool') {
+        const raw = payload.items[0];
+        const rawCallId =
+            typeof raw === 'object' && raw !== null && !Array.isArray(raw) ? ownValue(raw, 'call_id') : undefined;
+        if (rawCallId !== turn.blocks[0].call_id || block.dependencies.call_ids[0] !== turn.blocks[0].call_id) {
+            throw new TypeError(`OpenAI Responses replay block ${block.id} no longer matches its tool result call`);
+        }
+    }
+    const blocks = new Map<string, ContentBlock>();
+    for (const candidate of turn.blocks) {
+        if (candidate.type !== 'native_replay' && candidate.type !== 'tool_result') {
+            blocks.set(candidate.id, candidate);
+        }
+        if (candidate.type === 'tool_result') {
+            for (const nested of candidate.content) if (nested.type !== 'native_replay') blocks.set(nested.id, nested);
+        }
+    }
+    const actualIds = [...blocks.keys()].sort();
+    const expectedIds = [...block.dependencies.block_ids].sort();
+    if (JSON.stringify(actualIds) !== JSON.stringify(expectedIds)) {
+        throw new TypeError(`OpenAI Responses replay block ${block.id} no longer matches its semantic blocks`);
+    }
+    for (const entry of payload.semantic_entries) {
+        const semantic = blocks.get(entry.block_id);
+        if (semantic === undefined)
+            throw new TypeError(`OpenAI Responses replay references missing block ${entry.block_id}`);
+        const raw = rawAt(payload, entry);
+        if (entry.kind === 'tool_call') {
+            if (
+                semantic.type !== 'tool_call' ||
+                raw.call_id !== semantic.call_id ||
+                raw.name !== semantic.tool_name ||
+                typeof raw.arguments !== 'string'
+            ) {
+                throw new TypeError(
+                    `OpenAI Responses replay tool call ${entry.block_id} no longer matches canonical data`,
+                );
+            }
+            let parsedArguments: unknown;
+            try {
+                parsedArguments = JSON.parse(raw.arguments);
+            } catch {
+                parsedArguments = undefined;
+            }
+            const argumentsMatch =
+                semantic.arguments.type === 'invalid'
+                    ? semantic.arguments.raw === raw.arguments
+                    : stableJson(semantic.arguments.value) === stableJson(parsedArguments);
+            if (!argumentsMatch) {
+                throw new TypeError(`OpenAI Responses replay tool call ${entry.block_id} has changed arguments`);
+            }
+        } else if (entry.kind === 'asset') {
+            if ((semantic.type !== 'image' && semantic.type !== 'document') || semantic.asset_id !== entry.asset_id) {
+                throw new TypeError(`OpenAI Responses replay asset ${entry.block_id} no longer matches canonical data`);
+            }
+            const asset = document.assets[entry.asset_id];
+            if (asset === undefined)
+                throw new Error(`OpenAI Responses replay references missing asset ${entry.asset_id}`);
+            if (raw.type === 'image_generation_call') {
+                const expected = asset.storage.type === 'inline_base64' ? asset.storage.data : undefined;
+                const parsed = typeof raw.result === 'string' ? dataUrl(raw.result) : undefined;
+                const actual = typeof raw.result === 'string' ? (parsed?.data ?? raw.result) : undefined;
+                const actualMimeType = parsed?.mime_type ?? 'image/png';
+                if (expected === undefined || actual !== expected || asset.mime_type !== actualMimeType) {
+                    throw new TypeError(
+                        `OpenAI Responses replay image ${entry.asset_id} no longer matches canonical data`,
+                    );
+                }
+            } else if (raw.type === 'function_call_output') {
+                const part = Array.isArray(raw.output) ? raw.output[entry.content_index] : undefined;
+                if (stableJson(providerJsonValue(assetToInputPart(asset, target))) !== stableJson(part)) {
+                    throw new TypeError(
+                        `OpenAI Responses replay asset ${entry.asset_id} no longer matches canonical data`,
+                    );
+                }
+            }
+        } else {
+            let semanticText: string;
+            if (entry.kind === 'reasoning') {
+                if (semantic.type !== 'reasoning') {
+                    throw new TypeError(
+                        `OpenAI Responses replay text ${entry.block_id} has incompatible canonical data`,
+                    );
+                }
+                semanticText = semantic.text;
+            } else {
+                if (semantic.type !== 'text') {
+                    throw new TypeError(
+                        `OpenAI Responses replay text ${entry.block_id} has incompatible canonical data`,
+                    );
+                }
+                semanticText = semantic.text;
+            }
+            let text: unknown;
+            if (raw.type === 'function_call_output') {
+                const part = Array.isArray(raw.output) ? raw.output[entry.content_index] : undefined;
+                text =
+                    typeof part === 'object' && part !== null && !Array.isArray(part)
+                        ? ownValue(part, 'text')
+                        : entry.content_index === 0 && typeof raw.output === 'string'
+                          ? raw.output
+                          : undefined;
+            } else if (entry.kind === 'reasoning') {
+                const collection =
+                    semantic.type === 'reasoning' && semantic.representation === 'summary' ? raw.summary : raw.content;
+                const part = Array.isArray(collection) ? collection[entry.content_index] : undefined;
+                text =
+                    typeof part === 'object' && part !== null && !Array.isArray(part)
+                        ? ownValue(part, 'text')
+                        : undefined;
+            } else if (typeof raw.content === 'string' && entry.content_index === 0) {
+                text = raw.content;
+            } else {
+                const part = Array.isArray(raw.content) ? raw.content[entry.content_index] : undefined;
+                text =
+                    typeof part === 'object' && part !== null && !Array.isArray(part)
+                        ? ownValue(part, 'text')
+                        : undefined;
+            }
+            if (text !== semanticText) {
+                throw new TypeError(`OpenAI Responses replay text ${entry.block_id} no longer matches canonical data`);
+            }
+        }
+    }
+}
+
+function replayItems(
+    turn: ConversationTurn,
+    document: ConversationDocument,
+    target?: { provider?: string; model?: string },
+): OpenAIResponsesInputItem[] | undefined {
+    const replayBlocks: Array<Extract<ContentBlock, { type: 'native_replay' }>> = [];
+    for (const block of turn.blocks) {
+        if (block.type === 'native_replay') replayBlocks.push(block);
+        if (block.type === 'tool_result') {
+            for (const nested of block.content) if (nested.type === 'native_replay') replayBlocks.push(nested);
+        }
+    }
+    const foreign = replayBlocks.find((block) => block.protocol !== OPENAI_RESPONSES_PROTOCOL);
+    if (foreign !== undefined) {
+        throw new TypeError(`OpenAI Responses cannot discard protected ${foreign.protocol} replay block ${foreign.id}`);
+    }
+    const matching = replayBlocks.filter((block) => block.protocol === OPENAI_RESPONSES_PROTOCOL);
+    if (matching.length > 1) throw new TypeError(`OpenAI Responses turn ${turn.id} has multiple replay blocks`);
+    const replay = matching[0];
+    if (replay === undefined) return undefined;
+    assertReplayScope(replay, target);
+    const payload = rawReplayPayload(replay);
+    assertReplaySemantics(turn, document, replay, payload, target);
+    return providerJsonValue(payload.items) as unknown as OpenAIResponsesInputItem[];
+}
+
+function compileOrdinaryTurn(
+    turn: ConversationTurn,
+    document: ConversationDocument,
+    target?: { provider?: string },
+): OpenAIResponsesInputItem[] {
+    if (turn.kind === 'tool') {
+        const result = turn.blocks[0];
+        const parts = result.content.flatMap((block): OpenAI.Responses.ResponseInputContent[] => {
+            if (block.type === 'native_replay') return [];
+            if (block.type === 'extension' && block.model_projection === 'excluded') return [];
+            return [ordinaryBlockToPart(block, document, target)];
+        });
+        const output: string | OpenAI.Responses.ResponseInputContent[] =
+            parts.length === 1 && parts[0].type === 'input_text' ? parts[0].text : parts;
+        return [{ type: 'function_call_output', call_id: result.call_id, output }];
+    }
+    const parts = turn.blocks.flatMap((block): OpenAI.Responses.ResponseInputContent[] => {
+        if (block.type === 'extension' && block.model_projection === 'excluded') return [];
+        if (block.type === 'native_replay') return [];
+        if (block.type === 'tool_call' || block.type === 'reasoning') {
+            throw new TypeError(
+                `OpenAI Responses requires protected replay for canonical ${block.type} block ${block.id}`,
+            );
+        }
+        return [ordinaryBlockToPart(block, document, target)];
+    });
+    const content: string | OpenAI.Responses.ResponseInputContent[] =
+        parts.length === 1 && parts[0].type === 'input_text' ? parts[0].text : parts;
+    const role =
+        turn.kind === 'program' && turn.authority === 'system'
+            ? 'system'
+            : turn.kind === 'program' && turn.authority === 'developer'
+              ? 'developer'
+              : turn.kind === 'agent'
+                ? 'assistant'
+                : 'user';
+    return [{ role, content } as OpenAIResponsesInputItem];
+}
+
+export function compileOpenAIResponsesConversation(
+    document: ConversationDocument,
+    target?: { provider?: string; model?: string },
+): { conversation: OpenAIResponsesInputItem[]; mappings: NativeItemMapping[] } {
+    const conversation: OpenAIResponsesInputItem[] = [];
+    const mappings: NativeItemMapping[] = [];
+    for (const turn of selectedCanonicalTurns(document, {
+        allow_interrupted_with_replay_protocol: OPENAI_RESPONSES_PROTOCOL,
+    })) {
+        const items = replayItems(turn, document, target) ?? compileOrdinaryTurn(turn, document, target);
+        const itemIndex = conversation.length;
+        conversation.push(...items);
+        mappings.push({ canonical_id: turn.id, native_id: `items/${itemIndex}`, kind: 'turn' });
+        for (const block of turn.blocks) {
+            mappings.push({
+                canonical_id: block.id,
+                native_id: `items/${itemIndex}/blocks/${block.id}`,
+                kind: 'block',
+            });
+            if (block.type === 'tool_call')
+                mappings.push({ canonical_id: block.call_id, native_id: block.call_id, kind: 'call' });
+            if (block.type === 'tool_result')
+                mappings.push({ canonical_id: block.call_id, native_id: block.call_id, kind: 'call' });
+        }
+    }
+    return { conversation, mappings };
+}
+
+export async function prepareOpenAIResponsesCanonicalState(input: {
+    conversation: unknown;
+    prompt: OpenAIResponsesInputItem[];
+    options: ExecutionOptions;
+    provider: string;
+}): Promise<Omit<PreparedOpenAIResponsesConversation, 'payload' | 'receipt' | 'diagnostics'>> {
+    const runtime = resolveConversationRuntime(input.options);
+    const toolDefinitions = await canonicalToolDefinitions(input.options.tools);
+    let document = parseCanonicalConversation(input.conversation);
+    if (document === undefined) {
+        document = newCanonicalConversation(runtime);
+        if (input.conversation !== undefined && input.conversation !== null) {
+            if (!isOpenAIResponsesHistory(input.conversation, OPENAI_RESPONSES_PROTOCOL)) {
+                throw new TypeError('Conversation is neither canonical nor registered OpenAI Responses history');
+            }
+            const imported = await itemsToRecords({
+                items: wrappedHistoryItems(input.conversation) ?? [],
+                scope: `${runtime.conversation_id}:legacy`,
+                source: 'imported',
+                runtime,
+                provider: input.provider,
+                model: input.options.model,
+                tool_definitions: toolDefinitions,
+                ...(sourceHistoryTurnNumber(input.conversation) === undefined
+                    ? {}
+                    : { source_history_turn_number: sourceHistoryTurnNumber(input.conversation) }),
+            });
+            const contextEntries = await Promise.all(
+                imported.turns.map(async (turn, index) => ({
+                    id: await entityId('context', `${runtime.conversation_id}:legacy`, index),
+                    type: 'source_turn' as const,
+                    turn_id: turn.id,
+                })),
+            );
+            document = appendConversationRecords(
+                document,
+                {
+                    turns: imported.turns,
+                    assets: imported.assets,
+                    tool_definitions: toolDefinitions,
+                    context_entries: contextEntries,
+                    execution_receipts: imported.execution_receipts,
+                },
+                {
+                    expected_revision: document.revision,
+                    operation_id: await entityId('import', runtime.conversation_id, OPENAI_RESPONSES_PROTOCOL),
+                    payload_fingerprint: await fingerprintJson(providerJsonValue(input.conversation)),
+                    recorded_at: runtime.recorded_at,
+                },
+            ).document;
+        }
+    } else if (
+        runtime.conversation_id !== document.id &&
+        input.options.conversation_runtime?.conversation_id !== undefined
+    ) {
+        throw new Error('conversation_runtime.conversation_id does not match the canonical document');
+    }
+
+    const target = { provider: input.provider, model: input.options.model };
+    const priorNativeItemCount = compileOpenAIResponsesConversation(document, target).conversation.length;
+    const received = await itemsToRecords({
+        items: input.prompt,
+        scope: runtime.input_operation_id,
+        source: 'received',
+        runtime: { ...runtime, conversation_id: document.id },
+        provider: input.provider,
+        model: input.options.model,
+        tool_definitions: toolDefinitions,
+    });
+    const contextEntries = await Promise.all(
+        received.turns.map(async (turn, index) => ({
+            id: await entityId('context', runtime.input_operation_id, index),
+            type: 'source_turn' as const,
+            turn_id: turn.id,
+        })),
+    );
+    const appended = await appendCanonicalPrompt(
+        document,
+        { ...received, context_entries: contextEntries, item_mappings: received.mappings },
+        { ...runtime, conversation_id: document.id },
+        input.options.tools,
+        providerJsonValue(input.prompt),
+    );
+    const compiled = compileOpenAIResponsesConversation(appended.document, target);
+    const acceptedResponse = acceptedCanonicalResponse(appended.document, runtime.response_operation_id);
+    if (
+        acceptedResponse !== undefined &&
+        (acceptedResponse.generation.request_id !== runtime.request_id ||
+            acceptedResponse.generation.provider !== input.provider ||
+            acceptedResponse.generation.protocol !== OPENAI_RESPONSES_PROTOCOL ||
+            acceptedResponse.generation.requested_model !== input.options.model)
+    ) {
+        throw new Error(
+            `Accepted response operation ${runtime.response_operation_id} has incompatible request identity`,
+        );
+    }
+    const identities =
+        acceptedResponse === undefined
+            ? await canonicalResponseIdentities(runtime)
+            : { generation_id: acceptedResponse.generation.id, response_turn_id: acceptedResponse.turn.id };
+    return {
+        document: appended.document,
+        native_conversation: compiled.conversation,
+        runtime: { ...runtime, conversation_id: document.id },
+        generation_id: identities.generation_id,
+        response_turn_id: identities.response_turn_id,
+        tool_definitions: appended.tool_definitions,
+        provider: input.provider,
+        requested_model: input.options.model,
+        prior_native_item_count: priorNativeItemCount,
+        ...(acceptedResponse === undefined ? {} : { accepted_response: acceptedResponse }),
+    };
+}
+
+export async function finalizeOpenAIResponsesPreparedRequest(
+    state: Omit<PreparedOpenAIResponsesConversation, 'payload' | 'receipt' | 'diagnostics'>,
+    payload: OpenAIResponsesPayload,
+): Promise<PreparedOpenAIResponsesConversation> {
+    const model = state.requested_model;
+    const compiled = compileOpenAIResponsesConversation(state.document, { provider: state.provider, model });
+    const receipt = await createRequestReceipt(
+        state.document,
+        state.runtime,
+        {
+            provider: state.provider,
+            protocol: OPENAI_RESPONSES_PROTOCOL,
+            model,
+            adapter_version: OPENAI_RESPONSES_ADAPTER_VERSION,
+        },
+        providerJsonValue(payload),
+        compiled.mappings,
+        state.tool_definitions,
+    );
+    return { ...state, payload, receipt, diagnostics: [] };
+}
+
+function safeUsageNumber(value: unknown): number | undefined {
+    return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 ? value : undefined;
+}
+
+type OpenAIResponsesUsageLike = OpenAI.Responses.ResponseUsage & {
+    cached_tokens?: number | null;
+    cache_write_tokens?: number | null;
+    prompt_tokens_details?: { cached_tokens?: number | null; cache_write_tokens?: number | null } | null;
+    input_tokens_details?: OpenAI.Responses.ResponseUsage['input_tokens_details'] & {
+        cache_write_tokens?: number | null;
+    };
+};
+
+function openAIResponsesUsage(native: OpenAI.Responses.ResponseUsage | null | undefined): GenerationUsage | undefined {
+    if (native == null) return undefined;
+    const details = native as OpenAIResponsesUsageLike;
+    const input = safeUsageNumber(native.input_tokens);
+    const output = safeUsageNumber(native.output_tokens);
+    const reasoningCandidate = safeUsageNumber(native.output_tokens_details?.reasoning_tokens);
+    const reasoning =
+        reasoningCandidate !== undefined && (output === undefined || reasoningCandidate <= output)
+            ? reasoningCandidate
+            : undefined;
+    const cacheReadCandidate = safeUsageNumber(
+        details.input_tokens_details?.cached_tokens ??
+            details.prompt_tokens_details?.cached_tokens ??
+            details.cached_tokens,
+    );
+    const cacheRead =
+        input !== undefined && cacheReadCandidate !== undefined && cacheReadCandidate <= input
+            ? cacheReadCandidate
+            : undefined;
+    const cacheWrite = safeUsageNumber(
+        details.input_tokens_details?.cache_write_tokens ??
+            details.prompt_tokens_details?.cache_write_tokens ??
+            details.cache_write_tokens,
+    );
+    const total =
+        input !== undefined && output !== undefined && Number.isSafeInteger(input + output)
+            ? input + output
+            : undefined;
+    const inputNewCandidate =
+        input !== undefined && cacheRead !== undefined ? input - cacheRead - (cacheWrite ?? 0) : undefined;
+    const inputNew = inputNewCandidate !== undefined && inputNewCandidate >= 0 ? inputNewCandidate : undefined;
+    const basis = 'openai_responses_tokens';
+    return {
+        ...(input === undefined ? {} : { input_tokens: input }),
+        ...(output === undefined ? {} : { output_tokens: output }),
+        ...(reasoning === undefined ? {} : { reasoning_tokens: reasoning }),
+        ...(total === undefined ? {} : { total_tokens: total }),
+        ...(cacheRead === undefined ? {} : { cache_read_tokens: cacheRead }),
+        ...(cacheWrite === undefined ? {} : { cache_write_tokens: cacheWrite }),
+        ...(inputNew === undefined ? {} : { input_new_tokens: inputNew }),
+        accounting_provenance: {
+            ...(input === undefined ? {} : { input_tokens: { method: 'reported' as const, accounting_basis: basis } }),
+            ...(output === undefined
+                ? {}
+                : { output_tokens: { method: 'reported' as const, accounting_basis: basis } }),
+            ...(reasoning === undefined
+                ? {}
+                : { reasoning_tokens: { method: 'reported' as const, accounting_basis: basis } }),
+            ...(total === undefined ? {} : { total_tokens: { method: 'derived' as const, accounting_basis: basis } }),
+            ...(cacheRead === undefined
+                ? {}
+                : { cache_read_tokens: { method: 'reported' as const, accounting_basis: basis } }),
+            ...(cacheWrite === undefined
+                ? {}
+                : { cache_write_tokens: { method: 'reported' as const, accounting_basis: basis } }),
+            ...(inputNew === undefined
+                ? {}
+                : { input_new_tokens: { method: 'derived' as const, accounting_basis: basis } }),
+        },
+        ...(inputNew === undefined
+            ? {}
+            : {
+                  input_partition: {
+                      type: 'complete_disjoint',
+                      cache_write_bucket: cacheWrite === undefined ? 'inapplicable' : 'included',
+                  },
+              }),
+        reported_usage: [
+            {
+                source: 'provider',
+                protocol: OPENAI_RESPONSES_PROTOCOL,
+                accounting_basis: basis,
+                payload: providerJsonValue(native),
+            },
+        ],
+    };
+}
+
+export async function decodeOpenAIResponsesCanonicalResponse(input: {
+    response: OpenAI.Responses.Response;
+    prepared: PreparedOpenAIResponsesConversation;
+    fallback_items?: OpenAIResponsesInputItem[];
+}): Promise<DecodedConversationResponse> {
+    const { response, prepared } = input;
+    if (response.status !== 'completed' && response.status !== 'incomplete') {
+        throw new Error(`OpenAI Responses response ${response.id} is not a completed terminal response`);
+    }
+    const items = response.output.length > 0 ? response.output : (input.fallback_items ?? []);
+    const completedAt = prepared.runtime.completed_at ?? new Date().toISOString();
+    const records = await assistantItemsRecords({
+        items: providerJsonValue(items) as unknown as Record<string, unknown>[],
+        first_item_index: 0,
+        scope: prepared.runtime.response_operation_id,
+        source: 'received',
+        runtime: { ...prepared.runtime, recorded_at: completedAt },
+        provider: prepared.provider,
+        model: prepared.requested_model,
+        tool_definitions: prepared.tool_definitions,
+    });
+    const received = records.turns[0];
+    if (received?.kind !== 'agent') throw new Error('OpenAI Responses response did not decode to an agent turn');
+    const hasTools = received.blocks.some((block) => block.type === 'tool_call');
+    const finishReason = hasTools
+        ? 'tool_use'
+        : response.status === 'incomplete'
+          ? response.incomplete_details?.reason === 'max_output_tokens'
+              ? 'length'
+              : (response.incomplete_details?.reason ?? 'incomplete')
+          : 'stop';
+    const turn: ConversationTurn = {
+        ...received,
+        id: prepared.response_turn_id,
+        status: response.status === 'incomplete' ? 'interrupted' : 'completed',
+        timestamps: {
+            recorded_at: completedAt,
+            ...(prepared.runtime.started_at === undefined ? {} : { started_at: prepared.runtime.started_at }),
+            completed_at: completedAt,
+        },
+        provenance: { type: 'generated' },
+        generation_id: prepared.generation_id,
+        blocks: received.blocks.map((block) =>
+            block.type !== 'native_replay'
+                ? block
+                : {
+                      ...block,
+                      dependencies: {
+                          ...block.dependencies,
+                          turn_ids: [prepared.response_turn_id],
+                          request_ids: [prepared.receipt.request_id],
+                      },
+                  },
+        ),
+    };
+    const baseGeneration = await createExecutedGeneration({
+        id: prepared.generation_id,
+        runtime: prepared.runtime,
+        receipt: prepared.receipt,
+        provider: prepared.provider,
+        protocol: OPENAI_RESPONSES_PROTOCOL,
+        adapter_version: OPENAI_RESPONSES_ADAPTER_VERSION,
+        requested_model: prepared.requested_model,
+        resolved_model: response.model,
+        provider_response_id: response.id,
+        finish_reason: finishReason,
+        usage: openAIResponsesUsage(response.usage),
+    });
+    const generation: ExecutedGeneration = {
+        ...baseGeneration,
+        ...(typeof response.service_tier === 'string'
+            ? { metadata: { openai_responses: { service_tier: response.service_tier } } }
+            : {}),
+    };
+    return {
+        turns: [turn],
+        generation,
+        assets: records.assets.map((asset) => ({
+            ...asset,
+            provenance: { type: 'generated', generation_id: generation.id, source_turn_id: turn.id },
+        })),
+        diagnostics: [],
+        payload_fingerprint: await fingerprintJson(providerJsonValue(response)),
+    };
+}
+
+export function appendOpenAIResponsesCanonicalResponse(
+    prepared: PreparedOpenAIResponsesConversation,
+    decoded: DecodedConversationResponse,
+): ConversationDocument {
+    return appendDecodedConversationResponse(prepared, decoded, {
+        operation_id: prepared.runtime.response_operation_id,
+        recorded_at: decoded.generation.timestamps.recorded_at,
+    }).document;
+}
+
+/** Read-only compatibility projection for versioned legacy API responses. */
+export function exportLegacyOpenAIResponsesConversation(document: ConversationDocument): OpenAIResponsesInputItem[] {
+    return compileOpenAIResponsesConversation(parseConversationDocument(document)).conversation;
+}

--- a/drivers/src/openai/openai-responses-lifecycle.test.ts
+++ b/drivers/src/openai/openai-responses-lifecycle.test.ts
@@ -1,0 +1,543 @@
+import { parseConversationDocument } from '@llumiverse/conversation';
+import { type ExecutionOptions, PromptRole, Providers } from '@llumiverse/core';
+import type OpenAI from 'openai';
+import { describe, expect, it, vi } from 'vitest';
+import { OpenAIResponsesDriverBase } from './index.js';
+import {
+    exportLegacyOpenAIResponsesConversation,
+    OPENAI_RESPONSES_PROTOCOL,
+} from './openai-responses-conversation-adapter.js';
+
+class TestOpenAIResponsesDriver extends OpenAIResponsesDriverBase {
+    provider: Providers.openai = Providers.openai;
+    service: OpenAI;
+
+    constructor(create: (request: unknown, options?: unknown) => Promise<unknown>) {
+        super({});
+        this.service = { responses: { create } } as unknown as OpenAI;
+    }
+}
+
+type ResponseStatus = OpenAI.Responses.Response['status'];
+
+const toolDefinition: NonNullable<ExecutionOptions['tools']>[number] = {
+    name: 'lookup_weather',
+    description: 'Look up weather',
+    input_schema: {
+        type: 'object',
+        properties: { city: { type: 'string' } },
+        required: ['city'],
+        additionalProperties: false,
+    },
+};
+
+function messageItem(id: string, text: string, status: 'completed' | 'incomplete' = 'completed') {
+    return {
+        type: 'message' as const,
+        id,
+        role: 'assistant' as const,
+        status,
+        content: [
+            {
+                type: 'output_text' as const,
+                text,
+                annotations: [],
+                logprobs: [],
+            },
+        ],
+    };
+}
+
+function response(input: {
+    id: string;
+    output: OpenAI.Responses.ResponseOutputItem[];
+    model?: string;
+    status?: ResponseStatus;
+    inputTokens?: number;
+    outputTokens?: number;
+    cachedTokens?: number;
+    cacheWriteTokens?: number;
+    reasoningTokens?: number;
+}): OpenAI.Responses.Response {
+    const status = input.status ?? 'completed';
+    const inputTokens = input.inputTokens ?? 11;
+    const outputTokens = input.outputTokens ?? 7;
+    return {
+        id: input.id,
+        object: 'response',
+        created_at: 1,
+        model: input.model ?? 'gpt-5',
+        service_tier: 'default',
+        status,
+        output: input.output,
+        output_text: '',
+        parallel_tool_calls: true,
+        tool_choice: 'auto',
+        tools: [],
+        error: status === 'failed' ? { code: 'server_error', message: 'provider failed' } : null,
+        incomplete_details: status === 'incomplete' ? { reason: 'max_output_tokens' } : null,
+        instructions: null,
+        metadata: null,
+        temperature: null,
+        top_p: null,
+        usage: {
+            input_tokens: inputTokens,
+            output_tokens: outputTokens,
+            total_tokens: inputTokens + outputTokens,
+            input_tokens_details: {
+                cached_tokens: input.cachedTokens ?? 0,
+                ...(input.cacheWriteTokens === undefined ? {} : { cache_write_tokens: input.cacheWriteTokens }),
+            },
+            output_tokens_details: { reasoning_tokens: input.reasoningTokens ?? 0 },
+        },
+    } as unknown as OpenAI.Responses.Response;
+}
+
+function runtimeOptions(input: {
+    flow: string;
+    operation: string;
+    attempt: string;
+    recordedAt: string;
+    conversation?: unknown;
+    model?: string;
+}): ExecutionOptions {
+    return {
+        model: input.model ?? 'gpt-5',
+        ...(input.conversation === undefined ? {} : { conversation: input.conversation }),
+        conversation_runtime: {
+            conversation_id: `conversation:${input.flow}`,
+            request_id: `request:${input.flow}:${input.operation}`,
+            attempt_id: `attempt:${input.flow}:${input.attempt}`,
+            input_operation_id: `input:${input.flow}:${input.operation}`,
+            response_operation_id: `response:${input.flow}:${input.operation}`,
+            recorded_at: input.recordedAt,
+            started_at: input.recordedAt,
+        },
+    };
+}
+
+function latestGeneratedText(value: unknown): string | undefined {
+    const document = parseConversationDocument(value);
+    for (let index = document.turns.length - 1; index >= 0; index -= 1) {
+        const turn = document.turns[index];
+        if (turn.kind !== 'agent' || turn.provenance.type !== 'generated') continue;
+        return turn.blocks.find((block) => block.type === 'text')?.text;
+    }
+    return undefined;
+}
+
+async function consume(stream: AsyncIterable<string>): Promise<string> {
+    let text = '';
+    for await (const chunk of stream) text += chunk;
+    return text;
+}
+
+describe('OpenAI Responses canonical lifecycle', () => {
+    it('validates structured sync output, retains exact native data, and recovers a persisted retry', async () => {
+        const rawText = '{ "answer" : "Tokyo", "note" : null }';
+        const output = [
+            {
+                ...messageItem('message:structured', rawText),
+                content: [
+                    {
+                        type: 'output_text' as const,
+                        text: rawText,
+                        annotations: [
+                            {
+                                type: 'url_citation' as const,
+                                start_index: 13,
+                                end_index: 20,
+                                title: 'Tokyo',
+                                url: 'https://example.com/tokyo',
+                            },
+                        ],
+                        logprobs: [],
+                    },
+                ],
+            },
+        ] satisfies OpenAI.Responses.ResponseOutputItem[];
+        const nativeResponse = response({
+            id: 'response:structured',
+            output,
+            inputTokens: 100,
+            outputTokens: 20,
+            cachedTokens: 25,
+            cacheWriteTokens: 5,
+            reasoningTokens: 7,
+        });
+        const create = vi.fn(async (_request: unknown, _options?: unknown) => nativeResponse);
+        const driver = new TestOpenAIResponsesDriver(create);
+        const segments = [{ role: PromptRole.user, content: 'Return the city as JSON.' }];
+        const resultSchema: NonNullable<ExecutionOptions['result_schema']> = {
+            type: 'object',
+            properties: { answer: { type: 'string' }, note: { type: 'null' } },
+            required: ['answer', 'note'],
+            additionalProperties: false,
+        };
+        const firstOptions = {
+            ...runtimeOptions({
+                flow: 'structured',
+                operation: 'generate',
+                attempt: 'first',
+                recordedAt: '2026-09-12T00:00:00.000Z',
+            }),
+            result_schema: resultSchema,
+        };
+
+        const first = await driver.execute(segments, firstOptions);
+
+        expect(first.result).toEqual([{ type: 'json', value: { answer: 'Tokyo', note: null } }]);
+        expect(latestGeneratedText(first.conversation)).toBe(rawText);
+        const document = parseConversationDocument(JSON.parse(JSON.stringify(first.conversation)));
+        const generation = Object.values(document.generations).find(
+            (candidate) => candidate.record_source === 'executed',
+        );
+        expect(generation).toMatchObject({
+            provider: 'openai',
+            protocol: OPENAI_RESPONSES_PROTOCOL,
+            requested_model: 'gpt-5',
+            resolved_model: 'gpt-5',
+            provider_response_id: 'response:structured',
+            usage: {
+                input_tokens: 100,
+                output_tokens: 20,
+                reasoning_tokens: 7,
+                cache_read_tokens: 25,
+                cache_write_tokens: 5,
+                input_new_tokens: 70,
+                total_tokens: 120,
+            },
+        });
+        expect(exportLegacyOpenAIResponsesConversation(document).at(-1)).toEqual(output[0]);
+
+        const retried = await driver.execute(segments, {
+            ...runtimeOptions({
+                flow: 'structured',
+                operation: 'generate',
+                attempt: 'retry',
+                recordedAt: '2026-09-12T00:05:00.000Z',
+                conversation: document,
+            }),
+            result_schema: resultSchema,
+        });
+
+        expect(retried.result).toEqual(first.result);
+        expect(retried.token_usage).toEqual(first.token_usage);
+        expect(retried.service_tier).toBe(first.service_tier);
+        expect(retried.conversation).toEqual(document);
+        expect(create).toHaveBeenCalledTimes(1);
+    });
+
+    it('preserves tool result status internally, projects rich continuation, and recovers its accepted response', async () => {
+        const callItem = {
+            type: 'function_call' as const,
+            id: 'item:lookup',
+            call_id: 'call:lookup',
+            name: 'lookup_weather',
+            arguments: '{ "city" : "Tokyo", "units" : null }',
+            status: 'completed' as const,
+        };
+        const responses = [
+            response({ id: 'response:tool-call', output: [callItem] }),
+            response({ id: 'response:tool-result', output: [messageItem('message:tool-result', 'Try again later.')] }),
+        ];
+        const create = vi.fn(async (_request: unknown, _options?: unknown) => {
+            const next = responses.shift();
+            if (!next) throw new Error('Unexpected provider call');
+            return next;
+        });
+        const driver = new TestOpenAIResponsesDriver(create);
+        const tools = [toolDefinition];
+        const first = await driver.execute([{ role: PromptRole.user, content: 'Weather in Tokyo?' }], {
+            ...runtimeOptions({
+                flow: 'tools',
+                operation: 'ask',
+                attempt: 'ask',
+                recordedAt: '2026-09-12T01:00:00.000Z',
+            }),
+            tools,
+        });
+        expect(first.tool_use).toEqual([
+            { id: 'call:lookup', tool_name: 'lookup_weather', tool_input: { city: 'Tokyo', units: null } },
+        ]);
+
+        const resultSegments = [
+            {
+                role: PromptRole.tool,
+                content: '{"error":"weather service unavailable"}',
+                tool_use_id: 'call:lookup',
+                tool_result_status: 'error' as const,
+            },
+        ];
+        const second = await driver.execute(resultSegments, {
+            ...runtimeOptions({
+                flow: 'tools',
+                operation: 'answer',
+                attempt: 'answer',
+                recordedAt: '2026-09-12T01:01:00.000Z',
+                conversation: first.conversation,
+            }),
+            tools,
+        });
+        const secondRequest = create.mock.calls[1]?.[0] as { input?: Array<Record<string, unknown>> };
+        const projectedResult = secondRequest.input?.find((item) => item.type === 'function_call_output');
+        expect(projectedResult).toEqual({
+            type: 'function_call_output',
+            call_id: 'call:lookup',
+            output: '{"error":"weather service unavailable"}',
+        });
+        expect(JSON.stringify(secondRequest)).not.toContain('_llumiverse_tool_result_status');
+
+        const persisted = parseConversationDocument(JSON.parse(JSON.stringify(second.conversation)));
+        const toolTurn = persisted.turns.find((turn) => turn.kind === 'tool');
+        expect(toolTurn?.blocks[0]).toMatchObject({ type: 'tool_result', call_id: 'call:lookup', status: 'error' });
+        expect(
+            Object.values(persisted.execution_receipts).find(
+                (receipt) => receipt.executor === 'application' && receipt.call_id === 'call:lookup',
+            ),
+        ).toMatchObject({ status: 'error' });
+
+        const retried = await driver.execute(resultSegments, {
+            ...runtimeOptions({
+                flow: 'tools',
+                operation: 'answer',
+                attempt: 'answer-retry',
+                recordedAt: '2026-09-12T01:05:00.000Z',
+                conversation: persisted,
+            }),
+            tools,
+        });
+        expect(retried.result).toEqual(second.result);
+        expect(retried.conversation).toEqual(persisted);
+        expect(create).toHaveBeenCalledTimes(2);
+    });
+
+    it('streams reasoning and text through core, finalizes authoritative output, and recovers without transport', async () => {
+        const reasoningItem = {
+            type: 'reasoning' as const,
+            id: 'reasoning:stream',
+            summary: [{ type: 'summary_text' as const, text: 'Check the evidence.' }],
+            encrypted_content: 'opaque-stream-reasoning',
+            status: 'completed' as const,
+        };
+        const final = response({
+            id: 'response:stream',
+            output: [reasoningItem, messageItem('message:stream', 'It is clear.')],
+            reasoningTokens: 4,
+        });
+        const create = vi.fn(async (_request: unknown, _options?: unknown) =>
+            (async function* () {
+                yield {
+                    type: 'response.reasoning_summary_text.delta' as const,
+                    item_id: 'reasoning:stream',
+                    output_index: 0,
+                    summary_index: 0,
+                    sequence_number: 1,
+                    delta: 'Check the evidence.',
+                };
+                yield {
+                    type: 'response.output_text.delta' as const,
+                    item_id: 'message:stream',
+                    output_index: 1,
+                    content_index: 0,
+                    sequence_number: 2,
+                    delta: 'It is clear.',
+                    logprobs: [],
+                };
+                yield { type: 'response.completed' as const, sequence_number: 3, response: final };
+            })(),
+        );
+        const driver = new TestOpenAIResponsesDriver(create);
+        const segments = [{ role: PromptRole.user, content: 'Explain.' }];
+        const firstOptions = {
+            ...runtimeOptions({
+                flow: 'stream',
+                operation: 'generate',
+                attempt: 'first',
+                recordedAt: '2026-09-12T02:00:00.000Z',
+            }),
+            model_options: { _option_id: 'openai-thinking' as const },
+        };
+
+        const first = await driver.stream(segments, firstOptions);
+        expect(await consume(first)).toBe('Check the evidence.\nIt is clear.');
+        expect(first.completion?.result).toEqual([
+            { type: 'thoughts', value: 'Check the evidence.' },
+            { type: 'text', value: 'It is clear.' },
+        ]);
+        const persisted = parseConversationDocument(JSON.parse(JSON.stringify(first.completion?.conversation)));
+        expect(JSON.stringify(persisted)).toContain('opaque-stream-reasoning');
+
+        const retried = await driver.stream(segments, {
+            ...runtimeOptions({
+                flow: 'stream',
+                operation: 'generate',
+                attempt: 'retry',
+                recordedAt: '2026-09-12T02:05:00.000Z',
+                conversation: persisted,
+            }),
+            model_options: { _option_id: 'openai-thinking' as const },
+        });
+        expect(await consume(retried)).toBe('Check the evidence.\nIt is clear.');
+        expect(retried.completion?.conversation).toEqual(persisted);
+        expect(create).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([
+        ['truncated', undefined],
+        ['failed', 7],
+    ] as const)('does not persist a canonical response when a stream is %s', async (failure, billedOutputTokens) => {
+        const failed = response({
+            id: 'response:failed-stream',
+            output: [messageItem('message:failed-stream', 'partial')],
+            status: 'failed',
+            outputTokens: billedOutputTokens ?? 0,
+        });
+        const create = vi.fn(async (_request: unknown, _options?: unknown) =>
+            (async function* () {
+                yield {
+                    type: 'response.output_text.delta' as const,
+                    item_id: 'message:failed-stream',
+                    output_index: 0,
+                    content_index: 0,
+                    sequence_number: 1,
+                    delta: 'partial',
+                    logprobs: [],
+                };
+                if (failure === 'failed') {
+                    yield { type: 'response.failed' as const, sequence_number: 2, response: failed };
+                }
+            })(),
+        );
+        const driver = new TestOpenAIResponsesDriver(create);
+        const stream = await driver.stream([{ role: PromptRole.user, content: 'Continue.' }], {
+            ...runtimeOptions({
+                flow: `stream-${failure}`,
+                operation: 'generate',
+                attempt: 'first',
+                recordedAt: '2026-09-12T03:00:00.000Z',
+            }),
+        });
+
+        await expect(consume(stream)).rejects.toThrow(
+            failure === 'failed' ? 'provider failed' : 'ended without a final response',
+        );
+        expect(stream.completion?.conversation).toBeUndefined();
+        if (billedOutputTokens !== undefined) {
+            expect(stream.completion?.token_usage?.result).toBe(billedOutputTokens);
+        }
+    });
+
+    it('retains an incomplete native turn and replays it for a later Responses continuation', async () => {
+        const partialItem = messageItem('message:partial', 'First,', 'incomplete');
+        const partial = response({ id: 'response:partial', output: [partialItem], status: 'incomplete' });
+        const completed = response({
+            id: 'response:continued',
+            output: [messageItem('message:continued', 'the rest follows.')],
+        });
+        const create = vi.fn(async (request: unknown, _options?: unknown) => {
+            if ((request as { stream?: boolean }).stream) {
+                return (async function* () {
+                    yield {
+                        type: 'response.output_text.delta' as const,
+                        item_id: 'message:partial',
+                        output_index: 0,
+                        content_index: 0,
+                        sequence_number: 1,
+                        delta: 'First,',
+                        logprobs: [],
+                    };
+                    yield { type: 'response.incomplete' as const, sequence_number: 2, response: partial };
+                })();
+            }
+            return completed;
+        });
+        const driver = new TestOpenAIResponsesDriver(create);
+        const first = await driver.stream([{ role: PromptRole.user, content: 'Start an explanation.' }], {
+            ...runtimeOptions({
+                flow: 'partial',
+                operation: 'start',
+                attempt: 'start',
+                recordedAt: '2026-09-12T04:00:00.000Z',
+            }),
+        });
+        await consume(first);
+        expect(first.completion?.finish_reason).toBe('length');
+        const partialDocument = parseConversationDocument(first.completion?.conversation);
+        expect(partialDocument.turns.at(-1)?.status).toBe('interrupted');
+
+        const continuation = await driver.execute([{ role: PromptRole.user, content: 'Continue.' }], {
+            ...runtimeOptions({
+                flow: 'partial',
+                operation: 'continue',
+                attempt: 'continue',
+                recordedAt: '2026-09-12T04:01:00.000Z',
+                conversation: partialDocument,
+            }),
+        });
+        const continuationRequest = create.mock.calls[1]?.[0] as { input?: unknown[] };
+        expect(continuationRequest.input).toEqual(expect.arrayContaining([partialItem]));
+        expect(continuation.result).toEqual([{ type: 'text', value: 'the rest follows.' }]);
+    });
+
+    it('applies request-only history retention and prompt transforms without rewriting canonical source', async () => {
+        const nativeHistory = {
+            _arrayConversation: [{ role: 'user' as const, content: '<heartbeat>old status</heartbeat>' }],
+            _llumiverse_meta: { turnNumber: 20 },
+        };
+        const currentPrompt = [
+            {
+                type: 'message' as const,
+                role: 'system' as const,
+                content: [
+                    { type: 'input_text' as const, text: 'Inspect this image.' },
+                    {
+                        type: 'input_image' as const,
+                        image_url: 'data:image/png;base64,aW1hZ2U=',
+                        detail: 'auto' as const,
+                    },
+                ],
+            },
+        ];
+        const create = vi.fn(async (_request: unknown, _options?: unknown) =>
+            response({ id: 'response:projection', output: [messageItem('message:projection', 'Done.')], model: 'o1' }),
+        );
+        const driver = new TestOpenAIResponsesDriver(create);
+
+        const completion = await driver.requestTextCompletion(currentPrompt, {
+            ...runtimeOptions({
+                flow: 'projection',
+                operation: 'generate',
+                attempt: 'first',
+                recordedAt: '2026-09-12T05:00:00.000Z',
+                conversation: nativeHistory,
+                model: 'o1',
+            }),
+            stripHeartbeatsAfterTurns: 1,
+            model_options: { _option_id: 'openai-thinking', image_detail: 'high' },
+        });
+        const request = create.mock.calls[0]?.[0] as { input?: unknown[] };
+        expect(request.input).toEqual([
+            { role: 'user', content: '[Heartbeat removed from conversation history]' },
+            {
+                role: 'developer',
+                content: [
+                    { type: 'input_text', text: 'Inspect this image.' },
+                    { type: 'input_image', image_url: 'data:image/png;base64,aW1hZ2U=', detail: 'high' },
+                ],
+            },
+        ]);
+
+        const projected = exportLegacyOpenAIResponsesConversation(parseConversationDocument(completion.conversation));
+        expect(projected.slice(0, 2)).toEqual([
+            { role: 'user', content: '<heartbeat>old status</heartbeat>' },
+            {
+                role: 'system',
+                content: [
+                    { type: 'input_text', text: 'Inspect this image.' },
+                    { type: 'input_image', image_url: 'data:image/png;base64,aW1hZ2U=', detail: 'auto' },
+                ],
+            },
+        ]);
+    });
+});

--- a/drivers/src/openai/openai_chat_completions.test.ts
+++ b/drivers/src/openai/openai_chat_completions.test.ts
@@ -1,10 +1,20 @@
-import { type CompletionChunkObject, type ExecutionOptions, getConversationMeta } from '@llumiverse/core';
+import { type ConversationDocument, parseConversationDocument } from '@llumiverse/conversation';
+import {
+    type AIModel,
+    type CompletionChunkObject,
+    type EmbeddingsOptions,
+    type EmbeddingsResult,
+    type ExecutionOptions,
+    type ModelSearchPayload,
+    PromptRole,
+} from '@llumiverse/core';
 import type { ServerSentEvent } from '@vertesia/api-fetch-client';
 import type OpenAI from 'openai';
 import { describe, expect, it, vi } from 'vitest';
 import {
     normalizeOpenAIChatCompletionsResponse,
     normalizeOpenAIChatCompletionsStream,
+    OpenAIChatCompletionsDriverBase,
     type OpenAIChatCompletionsPayload,
     type OpenAIChatCompletionsPrompt,
     OpenAIChatCompletionsProtocol,
@@ -14,6 +24,7 @@ import {
     parseOpenAIChatCompletionsToolCalls,
     prepareOpenAIChatCompletionsConversation,
 } from './openai_chat_completions.js';
+import { exportLegacyOpenAIChatCompletionsConversation } from './openai-chat-conversation-adapter.js';
 
 const streamChunk = {
     id: 'chatcmpl-stream',
@@ -99,6 +110,21 @@ async function collectChunks(stream: AsyncIterable<CompletionChunkObject>): Prom
     return chunks;
 }
 
+function latestGeneratedText(value: unknown): string | undefined {
+    const document = parseConversationDocument(value);
+    for (let index = document.turns.length - 1; index >= 0; index -= 1) {
+        const turn = document.turns[index];
+        if (turn.kind !== 'agent' || turn.provenance.type !== 'generated') continue;
+        return turn.blocks.find((block) => block.type === 'text')?.text;
+    }
+    return undefined;
+}
+
+function latestExecutedGeneration(value: unknown) {
+    const document = parseConversationDocument(value);
+    return Object.values(document.generations).find((generation) => generation.record_source === 'executed');
+}
+
 class TestOpenAIChatCompletionsProtocol extends OpenAIChatCompletionsProtocol<undefined> {
     payloads: OpenAIChatCompletionsPayload[] = [];
 
@@ -133,6 +159,42 @@ class TestOpenAIChatCompletionsProtocol extends OpenAIChatCompletionsProtocol<un
     }
 }
 
+class TestOpenAIChatCompletionsDriver extends OpenAIChatCompletionsDriverBase {
+    readonly provider = 'openai_compatible';
+    readonly payloads: OpenAIChatCompletionsPayload[] = [];
+
+    constructor(
+        private readonly response?: OpenAIChatCompletionsResponse,
+        private readonly responseStream?: ReadableStream,
+    ) {
+        super({});
+    }
+
+    async _postChatCompletion(payload: OpenAIChatCompletionsPayload): Promise<OpenAIChatCompletionsResponse> {
+        this.payloads.push(payload);
+        if (this.response === undefined) throw new Error('Missing test response');
+        return this.response;
+    }
+
+    async _postChatCompletionStream(payload: OpenAIChatCompletionsPayload): Promise<ReadableStream> {
+        this.payloads.push(payload);
+        if (this.responseStream === undefined) throw new Error('Missing test stream');
+        return this.responseStream;
+    }
+
+    async listModels(_params?: ModelSearchPayload): Promise<AIModel[]> {
+        return [];
+    }
+
+    async validateConnection(): Promise<boolean> {
+        return true;
+    }
+
+    async generateEmbeddings(_options: EmbeddingsOptions): Promise<EmbeddingsResult> {
+        return { model: 'test/model', results: [] };
+    }
+}
+
 const prompt: OpenAIChatCompletionsPrompt = {
     _is_openai_chat_completions: true,
     messages: [{ role: 'user', content: 'Hello' }],
@@ -142,6 +204,26 @@ const options: ExecutionOptions = {
     model: 'test/model',
     model_options: { _option_id: 'text-fallback' },
 };
+
+function legacyConversation(value: unknown): OpenAIChatCompletionsPrompt {
+    return exportLegacyOpenAIChatCompletionsConversation(value as ConversationDocument);
+}
+
+function canonicalOptions(attempt: string, recordedAt: string, conversation?: unknown): ExecutionOptions {
+    return {
+        model: 'test/model',
+        ...(conversation === undefined ? {} : { conversation }),
+        conversation_runtime: {
+            conversation_id: 'conversation:structured-output',
+            request_id: 'request:structured-output',
+            attempt_id: attempt,
+            input_operation_id: 'input:structured-output',
+            response_operation_id: 'response:structured-output',
+            recorded_at: recordedAt,
+            started_at: recordedAt,
+        },
+    };
+}
 
 describe('OpenAIChatCompletionsProtocol', () => {
     it('preserves compatible-provider prompt cache usage', async () => {
@@ -180,6 +262,17 @@ describe('OpenAIChatCompletionsProtocol', () => {
             prompt_new: 200,
             result: 20,
             total: 1_020,
+        });
+        expect(latestExecutedGeneration(completion.conversation)?.usage).toMatchObject({
+            input_tokens: 1_000,
+            output_tokens: 20,
+            reasoning_tokens: 0,
+            total_tokens: 1_020,
+            cache_read_tokens: 800,
+            input_new_tokens: 200,
+            accounting_provenance: {
+                reasoning_tokens: { method: 'reported', accounting_basis: 'openai_chat_tokens' },
+            },
         });
     });
 
@@ -461,14 +554,14 @@ describe('OpenAIChatCompletionsProtocol', () => {
             model_options: { _option_id: 'text-fallback', include_thoughts: false },
         });
         expect(hidden.result).toEqual([{ type: 'text', value: 'answer' }]);
-        expect(hidden.conversation).toMatchObject({
+        expect(legacyConversation(hidden.conversation)).toMatchObject({
             messages: expect.arrayContaining([
                 expect.objectContaining({ reasoning_content: 'signed-or-native-reasoning' }),
             ]),
         });
     });
 
-    it('removes DeepSeek R1 reasoning from replay while still projecting it as thoughts', async () => {
+    it('keeps exact DeepSeek R1 reasoning in canonical source while excluding it from the next request', async () => {
         const model = new TestOpenAIChatCompletionsProtocol({
             id: 'chatcmpl-r1',
             object: 'chat.completion',
@@ -493,7 +586,13 @@ describe('OpenAIChatCompletionsProtocol', () => {
             { type: 'thoughts', value: 'visible reasoning' },
             { type: 'text', value: 'answer' },
         ]);
-        expect(JSON.stringify(completion.conversation)).not.toContain('visible reasoning');
+        expect(JSON.stringify(completion.conversation)).toContain('visible reasoning');
+        await model.requestTextCompletion(undefined, prompt, {
+            ...options,
+            model: 'deepseek-ai/deepseek-r1-0528-maas',
+            conversation: completion.conversation,
+        });
+        expect(JSON.stringify(model.payloads[1].messages)).not.toContain('visible reasoning');
     });
 
     it('replays DeepSeek V3.2 reasoning only within the current user tool turn', () => {
@@ -577,7 +676,7 @@ describe('OpenAIChatCompletionsProtocol', () => {
             tools: [{ name: 'lookup', input_schema: { type: 'object' } }],
             stripImagesAfterTurns: 0,
         });
-        const conversation = completion.conversation as OpenAIChatCompletionsPrompt;
+        const conversation = legacyConversation(completion.conversation);
 
         expect(conversation.messages[0]).toEqual(imagePrompt.messages[0]);
         expect(conversation.messages[1].reasoning_content).toBe('tool reasoning');
@@ -677,7 +776,7 @@ describe('OpenAIChatCompletionsProtocol', () => {
             { type: 'thoughts', value: 'hidden reasoning' },
             { type: 'text', value: '{"answer":"Paris"}' },
         ]);
-        expect(completion.conversation).toMatchObject({
+        expect(legacyConversation(completion.conversation)).toMatchObject({
             messages: expect.arrayContaining([
                 expect.objectContaining({
                     role: 'assistant',
@@ -687,7 +786,7 @@ describe('OpenAIChatCompletionsProtocol', () => {
         });
     });
 
-    it('applies conversation stripping and turn metadata to non-streaming completions', async () => {
+    it('applies stripping to the request projection while preserving canonical source media', async () => {
         const model = new TestOpenAIChatCompletionsProtocol({
             id: 'chatcmpl-1',
             object: 'chat.completion',
@@ -722,12 +821,73 @@ describe('OpenAIChatCompletionsProtocol', () => {
             ...options,
             stripImagesAfterTurns: 0,
         });
-        const conversation = completion.conversation as OpenAIChatCompletionsPrompt;
+        expect(JSON.stringify(legacyConversation(completion.conversation).messages[0].content)).toContain('aW1hZ2U=');
 
-        expect(getConversationMeta(conversation).turnNumber).toBe(1);
-        expect(conversation.messages[0].content).toEqual([
-            { type: 'text', text: 'What is this?' },
-            { type: 'text', text: '[Image removed from conversation history]' },
+        await model.requestTextCompletion(undefined, prompt, {
+            ...options,
+            conversation: completion.conversation,
+            stripImagesAfterTurns: 0,
+        });
+        expect(model.payloads[1].messages[0].content).toBe('What is this?\n[Image removed from conversation history]');
+    });
+
+    it('preserves imported history age when applying the host retention projection', async () => {
+        const model = new TestOpenAIChatCompletionsProtocol({
+            id: 'chatcmpl-aged-history',
+            object: 'chat.completion',
+            created: 1,
+            model: 'test/model',
+            choices: [
+                {
+                    index: 0,
+                    message: { role: 'assistant', content: 'ok' },
+                    finish_reason: 'stop',
+                    logprobs: null,
+                },
+            ],
+        });
+        const oldText = 'x'.repeat(32_001);
+        const agedHistory = {
+            _is_openai_chat_completions: true as const,
+            _llumiverse_meta: { turnNumber: 20 },
+            messages: [
+                {
+                    role: 'user' as const,
+                    content: [
+                        { type: 'text' as const, text: 'old image' },
+                        {
+                            type: 'image_url' as const,
+                            image_url: { url: 'data:image/png;base64,b2xkLWltYWdl', detail: 'auto' as const },
+                        },
+                    ],
+                },
+                { role: 'assistant' as const, content: oldText },
+                { role: 'user' as const, content: '<heartbeat>old status</heartbeat>' },
+            ],
+        };
+
+        await model.requestTextCompletion(
+            undefined,
+            { _is_openai_chat_completions: true, messages: [{ role: 'user', content: 'current request' }] },
+            {
+                ...canonicalOptions('attempt:aged', '2026-09-11T00:00:00.000Z', agedHistory),
+                stripImagesAfterTurns: 5,
+                stripTextMaxTokens: 8_000,
+                stripHeartbeatsAfterTurns: 1,
+            },
+        );
+
+        expect(model.payloads[0].messages).toEqual([
+            {
+                role: 'user',
+                content: 'old image\n[Image removed from conversation history]',
+            },
+            {
+                role: 'assistant',
+                content: `${oldText.slice(0, 32_000)}\n\n[Content truncated - exceeded token limit]`,
+            },
+            { role: 'user', content: '[Heartbeat removed from conversation history]' },
+            { role: 'user', content: 'current request' },
         ]);
     });
 
@@ -763,11 +923,16 @@ describe('OpenAIChatCompletionsProtocol', () => {
             stripImagesAfterTurns: 0,
             stripTextMaxTokens: 1,
         });
-        const conversation = completion.conversation as OpenAIChatCompletionsPrompt;
-
-        expect(JSON.stringify(conversation.messages[0].content)).not.toContain('aW1hZ2U=');
-        expect(JSON.stringify(conversation.messages[0].content)).toContain('Content truncated');
-        expect(conversation.messages[1].reasoning_content).toContain('Content truncated');
+        expect(JSON.stringify(completion.conversation)).toContain('aW1hZ2U=');
+        expect(JSON.stringify(completion.conversation)).toContain('reasoning projection');
+        await model.requestTextCompletion(undefined, prompt, {
+            ...options,
+            conversation: completion.conversation,
+            stripImagesAfterTurns: 0,
+            stripTextMaxTokens: 1,
+        });
+        expect(JSON.stringify(model.payloads[1].messages)).not.toContain('aW1hZ2U=');
+        expect(JSON.stringify(model.payloads[1].messages)).toContain('Content truncated');
     });
 
     it('reads streaming content arrays', async () => {
@@ -883,7 +1048,7 @@ describe('OpenAIChatCompletionsProtocol', () => {
         for await (const chunk of stream) results.push(...chunk.result);
         const conversation = await stream.finalizeConversation?.();
 
-        expect(conversation).toMatchObject({
+        expect(legacyConversation(conversation)).toMatchObject({
             messages: expect.arrayContaining([
                 expect.objectContaining({
                     role: 'assistant',
@@ -1304,5 +1469,134 @@ describe('OpenAIChatCompletionsProtocol', () => {
                 additionalProperties: false,
             },
         });
+    });
+
+    it('rejects a truncated stream before persisting a completed canonical response', async () => {
+        const model = new TestOpenAIChatCompletionsProtocol(
+            undefined,
+            createSSEStream([
+                {
+                    type: 'event',
+                    data: JSON.stringify({
+                        id: 'chatcmpl-truncated',
+                        object: 'chat.completion.chunk',
+                        created: 1,
+                        model: 'test/model',
+                        choices: [{ index: 0, delta: { content: 'partial' } }],
+                    }),
+                },
+            ]),
+        );
+
+        const stream = await model.requestTextCompletionStream(undefined, prompt, options);
+        await collectChunks(stream);
+        if (stream.finalizeConversation === undefined) throw new Error('Expected canonical stream finalizer');
+        await expect(stream.finalizeConversation()).rejects.toThrow(
+            'Chat Completions stream ended without a terminal finish reason',
+        );
+    });
+
+    it('validates structured output through the full driver and recovers it without a second provider call', async () => {
+        const rawText = '{ "answer" : "Tokyo" }';
+        const driver = new TestOpenAIChatCompletionsDriver({
+            id: 'chatcmpl-structured',
+            object: 'chat.completion',
+            created: 1,
+            model: 'test/model',
+            choices: [
+                {
+                    index: 0,
+                    message: { role: 'assistant', content: rawText },
+                    finish_reason: 'stop',
+                    logprobs: null,
+                },
+            ],
+        });
+        const resultSchema: NonNullable<ExecutionOptions['result_schema']> = {
+            type: 'object',
+            properties: { answer: { type: 'string' } },
+            required: ['answer'],
+            additionalProperties: false,
+        };
+        const segments = [{ role: PromptRole.user, content: 'Return the city.' }];
+        const first = await driver.execute(segments, {
+            ...canonicalOptions('attempt:first', '2026-09-11T00:00:00.000Z'),
+            result_schema: resultSchema,
+        });
+
+        expect(first.result).toEqual([{ type: 'json', value: { answer: 'Tokyo' } }]);
+        expect(latestGeneratedText(first.conversation)).toBe(rawText);
+
+        const retried = await driver.execute(segments, {
+            ...canonicalOptions('attempt:retry', '2026-09-11T00:01:00.000Z', first.conversation),
+            result_schema: resultSchema,
+        });
+        expect(retried.result).toEqual(first.result);
+        expect(retried.conversation).toEqual(first.conversation);
+        expect(driver.payloads).toHaveLength(1);
+    });
+
+    it('validates streamed structured output while retaining its exact canonical text', async () => {
+        const rawText = '{"answer":"Tokyo"}';
+        const driver = new TestOpenAIChatCompletionsDriver(
+            undefined,
+            createSSEStream([
+                {
+                    type: 'event',
+                    data: JSON.stringify({
+                        id: 'chatcmpl-stream-structured',
+                        object: 'chat.completion.chunk',
+                        created: 1,
+                        model: 'test/model',
+                        choices: [{ index: 0, delta: { content: rawText }, finish_reason: 'stop' }],
+                    }),
+                },
+            ]),
+        );
+        const stream = await driver.stream([{ role: PromptRole.user, content: 'Return the city.' }], {
+            ...canonicalOptions('attempt:stream', '2026-09-11T00:00:00.000Z'),
+            result_schema: {
+                type: 'object',
+                properties: { answer: { type: 'string' } },
+                required: ['answer'],
+                additionalProperties: false,
+            },
+        });
+
+        for await (const _chunk of stream) {
+            // Consume the public stream so core finalization and schema validation run.
+        }
+        expect(stream.completion?.result).toEqual([{ type: 'json', value: { answer: 'Tokyo' } }]);
+        expect(latestGeneratedText(stream.completion?.conversation)).toBe(rawText);
+    });
+
+    it('keeps invalid structured output as canonical source and reports the full-driver validation error', async () => {
+        const rawText = '{"answer":{}}';
+        const driver = new TestOpenAIChatCompletionsDriver({
+            id: 'chatcmpl-invalid-structured',
+            object: 'chat.completion',
+            created: 1,
+            model: 'test/model',
+            choices: [
+                {
+                    index: 0,
+                    message: { role: 'assistant', content: rawText },
+                    finish_reason: 'stop',
+                    logprobs: null,
+                },
+            ],
+        });
+        const completion = await driver.execute([{ role: PromptRole.user, content: 'Return the city.' }], {
+            ...canonicalOptions('attempt:invalid', '2026-09-11T00:00:00.000Z'),
+            result_schema: {
+                type: 'object',
+                properties: { answer: { type: 'string' } },
+                required: ['answer'],
+                additionalProperties: false,
+            },
+        });
+
+        expect(completion.error).toMatchObject({ code: 'validation_error' });
+        expect(latestGeneratedText(completion.conversation)).toBe(rawText);
     });
 });

--- a/drivers/src/openai/openai_chat_completions.ts
+++ b/drivers/src/openai/openai_chat_completions.ts
@@ -33,10 +33,19 @@ import {
 } from '@llumiverse/core';
 import { transformSSEStream } from '@llumiverse/core/async';
 import OpenAI from 'openai';
+import { canonicalConversationTurnNumber } from '../conversation/canonical-runtime.js';
 import { resolveModelListingMetadata } from '../shared/model-listing.js';
 import { createToolChoiceConfigurationError } from '../shared/tool-choice-error.js';
 import { getOpenAIExtraBody, mergeOpenAIExtraBody } from './extra_body.js';
 import { OpenAICompatibleDriverBase } from './openai_compatible.js';
+import {
+    appendOpenAIChatCanonicalResponse,
+    compileOpenAIChatCompletionsConversation,
+    decodeOpenAIChatCanonicalResponse,
+    finalizeOpenAIChatPreparedRequest,
+    type PreparedOpenAIChatConversation,
+    prepareOpenAIChatCanonicalState,
+} from './openai-chat-conversation-adapter.js';
 import { formatOpenAISchema, limitedSchemaFormat } from './schema.js';
 
 type OpenAIChatServiceTier = OpenAI.Chat.ChatCompletionCreateParams['service_tier'];
@@ -60,6 +69,8 @@ export type OpenAIChatCompletionsMessage = {
      * Per OpenAI API spec: https://platform.openai.com/docs/api-reference/chat/messages#message-role
      */
     tool_call_id?: string;
+    /** Internal canonical-ingestion status; removed when building the provider request. */
+    tool_result_status?: 'success' | 'error' | 'cancelled' | 'denied';
     /**
      * Tool calls from assistant messages - stored and sent back with tool results.
      */
@@ -818,6 +829,14 @@ function finalizeOpenAIChatCompletionsConversation(
     options: ExecutionOptions,
 ): OpenAIChatCompletionsPrompt {
     conversation = incrementConversationTurn(conversation) as OpenAIChatCompletionsPrompt;
+    return projectOpenAIChatCompletionsHistory(conversation, options, getConversationMeta(conversation).turnNumber);
+}
+
+function projectOpenAIChatCompletionsHistory(
+    conversation: OpenAIChatCompletionsPrompt,
+    options: ExecutionOptions,
+    currentTurn: number,
+): OpenAIChatCompletionsPrompt {
     const reasoningPolicy = getOpenAIChatReasoningReplayPolicy(options.model);
     if (reasoningPolicy === 'omit') {
         conversation = { ...conversation, messages: conversation.messages.map(withoutOpenAIChatReasoning) };
@@ -841,7 +860,6 @@ function finalizeOpenAIChatCompletionsConversation(
     if (reasoningPolicy === 'active_tool_turn') {
         conversation = { ...conversation, messages: conversation.messages.map(withoutOpenAIChatReasoning) };
     }
-    const currentTurn = getConversationMeta(conversation).turnNumber;
     const stripOptions = {
         keepForTurns: options.stripImagesAfterTurns ?? Infinity,
         currentTurn,
@@ -868,6 +886,86 @@ function getOpenAIChatDriverProvider(driver: unknown): string {
         return Providers.openai_compatible;
     }
     return typeof driver.provider === 'string' ? driver.provider : Providers.openai_compatible;
+}
+
+function prepareCanonicalOpenAIProjection(
+    prepared: Omit<PreparedOpenAIChatConversation, 'payload' | 'receipt' | 'diagnostics'>,
+    options: ExecutionOptions,
+): OpenAIChatCompletionsPrompt {
+    const native = prepared.native_conversation;
+    const prior: OpenAIChatCompletionsPrompt = {
+        _is_openai_chat_completions: true,
+        messages: native.messages.slice(0, prepared.prior_native_message_count),
+    };
+    const projectedPrior = projectOpenAIChatCompletionsHistory(
+        prior,
+        options,
+        canonicalConversationTurnNumber(prepared.document),
+    );
+    return prepareOpenAIChatCompletionsConversation(
+        {
+            _is_openai_chat_completions: true,
+            messages: [...projectedPrior.messages, ...native.messages.slice(prepared.prior_native_message_count)],
+        },
+        options,
+    );
+}
+
+function canonicalOpenAIUsage(
+    prepared: Omit<PreparedOpenAIChatConversation, 'payload' | 'receipt' | 'diagnostics'>,
+): ExecutionTokenUsage | undefined {
+    const usage = prepared.accepted_response?.generation.usage;
+    if (usage === undefined) return undefined;
+    return {
+        ...(usage.input_tokens === undefined ? {} : { prompt: usage.input_tokens }),
+        ...(usage.output_tokens === undefined ? {} : { result: usage.output_tokens }),
+        ...(usage.total_tokens === undefined ? {} : { total: usage.total_tokens }),
+        ...(usage.cache_read_tokens === undefined ? {} : { prompt_cached: usage.cache_read_tokens }),
+        ...(usage.cache_write_tokens === undefined ? {} : { prompt_cache_write: usage.cache_write_tokens }),
+        ...(usage.input_new_tokens === undefined ? {} : { prompt_new: usage.input_new_tokens }),
+    };
+}
+
+function recoverOpenAICompletion(
+    prepared: Omit<PreparedOpenAIChatConversation, 'payload' | 'receipt' | 'diagnostics'>,
+    options: ExecutionOptions,
+    includeThoughts: boolean,
+): Completion {
+    const accepted = prepared.accepted_response;
+    if (accepted === undefined) throw new Error('No accepted Chat Completions response is available');
+    if (options.include_original_response) {
+        throw new Error('An idempotently recovered Chat Completions response cannot reconstruct original_response');
+    }
+    const projection = compileOpenAIChatCompletionsConversation(prepared.document);
+    const mapping = projection.mappings.find(
+        (candidate) => candidate.kind === 'turn' && candidate.canonical_id === accepted.turn.id,
+    );
+    const match = mapping === undefined ? undefined : /^messages\/(\d+)$/.exec(mapping.native_id);
+    const message = match == null ? undefined : projection.conversation.messages[Number(match[1])];
+    if (message?.role !== 'assistant') {
+        throw new Error(`Accepted Chat Completions turn ${accepted.turn.id} has no native projection`);
+    }
+    const toolUse = parseOpenAIChatCompletionsToolCalls(message.tool_calls);
+    return {
+        result: extractOpenAIChatCompletionsResults(message, includeThoughts),
+        tool_use: toolUse,
+        token_usage: canonicalOpenAIUsage(prepared),
+        finish_reason: normalizeOpenAIChatCompletionsFinishReason(accepted.generation.finish_reason, !!toolUse?.length),
+        conversation: prepared.document,
+    };
+}
+
+function recoveredOpenAIStream(completion: Completion): DriverCompletionStream {
+    const stream = (async function* (): AsyncIterable<CompletionChunkObject> {
+        yield {
+            result: completion.result,
+            tool_use: completion.tool_use,
+            token_usage: completion.token_usage,
+            finish_reason: completion.finish_reason,
+            service_tier: completion.service_tier,
+        };
+    })();
+    return Object.assign(stream, { finalizeConversation: () => completion.conversation });
 }
 
 export abstract class OpenAIChatCompletionsProtocol<DriverT> {
@@ -951,6 +1049,9 @@ export abstract class OpenAIChatCompletionsProtocol<DriverT> {
                 const toolMessage: OpenAIChatCompletionsMessage = {
                     role: 'tool',
                     tool_call_id: segment.tool_use_id,
+                    ...(segment.tool_result_status === undefined
+                        ? {}
+                        : { tool_result_status: segment.tool_result_status }),
                     content: content.length === 1 && content[0]?.type === 'text' ? content[0].text : content,
                 };
                 messages.push(toolMessage);
@@ -1007,14 +1108,24 @@ export abstract class OpenAIChatCompletionsProtocol<DriverT> {
         options: ExecutionOptions,
         signal?: AbortSignal,
     ): Promise<Completion> {
-        let conversation = updateOpenAIChatCompletionsConversation(
-            options.conversation as OpenAIChatCompletionsPrompt,
+        const provider = getOpenAIChatDriverProvider(driver);
+        const canonicalState = await prepareOpenAIChatCanonicalState({
+            conversation: options.conversation,
             prompt,
-        );
-        conversation = prepareOpenAIChatCompletionsConversation(conversation, options);
+            options,
+            provider,
+        });
         const includeThoughts =
             (options.model_options as TextFallbackOptions & { include_thoughts?: boolean })?.include_thoughts !== false;
-        const payload = this.buildPayload(conversation, options, false, getOpenAIChatDriverProvider(driver));
+        if (canonicalState.accepted_response !== undefined) {
+            return recoverOpenAICompletion(canonicalState, options, includeThoughts);
+        }
+        const conversation = prepareCanonicalOpenAIProjection(canonicalState, options);
+        const payload = this.buildPayload(conversation, options, false, provider);
+        const prepared = await finalizeOpenAIChatPreparedRequest(
+            { ...canonicalState, native_conversation: conversation },
+            payload,
+        );
         const result = await this.postChatCompletion(driver, payload, options, signal);
 
         const choice = result?.choices?.[0];
@@ -1028,24 +1139,12 @@ export abstract class OpenAIChatCompletionsProtocol<DriverT> {
             throw new Error('Chat Completions response is not valid: no data');
         }
 
-        const assistantMessage: OpenAIChatCompletionsMessage = {
-            role: 'assistant',
-            content: message.content ?? null,
-            reasoning_content: message.reasoning_content,
-            reasoning: message.reasoning,
-        };
-
-        if (tool_use && tool_use.length > 0 && message.tool_calls) {
-            assistantMessage.tool_calls = message.tool_calls.filter(
-                (toolCall): toolCall is OpenAI.Chat.ChatCompletionMessageFunctionToolCall =>
-                    toolCall.type === 'function',
-            );
-        }
-
-        conversation = updateOpenAIChatCompletionsConversation(conversation, {
-            messages: [assistantMessage],
-        });
-        conversation = finalizeOpenAIChatCompletionsConversation(conversation, options);
+        const decoded = await decodeOpenAIChatCanonicalResponse(
+            result,
+            prepared,
+            typeof choice?.finish_reason === 'string' ? choice.finish_reason : undefined,
+        );
+        const canonicalConversation = appendOpenAIChatCanonicalResponse(prepared, decoded);
 
         return {
             result: completionResults,
@@ -1056,7 +1155,7 @@ export abstract class OpenAIChatCompletionsProtocol<DriverT> {
             original_response: options.include_original_response
                 ? ((result as OpenAIChatCompletionsResponseWithOriginal)[originalResponseSymbol] ?? result)
                 : undefined,
-            conversation,
+            conversation: canonicalConversation,
         };
     }
 
@@ -1066,20 +1165,38 @@ export abstract class OpenAIChatCompletionsProtocol<DriverT> {
         options: ExecutionOptions,
         signal?: AbortSignal,
     ): Promise<DriverCompletionStream> {
-        let conversation = updateOpenAIChatCompletionsConversation(
-            options.conversation as OpenAIChatCompletionsPrompt,
+        const provider = getOpenAIChatDriverProvider(driver);
+        const canonicalState = await prepareOpenAIChatCanonicalState({
+            conversation: options.conversation,
             prompt,
-        );
-        conversation = prepareOpenAIChatCompletionsConversation(conversation, options);
+            options,
+            provider,
+        });
         const includeThoughts =
             (options.model_options as TextFallbackOptions & { include_thoughts?: boolean })?.include_thoughts !== false;
-        const payload = this.buildPayload(conversation, options, true, getOpenAIChatDriverProvider(driver));
+        if (canonicalState.accepted_response !== undefined) {
+            return recoveredOpenAIStream(recoverOpenAICompletion(canonicalState, options, includeThoughts));
+        }
+        const conversation = prepareCanonicalOpenAIProjection(canonicalState, options);
+        const payload = this.buildPayload(conversation, options, true, provider);
+        const prepared = await finalizeOpenAIChatPreparedRequest(
+            { ...canonicalState, native_conversation: conversation },
+            payload,
+        );
         const responseStream = await this.postChatCompletionStream(driver, payload, options, signal);
 
         const projector = new OpenAIThinkStreamProjector();
         let nativeContent = '';
         let nativeReasoningContent: string | undefined;
         let nativeReasoning: string | undefined;
+        let responseId: string | undefined;
+        let responseObject: string | undefined;
+        let responseCreated: number | undefined;
+        let responseModel: string | undefined;
+        let responseServiceTier: OpenAIChatServiceTier | undefined;
+        let responseSystemFingerprint: string | undefined;
+        let responseUsage: OpenAIChatCompletionsUsage | undefined;
+        let responseFinishReason: string | undefined;
         const nativeToolCalls = new Map<
             number,
             { id: string; type: 'function'; function: { name: string; arguments: string } }
@@ -1089,6 +1206,14 @@ export abstract class OpenAIChatCompletionsProtocol<DriverT> {
             const json = JSON.parse(data) as OpenAIChatCompletionsStreamResponse;
             const choice = json.choices?.[0];
             const delta = choice?.delta;
+            responseId = json.id;
+            responseObject = json.object;
+            responseCreated = json.created;
+            responseModel = json.model;
+            responseServiceTier = json.service_tier;
+            if (typeof json.system_fingerprint === 'string') responseSystemFingerprint = json.system_fingerprint;
+            if (json.usage != null) responseUsage = json.usage;
+            if (typeof choice?.finish_reason === 'string') responseFinishReason = choice.finish_reason;
             const chunkResults: CompletionResult[] = [];
             const content = extractOpenAIChatCompletionsContentText(delta?.content);
             if (content) {
@@ -1149,9 +1274,9 @@ export abstract class OpenAIChatCompletionsProtocol<DriverT> {
         });
 
         return Object.assign(stream, {
-            finalizeConversation: () => {
-                const assistantMessage: OpenAIChatCompletionsMessage = {
-                    role: 'assistant',
+            finalizeConversation: async () => {
+                const assistantMessage = {
+                    role: 'assistant' as const,
                     content: nativeContent || null,
                     ...(nativeReasoningContent !== undefined && { reasoning_content: nativeReasoningContent }),
                     ...(nativeReasoning !== undefined && { reasoning: nativeReasoning }),
@@ -1161,10 +1286,37 @@ export abstract class OpenAIChatCompletionsProtocol<DriverT> {
                             .map(([, toolCall]) => toolCall),
                     }),
                 };
-                return finalizeOpenAIChatCompletionsConversation(
-                    updateOpenAIChatCompletionsConversation(conversation, { messages: [assistantMessage] }),
-                    options,
-                );
+                if (
+                    responseId === undefined ||
+                    responseObject === undefined ||
+                    responseCreated === undefined ||
+                    responseModel === undefined
+                ) {
+                    throw new Error('Chat Completions stream ended without a complete native response identity');
+                }
+                if (responseFinishReason === undefined) {
+                    throw new Error('Chat Completions stream ended without a terminal finish reason');
+                }
+                const response: OpenAIChatCompletionsResponse = {
+                    id: responseId,
+                    object: responseObject as OpenAI.Chat.ChatCompletion['object'],
+                    created: responseCreated,
+                    model: responseModel,
+                    choices: [
+                        {
+                            index: 0,
+                            message: assistantMessage,
+                            finish_reason: responseFinishReason,
+                        },
+                    ],
+                    ...(responseServiceTier === undefined ? {} : { service_tier: responseServiceTier }),
+                    ...(responseSystemFingerprint === undefined
+                        ? {}
+                        : { system_fingerprint: responseSystemFingerprint }),
+                    ...(responseUsage === undefined ? {} : { usage: responseUsage }),
+                };
+                const decoded = await decodeOpenAIChatCanonicalResponse(response, prepared, responseFinishReason);
+                return appendOpenAIChatCanonicalResponse(prepared, decoded);
             },
         });
     }
@@ -1460,6 +1612,10 @@ export abstract class OpenAIChatCompletionsDriverBase<
             includeResultSchemaInPromptForModel: options.includeResultSchemaInPromptForModel,
             toolSchemaMode: options.toolSchemaMode,
         });
+    }
+
+    protected supportsCanonicalConversation(_options: ExecutionOptions): boolean {
+        return true;
     }
 
     /** @internal Provider SDK transport boundary. */

--- a/drivers/src/openai/openai_format.ts
+++ b/drivers/src/openai/openai_format.ts
@@ -191,7 +191,9 @@ export async function formatOpenAILikeMultimodalPrompt(
             // conversation, a document it fetched. The Responses API accepts those as a content
             // list on `function_call_output`; emitting only the text would silently drop them and
             // leave the model insisting it cannot see the image it just asked for.
-            const toolOutputMsg: OpenAI.Responses.ResponseInputItem.FunctionCallOutput = {
+            const toolOutputMsg: OpenAI.Responses.ResponseInputItem.FunctionCallOutput & {
+                _llumiverse_tool_result_status?: PromptSegment['tool_result_status'];
+            } = {
                 type: 'function_call_output',
                 call_id: msg.tool_use_id,
                 // The tool's own output reads first, then its attachments. With no attachments,
@@ -200,6 +202,9 @@ export async function formatOpenAILikeMultimodalPrompt(
                     fileParts.length > 0
                         ? [...(msg.content ? [{ type: 'input_text' as const, text: msg.content }] : []), ...fileParts]
                         : msg.content || '',
+                ...(msg.tool_result_status === undefined
+                    ? {}
+                    : { _llumiverse_tool_result_status: msg.tool_result_status }),
             };
             others.push(toolOutputMsg);
         } else if (msg.role !== PromptRole.negative && msg.role !== PromptRole.mask) {

--- a/drivers/src/openai/responses-reasoning.test.ts
+++ b/drivers/src/openai/responses-reasoning.test.ts
@@ -344,15 +344,22 @@ describe('OpenAI Responses reasoning', () => {
 
         const serialized = JSON.stringify(completion.conversation);
         expect(serialized).toContain('encrypted-replay-state');
-        expect(serialized).toContain('[Content truncated - exceeded token limit]');
+        expect(serialized).toContain('old tool output that should be truncated');
+        await driver.requestTextCompletion([{ type: 'message', role: 'user', content: 'next text request' }], {
+            model: 'gpt-5',
+            conversation: completion.conversation,
+            model_options: { _option_id: 'openai-thinking' },
+            stripTextMaxTokens: 1,
+        });
+        expect(JSON.stringify(create.mock.calls[1]?.[0])).toContain('[Content truncated - exceeded token limit]');
 
         const imageCompletion = await driver.requestTextCompletion(
             [
                 {
                     type: 'message',
                     role: 'user',
-                    content: [{ type: 'image_url', image_url: { url: 'data:image/png;base64,aW1hZ2U=' } }],
-                } as unknown as OpenAI.Responses.ResponseInputItem,
+                    content: [{ type: 'input_image', image_url: 'data:image/png;base64,aW1hZ2U=', detail: 'auto' }],
+                },
             ],
             {
                 model: 'gpt-5',
@@ -360,7 +367,14 @@ describe('OpenAI Responses reasoning', () => {
                 stripImagesAfterTurns: 0,
             },
         );
-        expect(JSON.stringify(imageCompletion.conversation)).toContain('[Image removed from conversation history]');
+        expect(JSON.stringify(imageCompletion.conversation)).toContain('aW1hZ2U=');
+        await driver.requestTextCompletion([{ type: 'message', role: 'user', content: 'next image request' }], {
+            model: 'gpt-5',
+            conversation: imageCompletion.conversation,
+            model_options: { _option_id: 'openai-thinking' },
+            stripImagesAfterTurns: 0,
+        });
+        expect(JSON.stringify(create.mock.calls[3]?.[0])).toContain('[Image removed from conversation history]');
 
         const heartbeatCompletion = await driver.requestTextCompletion(
             [{ type: 'message', role: 'user', content: '<heartbeat>old status</heartbeat>' }],
@@ -370,9 +384,14 @@ describe('OpenAI Responses reasoning', () => {
                 stripHeartbeatsAfterTurns: 0,
             },
         );
-        expect(JSON.stringify(heartbeatCompletion.conversation)).toContain(
-            '[Heartbeat removed from conversation history]',
-        );
+        expect(JSON.stringify(heartbeatCompletion.conversation)).toContain('<heartbeat>old status</heartbeat>');
+        await driver.requestTextCompletion([{ type: 'message', role: 'user', content: 'next heartbeat request' }], {
+            model: 'gpt-5',
+            conversation: heartbeatCompletion.conversation,
+            model_options: { _option_id: 'openai-thinking' },
+            stripHeartbeatsAfterTurns: 0,
+        });
+        expect(JSON.stringify(create.mock.calls[5]?.[0])).toContain('[Heartbeat removed from conversation history]');
     });
 
     it.each([false, true])('forwards OpenAI prompt cache controls when stream=%s', async (streaming) => {

--- a/drivers/src/shared/claude-messages-conversation-adapter.ts
+++ b/drivers/src/shared/claude-messages-conversation-adapter.ts
@@ -1,0 +1,1234 @@
+import type {
+    ContentBlockParam,
+    DocumentBlockParam,
+    ImageBlockParam,
+    Message,
+    MessageCreateParamsBase,
+    MessageParam,
+    TextBlockParam,
+    ToolResultBlockParam,
+} from '@anthropic-ai/sdk/resources/messages.js';
+import type { ExecutionOptions } from '@llumiverse/common';
+import {
+    type AgentContentBlock,
+    type Asset,
+    appendConversationRecords,
+    appendDecodedConversationResponse,
+    type ContentBlock,
+    type ConversationDocument,
+    type ConversationTurn,
+    type DecodedConversationResponse,
+    deriveConversationId,
+    type ExecutedGeneration,
+    type ExecutionReceipt,
+    fingerprintJson,
+    type GenerationUsage,
+    type ImportedTurnProvenance,
+    type JsonObject,
+    type NativeItemMapping,
+    type NestedToolResultContentBlock,
+    type PreparedConversationRequest,
+    type ProgramContentBlock,
+    parseConversationDocument,
+    preflightJsonInput,
+    type ToolDefinition,
+    type ToolResultBlock,
+    type UserContentBlock,
+} from '@llumiverse/conversation';
+import {
+    acceptedCanonicalResponse,
+    appendCanonicalPrompt,
+    type CanonicalPreparedState,
+    canonicalResponseIdentities,
+    canonicalToolDefinitions,
+    createExecutedGeneration,
+    createRequestReceipt,
+    newCanonicalConversation,
+    parseCanonicalConversation,
+    providerJsonValue,
+    type ResolvedConversationRuntimeContext,
+    resolveConversationRuntime,
+    selectedCanonicalTurns,
+} from '../conversation/canonical-runtime.js';
+import type { AnthropicUsageLike, ClaudePrompt } from './claude-messages.js';
+
+export const CLAUDE_MESSAGES_PROTOCOL = 'anthropic.messages' as const;
+export const CLAUDE_MESSAGES_ADAPTER_VERSION = '2026-09-11.canonical.1' as const;
+
+export type CanonicalToolResultStatus = 'success' | 'error' | 'cancelled' | 'denied';
+export type CanonicalClaudeToolResultBlockParam = ToolResultBlockParam & {
+    /** Internal ingestion evidence. This property is removed before provider transport. */
+    _llumiverse_tool_result_status?: CanonicalToolResultStatus;
+};
+
+interface ClaudeReplayCanonicalEntry extends JsonObject {
+    kind: 'canonical';
+    block_id: string;
+}
+interface ClaudeReplayThinkingEntry extends JsonObject {
+    kind: 'thinking';
+    block_id: string;
+    signature: string;
+}
+interface ClaudeReplayRedactedEntry extends JsonObject {
+    kind: 'redacted_thinking';
+    data: string;
+}
+type ClaudeReplayEntry = ClaudeReplayCanonicalEntry | ClaudeReplayThinkingEntry | ClaudeReplayRedactedEntry;
+type ClaudeReplayPayload = JsonObject & {
+    type: 'claude_messages_content_order';
+    entries: ClaudeReplayEntry[];
+};
+type SourceKind = 'imported' | 'received';
+
+export interface PreparedClaudeConversation
+    extends CanonicalPreparedState<ClaudePrompt>,
+        PreparedConversationRequest<MessageCreateParamsBase> {
+    provider: string;
+    prior_native_message_count: number;
+}
+
+function ownValue(value: object, key: string): unknown {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    return descriptor && 'value' in descriptor ? descriptor.value : undefined;
+}
+
+function sourceHistoryTurnNumber(history: ClaudePrompt): number | undefined {
+    const metadata = ownValue(history, '_llumiverse_meta');
+    if (typeof metadata !== 'object' || metadata === null || Array.isArray(metadata)) return undefined;
+    const turnNumber = ownValue(metadata, 'turnNumber');
+    return typeof turnNumber === 'number' && Number.isSafeInteger(turnNumber) && turnNumber >= 0
+        ? turnNumber
+        : undefined;
+}
+
+function isMessageParam(value: unknown): value is MessageParam {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+    const role = ownValue(value, 'role');
+    const content = ownValue(value, 'content');
+    return (
+        (role === 'user' || role === 'assistant' || role === 'system') &&
+        (typeof content === 'string' || Array.isArray(content))
+    );
+}
+
+export function isClaudeMessagesHistory(
+    value: unknown,
+    explicitProtocol?: typeof CLAUDE_MESSAGES_PROTOCOL,
+): value is ClaudePrompt | MessageParam[] {
+    if (!preflightJsonInput(value).success) return false;
+    if (Array.isArray(value)) {
+        return explicitProtocol === CLAUDE_MESSAGES_PROTOCOL && value.every(isMessageParam);
+    }
+    if (typeof value !== 'object' || value === null || ownValue(value, '_is_openai_chat_completions') === true) {
+        return false;
+    }
+    const messages = ownValue(value, 'messages');
+    const system = ownValue(value, 'system');
+    return (
+        Array.isArray(messages) &&
+        messages.every(isMessageParam) &&
+        (system === undefined || (Array.isArray(system) && system.every((block) => isSupportedTextBlock(block))))
+    );
+}
+
+function isSupportedTextBlock(value: unknown): value is TextBlockParam {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        !Array.isArray(value) &&
+        ownValue(value, 'type') === 'text' &&
+        typeof ownValue(value, 'text') === 'string'
+    );
+}
+
+async function entityId(kind: string, scope: string, ...position: Array<string | number>): Promise<string> {
+    return deriveConversationId(kind, scope, ...position.map(String));
+}
+
+function importedProvenance(nativeId: string, sourceHistoryNumber?: number): ImportedTurnProvenance {
+    return {
+        type: 'imported',
+        source: CLAUDE_MESSAGES_PROTOCOL,
+        native_id: { protocol: CLAUDE_MESSAGES_PROTOCOL, scope: 'history', value: nativeId },
+        ...(sourceHistoryNumber === undefined ? {} : { source_history_turn_number: sourceHistoryNumber }),
+        missing_metadata: ['actor_id', 'timestamps', 'exchange'],
+    };
+}
+
+function turnProvenance(source: SourceKind, nativeId: string, sourceHistoryNumber?: number) {
+    return source === 'imported' ? importedProvenance(nativeId, sourceHistoryNumber) : ({ type: 'received' } as const);
+}
+
+function assertAllowedKeys(value: object, allowed: readonly string[], label: string): void {
+    const extras = Object.keys(value).filter((key) => !allowed.includes(key));
+    if (extras.length > 0) throw new TypeError(`${label} contains unsupported field ${extras[0]}`);
+}
+
+function assertTextBlock(block: TextBlockParam): void {
+    assertAllowedKeys(block, ['type', 'text', 'cache_control', 'citations'], 'Claude text block');
+    if (block.citations !== undefined && block.citations !== null && block.citations.length > 0) {
+        throw new TypeError('Claude text citations are not supported by the canonical adapter');
+    }
+}
+
+function assetMetadata(block: ImageBlockParam | DocumentBlockParam): JsonObject | undefined {
+    const metadata: JsonObject = {};
+    if ('title' in block && block.title !== undefined && block.title !== null) metadata.title = block.title;
+    if ('context' in block && block.context !== undefined && block.context !== null) metadata.context = block.context;
+    if ('transformations' in block && block.transformations !== undefined && block.transformations !== null) {
+        metadata.transformations = providerJsonValue(block.transformations);
+    }
+    return Object.keys(metadata).length === 0 ? undefined : { claude_messages: metadata };
+}
+
+async function assetBlock(input: {
+    block: ImageBlockParam | DocumentBlockParam;
+    turn_id: string;
+    scope: string;
+    native_path: string;
+    source: SourceKind;
+    recorded_at: string;
+}): Promise<{ block: UserContentBlock; asset: Asset }> {
+    const { block } = input;
+    if (block.type === 'image') {
+        assertAllowedKeys(block, ['type', 'source', 'cache_control', 'transformations'], 'Claude image block');
+    } else {
+        assertAllowedKeys(
+            block,
+            ['type', 'source', 'cache_control', 'citations', 'context', 'title'],
+            'Claude document block',
+        );
+        if (block.citations !== undefined && block.citations !== null) {
+            throw new TypeError('Claude document citations are not supported by the canonical adapter');
+        }
+    }
+    const blockId = await entityId('block', input.scope, input.native_path);
+    const assetId = await entityId('asset', input.scope, input.native_path);
+    const source = block.source;
+    let storage: Asset['storage'];
+    let mimeType: string;
+    if (source.type === 'base64') {
+        storage = { type: 'inline_base64', data: source.data };
+        mimeType = source.media_type;
+    } else if (source.type === 'text') {
+        storage = { type: 'inline_text', text: source.data };
+        mimeType = source.media_type;
+    } else if (source.type === 'url') {
+        storage = { type: 'external', resolver: 'url', locator: { url: source.url } };
+        mimeType = block.type === 'image' ? 'application/octet-stream' : 'application/pdf';
+    } else if (source.type === 'file') {
+        storage = { type: 'external', resolver: 'anthropic_file', locator: { file_id: source.file_id } };
+        mimeType = 'application/octet-stream';
+    } else {
+        throw new TypeError(
+            `Claude ${block.type} source type ${source.type} is not supported by the canonical adapter`,
+        );
+    }
+    const asset: Asset = {
+        id: assetId,
+        kind: block.type,
+        mime_type: mimeType,
+        storage,
+        provenance:
+            input.source === 'imported'
+                ? { type: 'imported', source: CLAUDE_MESSAGES_PROTOCOL }
+                : { type: 'received', source_turn_id: input.turn_id },
+        content_hash: await fingerprintJson({ mime_type: mimeType, storage }),
+        created_at: input.recorded_at,
+        ...(assetMetadata(block) === undefined ? {} : { metadata: assetMetadata(block) }),
+    };
+    return {
+        block: {
+            id: blockId,
+            type: block.type,
+            asset_id: assetId,
+            ...('title' in block && typeof block.title === 'string' ? { caption: block.title } : {}),
+        } as UserContentBlock,
+        asset,
+    };
+}
+
+interface MessageRecords {
+    turns: ConversationTurn[];
+    assets: Asset[];
+    mappings: NativeItemMapping[];
+    execution_receipts: ExecutionReceipt[];
+}
+
+function isProgramBlock(block: AgentContentBlock): block is ProgramContentBlock {
+    return block.type !== 'tool_call';
+}
+
+function isUserBlock(block: AgentContentBlock): block is UserContentBlock {
+    return block.type !== 'tool_call' && block.type !== 'reasoning' && block.type !== 'native_replay';
+}
+
+function isToolResultContent(block: AgentContentBlock): block is NestedToolResultContentBlock {
+    return block.type !== 'tool_call';
+}
+
+async function canonicalBlock(input: {
+    native: ContentBlockParam;
+    turn_id: string;
+    scope: string;
+    native_path: string;
+    source: SourceKind;
+    runtime: ResolvedConversationRuntimeContext;
+    tool_definitions: readonly ToolDefinition[];
+    provider: string;
+}): Promise<{ block?: AgentContentBlock; asset?: Asset; replay_entry?: ClaudeReplayEntry }> {
+    const { native } = input;
+    if (native.type === 'text') {
+        assertTextBlock(native);
+        const block: AgentContentBlock = {
+            id: await entityId('block', input.scope, input.native_path),
+            type: 'text',
+            text: native.text,
+            format: 'plain',
+        };
+        return { block, replay_entry: { kind: 'canonical', block_id: block.id } };
+    }
+    if (native.type === 'image' || native.type === 'document') {
+        const converted = await assetBlock({
+            block: native,
+            turn_id: input.turn_id,
+            scope: input.scope,
+            native_path: input.native_path,
+            source: input.source,
+            recorded_at: input.runtime.recorded_at,
+        });
+        return {
+            block: converted.block,
+            asset: converted.asset,
+            replay_entry: { kind: 'canonical', block_id: converted.block.id },
+        };
+    }
+    if (native.type === 'thinking') {
+        assertAllowedKeys(native, ['type', 'thinking', 'signature'], 'Claude thinking block');
+        const block: AgentContentBlock = {
+            id: await entityId('reasoning', input.scope, input.native_path),
+            type: 'reasoning',
+            text: native.thinking,
+            representation: 'text',
+        };
+        return { block, replay_entry: { kind: 'thinking', block_id: block.id, signature: native.signature } };
+    }
+    if (native.type === 'redacted_thinking') {
+        assertAllowedKeys(native, ['type', 'data'], 'Claude redacted thinking block');
+        return { replay_entry: { kind: 'redacted_thinking', data: native.data } };
+    }
+    if (native.type === 'tool_use') {
+        assertAllowedKeys(native, ['type', 'id', 'name', 'input', 'cache_control'], 'Claude tool_use block');
+        const definition = input.tool_definitions.find((candidate) => candidate.name === native.name);
+        const block: AgentContentBlock = {
+            id: await entityId('block', input.scope, input.native_path),
+            type: 'tool_call',
+            call_id: native.id,
+            tool_name: native.name,
+            ...(definition === undefined ? {} : { definition_id: definition.id }),
+            executor: 'application',
+            arguments: { type: 'json', value: providerJsonValue(native.input) },
+            native_id: { protocol: CLAUDE_MESSAGES_PROTOCOL, scope: input.runtime.request_id, value: native.id },
+        };
+        return { block, replay_entry: { kind: 'canonical', block_id: block.id } };
+    }
+    throw new TypeError(`Claude content block type ${native.type} is not supported by the canonical adapter`);
+}
+
+function normalizedContent(content: MessageParam['content']): ContentBlockParam[] {
+    return typeof content === 'string' ? [{ type: 'text', text: content }] : content;
+}
+
+async function toolResultRecord(input: {
+    native: CanonicalClaudeToolResultBlockParam;
+    turn_id: string;
+    scope: string;
+    native_path: string;
+    source: SourceKind;
+    runtime: ResolvedConversationRuntimeContext;
+    tool_definitions: readonly ToolDefinition[];
+    provider: string;
+    provenance: ConversationTurn['provenance'];
+}): Promise<{ turn: ConversationTurn; assets: Asset[]; mappings: NativeItemMapping[]; receipt?: ExecutionReceipt }> {
+    assertAllowedKeys(
+        input.native,
+        ['type', 'tool_use_id', 'content', 'is_error', 'cache_control', '_llumiverse_tool_result_status'],
+        'Claude tool_result block',
+    );
+    const explicitStatus = input.native._llumiverse_tool_result_status;
+    if (explicitStatus === 'success' && input.native.is_error === true) {
+        throw new Error(
+            `Claude tool result ${input.native.tool_use_id} has contradictory success and is_error evidence`,
+        );
+    }
+    if (explicitStatus === 'error' && input.native.is_error === false) {
+        throw new Error(`Claude tool result ${input.native.tool_use_id} has contradictory error and is_error evidence`);
+    }
+    const status: ToolResultBlock['status'] =
+        explicitStatus ??
+        (input.native.is_error === true ? 'error' : input.source === 'imported' ? 'unknown' : 'success');
+    const nestedNative =
+        typeof input.native.content === 'string'
+            ? ([{ type: 'text', text: input.native.content }] satisfies TextBlockParam[])
+            : (input.native.content ?? []);
+    const content: NestedToolResultContentBlock[] = [];
+    const assets: Asset[] = [];
+    const mappings: NativeItemMapping[] = [];
+    for (let index = 0; index < nestedNative.length; index += 1) {
+        const native = nestedNative[index];
+        if (native.type !== 'text' && native.type !== 'image' && native.type !== 'document') {
+            throw new TypeError(
+                `Claude tool_result content type ${native.type} is not supported by the canonical adapter`,
+            );
+        }
+        const converted = await canonicalBlock({
+            native,
+            turn_id: input.turn_id,
+            scope: input.scope,
+            native_path: `${input.native_path}/content/${index}`,
+            source: input.source,
+            runtime: input.runtime,
+            tool_definitions: input.tool_definitions,
+            provider: input.provider,
+        });
+        if (converted.block !== undefined && isToolResultContent(converted.block)) {
+            content.push(converted.block);
+            mappings.push({
+                canonical_id: converted.block.id,
+                native_id: `${input.native_path}/content/${index}`,
+                kind: 'block',
+            });
+        }
+        if (converted.asset !== undefined) assets.push(converted.asset);
+    }
+    const resultBlock: ToolResultBlock = {
+        id: await entityId('block', input.scope, input.native_path),
+        type: 'tool_result',
+        call_id: input.native.tool_use_id,
+        status,
+        content,
+        native_id: {
+            protocol: CLAUDE_MESSAGES_PROTOCOL,
+            scope: input.runtime.request_id,
+            value: input.native.tool_use_id,
+        },
+    };
+    mappings.unshift(
+        { canonical_id: resultBlock.id, native_id: input.native_path, kind: 'block' },
+        { canonical_id: input.native.tool_use_id, native_id: input.native.tool_use_id, kind: 'call' },
+    );
+    const turn: ConversationTurn = {
+        id: input.turn_id,
+        kind: 'tool',
+        authority: 'ordinary',
+        status: 'completed',
+        timestamps: { recorded_at: input.runtime.recorded_at },
+        model_visibility: 'include',
+        provenance: input.provenance as Exclude<ConversationTurn, { kind: 'agent' }>['provenance'],
+        blocks: [resultBlock],
+    };
+    const receipt =
+        input.source === 'received' && status !== 'unknown'
+            ? {
+                  id: await entityId('execution_receipt', input.scope, input.native.tool_use_id),
+                  call_id: input.native.tool_use_id,
+                  executor: 'application' as const,
+                  status,
+                  result_turn_id: turn.id,
+                  result_fingerprint: await fingerprintJson(resultBlock),
+                  recorded_at: input.runtime.recorded_at,
+              }
+            : undefined;
+    return { turn, assets, mappings, ...(receipt === undefined ? {} : { receipt }) };
+}
+
+async function assistantMessageRecords(input: {
+    message: MessageParam;
+    message_index: number;
+    scope: string;
+    source: SourceKind;
+    runtime: ResolvedConversationRuntimeContext;
+    tool_definitions: readonly ToolDefinition[];
+    provider: string;
+    source_history_turn_number?: number;
+}): Promise<MessageRecords> {
+    const nativePath = `messages/${input.message_index}`;
+    const turnId = await entityId('turn', input.scope, nativePath);
+    const blocks: AgentContentBlock[] = [];
+    const assets: Asset[] = [];
+    const mappings: NativeItemMapping[] = [{ canonical_id: turnId, native_id: nativePath, kind: 'turn' }];
+    const entries: ClaudeReplayEntry[] = [];
+    const content = normalizedContent(input.message.content);
+    for (let index = 0; index < content.length; index += 1) {
+        const native = content[index];
+        if (native.type === 'tool_result') {
+            throw new TypeError('Claude assistant messages cannot contain tool_result blocks');
+        }
+        const converted = await canonicalBlock({
+            native,
+            turn_id: turnId,
+            scope: input.scope,
+            native_path: `${nativePath}/content/${index}`,
+            source: input.source,
+            runtime: input.runtime,
+            tool_definitions: input.tool_definitions,
+            provider: input.provider,
+        });
+        if (converted.block !== undefined) {
+            blocks.push(converted.block);
+            mappings.push({
+                canonical_id: converted.block.id,
+                native_id: `${nativePath}/content/${index}`,
+                kind: 'block',
+            });
+            if (converted.block.type === 'tool_call') {
+                mappings.push({
+                    canonical_id: converted.block.call_id,
+                    native_id: converted.block.call_id,
+                    kind: 'call',
+                });
+            }
+        }
+        if (converted.asset !== undefined) assets.push(converted.asset);
+        if (converted.replay_entry !== undefined) entries.push(converted.replay_entry);
+    }
+    if (entries.some((entry) => entry.kind !== 'canonical')) {
+        const replayId = await entityId('replay', input.scope, nativePath);
+        blocks.push({
+            id: replayId,
+            type: 'native_replay',
+            adapter: CLAUDE_MESSAGES_ADAPTER_VERSION,
+            protocol: CLAUDE_MESSAGES_PROTOCOL,
+            compatibility_scope: {
+                provider: input.provider,
+                protocol: CLAUDE_MESSAGES_PROTOCOL,
+                adapter_version: CLAUDE_MESSAGES_ADAPTER_VERSION,
+            },
+            payload: { type: 'claude_messages_content_order', entries },
+            dependencies: {
+                turn_ids: [turnId],
+                block_ids: blocks.map((block) => block.id),
+                call_ids: blocks.flatMap((block) => (block.type === 'tool_call' ? [block.call_id] : [])),
+                request_ids: [],
+            },
+        });
+        mappings.push({ canonical_id: replayId, native_id: `${nativePath}/content_order`, kind: 'block' });
+    }
+    const provenance = turnProvenance(input.source, nativePath, input.source_history_turn_number);
+    const turn: ConversationTurn =
+        input.source === 'imported'
+            ? {
+                  id: turnId,
+                  kind: 'agent',
+                  authority: 'ordinary',
+                  status: 'completed',
+                  timestamps: { recorded_at: input.runtime.recorded_at },
+                  model_visibility: 'include',
+                  provenance: provenance as ImportedTurnProvenance,
+                  blocks,
+              }
+            : {
+                  id: turnId,
+                  kind: 'agent',
+                  authority: 'ordinary',
+                  status: 'completed',
+                  timestamps: { recorded_at: input.runtime.recorded_at },
+                  model_visibility: 'include',
+                  provenance: { type: 'received' },
+                  blocks,
+              };
+    return { turns: [turn], assets, mappings, execution_receipts: [] };
+}
+
+async function nonAssistantMessageRecords(input: {
+    message: MessageParam;
+    message_index: number;
+    native_path?: string;
+    scope: string;
+    source: SourceKind;
+    runtime: ResolvedConversationRuntimeContext;
+    tool_definitions: readonly ToolDefinition[];
+    provider: string;
+    source_history_turn_number?: number;
+}): Promise<MessageRecords> {
+    const basePath = input.native_path ?? `messages/${input.message_index}`;
+    const content = normalizedContent(input.message.content);
+    const records: MessageRecords = { turns: [], assets: [], mappings: [], execution_receipts: [] };
+    let index = 0;
+    while (index < content.length) {
+        const native = content[index];
+        const nativePath = `${basePath}/content/${index}`;
+        const provenance = turnProvenance(input.source, basePath, input.source_history_turn_number);
+        if (native.type === 'tool_result') {
+            if (input.message.role !== 'user') {
+                throw new TypeError('Claude tool_result blocks require a user message');
+            }
+            const turnId = await entityId('turn', input.scope, nativePath);
+            const converted = await toolResultRecord({
+                native: native as CanonicalClaudeToolResultBlockParam,
+                turn_id: turnId,
+                scope: input.scope,
+                native_path: nativePath,
+                source: input.source,
+                runtime: input.runtime,
+                tool_definitions: input.tool_definitions,
+                provider: input.provider,
+                provenance,
+            });
+            records.turns.push(converted.turn);
+            records.assets.push(...converted.assets);
+            records.mappings.push({ canonical_id: turnId, native_id: basePath, kind: 'turn' }, ...converted.mappings);
+            if (converted.receipt !== undefined) records.execution_receipts.push(converted.receipt);
+            index += 1;
+            continue;
+        }
+
+        const segmentStart = index;
+        while (index < content.length && content[index].type !== 'tool_result') index += 1;
+        const turnId = await entityId(
+            'turn',
+            input.scope,
+            content.length === index - segmentStart ? basePath : `${basePath}/segment/${segmentStart}`,
+        );
+        const blocks: Array<ProgramContentBlock | UserContentBlock> = [];
+        for (let blockIndex = segmentStart; blockIndex < index; blockIndex += 1) {
+            const ordinary = content[blockIndex];
+            if (ordinary.type === 'tool_use' || ordinary.type === 'thinking' || ordinary.type === 'redacted_thinking') {
+                throw new TypeError(`Claude ${ordinary.type} blocks require an assistant message`);
+            }
+            const ordinaryPath = `${basePath}/content/${blockIndex}`;
+            const converted = await canonicalBlock({
+                native: ordinary,
+                turn_id: turnId,
+                scope: input.scope,
+                native_path: ordinaryPath,
+                source: input.source,
+                runtime: input.runtime,
+                tool_definitions: input.tool_definitions,
+                provider: input.provider,
+            });
+            if (converted.block === undefined) continue;
+            if (input.message.role === 'system') {
+                if (!isProgramBlock(converted.block) || converted.block.type !== 'text') {
+                    throw new TypeError('Claude system content only supports text blocks');
+                }
+                blocks.push(converted.block);
+            } else if (isUserBlock(converted.block)) {
+                blocks.push(converted.block);
+            }
+            if (converted.asset !== undefined) records.assets.push(converted.asset);
+            records.mappings.push({
+                canonical_id: converted.block.id,
+                native_id: ordinaryPath,
+                kind: 'block',
+            });
+        }
+        const common = {
+            id: turnId,
+            status: 'completed' as const,
+            timestamps: { recorded_at: input.runtime.recorded_at },
+            model_visibility: 'include' as const,
+            provenance: provenance as Exclude<ConversationTurn, { kind: 'agent' }>['provenance'],
+        };
+        const turn: ConversationTurn =
+            input.message.role === 'system'
+                ? {
+                      ...common,
+                      kind: 'program',
+                      authority: 'system',
+                      blocks: blocks as ProgramContentBlock[],
+                  }
+                : {
+                      ...common,
+                      kind: 'user',
+                      authority: 'ordinary',
+                      blocks: blocks as UserContentBlock[],
+                  };
+        records.turns.push(turn);
+        records.mappings.push({ canonical_id: turnId, native_id: basePath, kind: 'turn' });
+    }
+    return records;
+}
+
+async function messageRecords(input: {
+    message: MessageParam;
+    message_index: number;
+    native_path?: string;
+    scope: string;
+    source: SourceKind;
+    runtime: ResolvedConversationRuntimeContext;
+    tool_definitions: readonly ToolDefinition[];
+    provider: string;
+    source_history_turn_number?: number;
+}): Promise<MessageRecords> {
+    return input.message.role === 'assistant' ? assistantMessageRecords(input) : nonAssistantMessageRecords(input);
+}
+
+async function promptRecords(input: {
+    prompt: ClaudePrompt;
+    scope: string;
+    source: SourceKind;
+    runtime: ResolvedConversationRuntimeContext;
+    tool_definitions: readonly ToolDefinition[];
+    provider: string;
+    source_history_turn_number?: number;
+}): Promise<MessageRecords> {
+    const records: MessageRecords = { turns: [], assets: [], mappings: [], execution_receipts: [] };
+    const append = (converted: MessageRecords) => {
+        records.turns.push(...converted.turns);
+        records.assets.push(...converted.assets);
+        records.mappings.push(...converted.mappings);
+        records.execution_receipts.push(...converted.execution_receipts);
+    };
+    for (let index = 0; index < (input.prompt.system?.length ?? 0); index += 1) {
+        const block = input.prompt.system?.[index];
+        if (block === undefined) continue;
+        append(
+            await messageRecords({
+                message: { role: 'system', content: [block] },
+                message_index: index,
+                native_path: `system/${index}`,
+                scope: input.scope,
+                source: input.source,
+                runtime: input.runtime,
+                tool_definitions: input.tool_definitions,
+                provider: input.provider,
+                ...(input.source_history_turn_number === undefined
+                    ? {}
+                    : { source_history_turn_number: input.source_history_turn_number }),
+            }),
+        );
+    }
+    for (let index = 0; index < input.prompt.messages.length; index += 1) {
+        append(
+            await messageRecords({
+                message: input.prompt.messages[index],
+                message_index: index,
+                scope: input.scope,
+                source: input.source,
+                runtime: input.runtime,
+                tool_definitions: input.tool_definitions,
+                provider: input.provider,
+                ...(input.source_history_turn_number === undefined
+                    ? {}
+                    : { source_history_turn_number: input.source_history_turn_number }),
+            }),
+        );
+    }
+    return records;
+}
+
+function claudeAssetMetadata(asset: Asset): JsonObject {
+    const value = asset.metadata?.claude_messages;
+    return typeof value === 'object' && value !== null && !Array.isArray(value) ? value : {};
+}
+
+function assetToClaudeBlock(asset: Asset): ImageBlockParam | DocumentBlockParam {
+    const metadata = claudeAssetMetadata(asset);
+    if (asset.kind === 'image') {
+        let source: ImageBlockParam['source'];
+        if (asset.storage.type === 'inline_base64') {
+            if (!['image/png', 'image/jpeg', 'image/gif', 'image/webp'].includes(asset.mime_type)) {
+                throw new TypeError(`Claude cannot project image MIME type ${asset.mime_type}`);
+            }
+            source = {
+                type: 'base64',
+                media_type: asset.mime_type as 'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp',
+                data: asset.storage.data,
+            };
+        } else if (asset.storage.type === 'external' && asset.storage.resolver === 'url') {
+            const url = asset.storage.locator.url;
+            if (typeof url !== 'string') throw new TypeError(`Claude image asset ${asset.id} has no URL`);
+            source = { type: 'url', url };
+        } else if (asset.storage.type === 'external' && asset.storage.resolver === 'anthropic_file') {
+            const fileId = asset.storage.locator.file_id;
+            if (typeof fileId !== 'string') throw new TypeError(`Claude image asset ${asset.id} has no file ID`);
+            source = { type: 'file', file_id: fileId };
+        } else {
+            throw new TypeError(`Claude cannot project image asset ${asset.id}`);
+        }
+        return {
+            type: 'image',
+            source,
+            ...(typeof metadata.transformations === 'object' && metadata.transformations !== null
+                ? { transformations: metadata.transformations as ImageBlockParam['transformations'] }
+                : {}),
+        };
+    }
+    if (asset.kind !== 'document') throw new TypeError(`Claude cannot project ${asset.kind} asset ${asset.id}`);
+    let source: DocumentBlockParam['source'];
+    if (asset.storage.type === 'inline_base64') {
+        if (asset.mime_type !== 'application/pdf') {
+            throw new TypeError(`Claude cannot project base64 document MIME type ${asset.mime_type}`);
+        }
+        source = { type: 'base64', media_type: 'application/pdf', data: asset.storage.data };
+    } else if (asset.storage.type === 'inline_text') {
+        source = { type: 'text', media_type: 'text/plain', data: asset.storage.text };
+    } else if (asset.storage.type === 'external' && asset.storage.resolver === 'url') {
+        const url = asset.storage.locator.url;
+        if (typeof url !== 'string') throw new TypeError(`Claude document asset ${asset.id} has no URL`);
+        source = { type: 'url', url };
+    } else if (asset.storage.type === 'external' && asset.storage.resolver === 'anthropic_file') {
+        const fileId = asset.storage.locator.file_id;
+        if (typeof fileId !== 'string') throw new TypeError(`Claude document asset ${asset.id} has no file ID`);
+        source = { type: 'file', file_id: fileId };
+    } else {
+        throw new TypeError(`Claude cannot project document asset ${asset.id}`);
+    }
+    return {
+        type: 'document',
+        source,
+        ...(typeof metadata.title === 'string' ? { title: metadata.title } : {}),
+        ...(typeof metadata.context === 'string' ? { context: metadata.context } : {}),
+    };
+}
+
+function canonicalBlockToClaude(block: ContentBlock, document: ConversationDocument): ContentBlockParam {
+    if (block.type === 'text') return { type: 'text', text: block.text };
+    if (block.type === 'json') return { type: 'text', text: JSON.stringify(block.value) };
+    if (block.type === 'image' || block.type === 'document') {
+        const asset = document.assets[block.asset_id];
+        if (asset === undefined) throw new Error(`Claude content references missing asset ${block.asset_id}`);
+        return assetToClaudeBlock(asset);
+    }
+    if (block.type === 'tool_call') {
+        if (block.arguments.type === 'invalid') {
+            throw new TypeError(`Claude cannot replay invalid JSON arguments for call ${block.call_id}`);
+        }
+        return { type: 'tool_use', id: block.call_id, name: block.tool_name, input: block.arguments.value };
+    }
+    throw new TypeError(`Claude cannot project canonical ${block.type} block`);
+}
+
+type ClaudeToolResultContentBlock = Extract<NonNullable<ToolResultBlockParam['content']>, unknown[]>[number];
+
+function canonicalToolResultContentToClaude(
+    block: NestedToolResultContentBlock,
+    document: ConversationDocument,
+): ClaudeToolResultContentBlock {
+    if (block.type !== 'text' && block.type !== 'image' && block.type !== 'document') {
+        throw new TypeError(`Claude cannot project canonical ${block.type} inside a tool result`);
+    }
+    return canonicalBlockToClaude(block, document) as ClaudeToolResultContentBlock;
+}
+
+function claudeReplay(
+    turn: ConversationTurn,
+    target?: { provider?: string; model?: string },
+): ClaudeReplayPayload | undefined {
+    const replayBlocks = turn.blocks.filter((block) => block.type === 'native_replay');
+    const replay = replayBlocks.find((block) => block.protocol === CLAUDE_MESSAGES_PROTOCOL);
+    const foreign = replayBlocks.find((block) => block.protocol !== CLAUDE_MESSAGES_PROTOCOL);
+    if (foreign !== undefined) {
+        throw new TypeError(`Claude cannot discard protected ${foreign.protocol} replay block ${foreign.id}`);
+    }
+    if (replay === undefined) return undefined;
+    if (
+        typeof replay.payload !== 'object' ||
+        replay.payload === null ||
+        Array.isArray(replay.payload) ||
+        replay.payload.type !== 'claude_messages_content_order' ||
+        !Array.isArray(replay.payload.entries)
+    ) {
+        throw new TypeError(`Claude replay block ${replay.id} has an unsupported payload`);
+    }
+    if (
+        replay.adapter !== CLAUDE_MESSAGES_ADAPTER_VERSION ||
+        replay.compatibility_scope.protocol !== CLAUDE_MESSAGES_PROTOCOL ||
+        replay.compatibility_scope.adapter_version !== CLAUDE_MESSAGES_ADAPTER_VERSION ||
+        (target?.provider !== undefined && replay.compatibility_scope.provider !== target.provider) ||
+        (target?.model !== undefined &&
+            replay.compatibility_scope.model !== undefined &&
+            replay.compatibility_scope.model !== target.model)
+    ) {
+        throw new TypeError(`Claude replay block ${replay.id} is outside its compatibility scope`);
+    }
+    return replay.payload as ClaudeReplayPayload;
+}
+
+function agentContent(
+    turn: ConversationTurn,
+    document: ConversationDocument,
+    target?: { provider?: string; model?: string },
+): ContentBlockParam[] {
+    const replay = claudeReplay(turn, target);
+    const blocks = new Map(turn.blocks.map((block) => [block.id, block]));
+    if (replay !== undefined) {
+        return replay.entries.map((entry): ContentBlockParam => {
+            if (entry.kind === 'redacted_thinking') return { type: 'redacted_thinking', data: entry.data };
+            const block = blocks.get(entry.block_id);
+            if (block === undefined) throw new Error(`Claude replay references missing block ${entry.block_id}`);
+            if (entry.kind === 'thinking') {
+                if (block.type !== 'reasoning') {
+                    throw new Error(`Claude thinking replay ${entry.block_id} does not reference reasoning`);
+                }
+                return { type: 'thinking', thinking: block.text, signature: entry.signature };
+            }
+            if (block.type === 'native_replay' || block.type === 'reasoning') {
+                throw new Error(`Claude canonical replay entry ${entry.block_id} has incompatible block type`);
+            }
+            return canonicalBlockToClaude(block, document);
+        });
+    }
+    return turn.blocks.flatMap((block): ContentBlockParam[] => {
+        if (block.type === 'native_replay') return [];
+        if (block.type === 'reasoning') {
+            throw new TypeError(`Claude reasoning block ${block.id} has no signed native replay evidence`);
+        }
+        return [canonicalBlockToClaude(block, document)];
+    });
+}
+
+function ordinaryContent(turn: ConversationTurn, document: ConversationDocument): ContentBlockParam[] {
+    if (turn.kind === 'tool') {
+        const result = turn.blocks[0];
+        const content = result.content.map((block) => canonicalToolResultContentToClaude(block, document));
+        return [
+            {
+                type: 'tool_result',
+                tool_use_id: result.call_id,
+                content,
+                ...(result.status === 'success' || result.status === 'unknown' ? {} : { is_error: true }),
+            },
+        ];
+    }
+    return turn.blocks.flatMap((block): ContentBlockParam[] => {
+        if (block.type === 'extension' && block.model_projection === 'excluded') return [];
+        if (block.type === 'extension') {
+            throw new TypeError(`Claude has no registered projection for extension block ${block.id}`);
+        }
+        if (block.type === 'external_reference' || block.type === 'audio' || block.type === 'video') {
+            throw new TypeError(`Claude cannot project canonical ${block.type} block ${block.id}`);
+        }
+        return [canonicalBlockToClaude(block, document)];
+    });
+}
+
+function appendClaudeMessage(messages: MessageParam[], message: MessageParam): void {
+    const prior = messages.at(-1);
+    if (prior?.role === 'user' && message.role === 'user') {
+        const priorContent = normalizedContent(prior.content);
+        prior.content = [...priorContent, ...normalizedContent(message.content)];
+        return;
+    }
+    messages.push(message);
+}
+
+export function compileClaudeMessagesConversation(
+    document: ConversationDocument,
+    target?: { provider?: string; model?: string },
+): {
+    conversation: ClaudePrompt;
+    mappings: NativeItemMapping[];
+} {
+    const system: TextBlockParam[] = [];
+    const messages: MessageParam[] = [];
+    const mappings: NativeItemMapping[] = [];
+    for (const turn of selectedCanonicalTurns(document)) {
+        if (turn.kind === 'program' && (turn.authority === 'system' || turn.authority === 'developer')) {
+            const nativeBlocks = ordinaryContent(turn, document);
+            for (const block of nativeBlocks) {
+                if (block.type !== 'text') throw new TypeError('Claude system context only supports text blocks');
+                const index = system.length;
+                system.push(block);
+                mappings.push({ canonical_id: turn.id, native_id: `system/${index}`, kind: 'turn' });
+            }
+            continue;
+        }
+        const content = turn.kind === 'agent' ? agentContent(turn, document, target) : ordinaryContent(turn, document);
+        const role = turn.kind === 'agent' ? 'assistant' : 'user';
+        const messageIndex = messages.length;
+        appendClaudeMessage(messages, { role, content });
+        const mappedIndex = messages.length === messageIndex ? Math.max(0, messageIndex - 1) : messageIndex;
+        mappings.push({ canonical_id: turn.id, native_id: `messages/${mappedIndex}`, kind: 'turn' });
+        for (const block of turn.blocks) {
+            mappings.push({
+                canonical_id: block.id,
+                native_id: `messages/${mappedIndex}/blocks/${block.id}`,
+                kind: 'block',
+            });
+            if (block.type === 'tool_call') {
+                mappings.push({ canonical_id: block.call_id, native_id: block.call_id, kind: 'call' });
+            }
+        }
+    }
+    return {
+        conversation: { messages, ...(system.length === 0 ? {} : { system }) },
+        mappings,
+    };
+}
+
+export async function prepareClaudeCanonicalState(input: {
+    conversation: unknown;
+    prompt: ClaudePrompt;
+    options: ExecutionOptions;
+    provider: string;
+}): Promise<Omit<PreparedClaudeConversation, 'payload' | 'receipt' | 'diagnostics'>> {
+    const runtime = resolveConversationRuntime(input.options);
+    const toolDefinitions = await canonicalToolDefinitions(input.options.tools);
+    let document = parseCanonicalConversation(input.conversation);
+    if (document === undefined) {
+        document = newCanonicalConversation(runtime);
+        if (input.conversation !== undefined && input.conversation !== null) {
+            if (!isClaudeMessagesHistory(input.conversation)) {
+                throw new TypeError('Conversation is neither canonical nor registered Claude Messages history');
+            }
+            const history = input.conversation as ClaudePrompt;
+            const imported = await promptRecords({
+                prompt: history,
+                scope: `${runtime.conversation_id}:legacy`,
+                source: 'imported',
+                runtime,
+                tool_definitions: toolDefinitions,
+                provider: input.provider,
+                ...(sourceHistoryTurnNumber(history) === undefined
+                    ? {}
+                    : { source_history_turn_number: sourceHistoryTurnNumber(history) }),
+            });
+            const contextEntries = await Promise.all(
+                imported.turns.map(async (turn, index) => ({
+                    id: await entityId('context', `${runtime.conversation_id}:legacy`, index),
+                    type: 'source_turn' as const,
+                    turn_id: turn.id,
+                })),
+            );
+            document = appendConversationRecords(
+                document,
+                {
+                    turns: imported.turns,
+                    assets: imported.assets,
+                    tool_definitions: toolDefinitions,
+                    context_entries: contextEntries,
+                },
+                {
+                    expected_revision: document.revision,
+                    operation_id: await entityId('import', runtime.conversation_id, CLAUDE_MESSAGES_PROTOCOL),
+                    payload_fingerprint: await fingerprintJson(providerJsonValue(history)),
+                    recorded_at: runtime.recorded_at,
+                },
+            ).document;
+        }
+    } else if (
+        runtime.conversation_id !== document.id &&
+        input.options.conversation_runtime?.conversation_id !== undefined
+    ) {
+        throw new Error('conversation_runtime.conversation_id does not match the canonical document');
+    }
+
+    const target = { provider: input.provider, model: input.options.model };
+    const priorNativeMessageCount = compileClaudeMessagesConversation(document, target).conversation.messages.length;
+    const received = await promptRecords({
+        prompt: input.prompt,
+        scope: runtime.input_operation_id,
+        source: 'received',
+        runtime: { ...runtime, conversation_id: document.id },
+        tool_definitions: toolDefinitions,
+        provider: input.provider,
+    });
+    const contextEntries = await Promise.all(
+        received.turns.map(async (turn, index) => ({
+            id: await entityId('context', runtime.input_operation_id, index),
+            type: 'source_turn' as const,
+            turn_id: turn.id,
+        })),
+    );
+    const appended = await appendCanonicalPrompt(
+        document,
+        {
+            ...received,
+            context_entries: contextEntries,
+            item_mappings: received.mappings,
+        },
+        { ...runtime, conversation_id: document.id },
+        input.options.tools,
+        providerJsonValue(input.prompt),
+    );
+    const compiled = compileClaudeMessagesConversation(appended.document, target);
+    const acceptedResponse = acceptedCanonicalResponse(appended.document, runtime.response_operation_id);
+    const identities =
+        acceptedResponse === undefined
+            ? await canonicalResponseIdentities(runtime)
+            : { generation_id: acceptedResponse.generation.id, response_turn_id: acceptedResponse.turn.id };
+    return {
+        document: appended.document,
+        native_conversation: compiled.conversation,
+        runtime: { ...runtime, conversation_id: document.id },
+        generation_id: identities.generation_id,
+        response_turn_id: identities.response_turn_id,
+        tool_definitions: appended.tool_definitions,
+        provider: input.provider,
+        prior_native_message_count: priorNativeMessageCount,
+        ...(acceptedResponse === undefined ? {} : { accepted_response: acceptedResponse }),
+    };
+}
+
+export async function finalizeClaudePreparedRequest(
+    state: Omit<PreparedClaudeConversation, 'payload' | 'receipt' | 'diagnostics'>,
+    payload: MessageCreateParamsBase,
+): Promise<PreparedClaudeConversation> {
+    const compiled = compileClaudeMessagesConversation(state.document, {
+        provider: state.provider,
+        model: payload.model,
+    });
+    const receipt = await createRequestReceipt(
+        state.document,
+        state.runtime,
+        {
+            provider: state.provider,
+            protocol: CLAUDE_MESSAGES_PROTOCOL,
+            model: payload.model,
+            adapter_version: CLAUDE_MESSAGES_ADAPTER_VERSION,
+        },
+        providerJsonValue(payload),
+        compiled.mappings,
+        state.tool_definitions,
+    );
+    return { ...state, payload, receipt, diagnostics: [] };
+}
+
+function safeUsageNumber(value: unknown): number | undefined {
+    return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 ? value : undefined;
+}
+
+function safeSum(...values: number[]): number | undefined {
+    const total = values.reduce((sum, value) => sum + value, 0);
+    return Number.isSafeInteger(total) ? total : undefined;
+}
+
+function claudeUsage(native: AnthropicUsageLike | undefined): GenerationUsage | undefined {
+    if (native === undefined) return undefined;
+    const inputNew = safeUsageNumber(native.input_tokens);
+    const output = safeUsageNumber(native.output_tokens);
+    const cacheRead = safeUsageNumber(native.cache_read_input_tokens);
+    const cacheWrite = safeUsageNumber(native.cache_creation_input_tokens);
+    const input =
+        inputNew !== undefined && cacheRead !== undefined && cacheWrite !== undefined
+            ? safeSum(inputNew, cacheRead, cacheWrite)
+            : undefined;
+    const total = input !== undefined && output !== undefined ? safeSum(input, output) : undefined;
+    const basis = 'anthropic_messages_tokens';
+    return {
+        ...(input === undefined ? {} : { input_tokens: input }),
+        ...(output === undefined ? {} : { output_tokens: output }),
+        ...(total === undefined ? {} : { total_tokens: total }),
+        ...(cacheRead === undefined ? {} : { cache_read_tokens: cacheRead }),
+        ...(cacheWrite === undefined ? {} : { cache_write_tokens: cacheWrite }),
+        ...(inputNew === undefined ? {} : { input_new_tokens: inputNew }),
+        accounting_provenance: {
+            ...(input === undefined ? {} : { input_tokens: { method: 'derived' as const, accounting_basis: basis } }),
+            ...(output === undefined
+                ? {}
+                : { output_tokens: { method: 'reported' as const, accounting_basis: basis } }),
+            ...(total === undefined ? {} : { total_tokens: { method: 'derived' as const, accounting_basis: basis } }),
+            ...(cacheRead === undefined
+                ? {}
+                : { cache_read_tokens: { method: 'reported' as const, accounting_basis: basis } }),
+            ...(cacheWrite === undefined
+                ? {}
+                : { cache_write_tokens: { method: 'reported' as const, accounting_basis: basis } }),
+            ...(inputNew === undefined
+                ? {}
+                : { input_new_tokens: { method: 'reported' as const, accounting_basis: basis } }),
+        },
+        ...(input === undefined
+            ? {}
+            : { input_partition: { type: 'complete_disjoint', cache_write_bucket: 'included' } }),
+        reported_usage: [
+            {
+                source: 'provider',
+                protocol: CLAUDE_MESSAGES_PROTOCOL,
+                accounting_basis: basis,
+                payload: providerJsonValue(native),
+            },
+        ],
+    };
+}
+
+export async function decodeClaudeCanonicalResponse(
+    response: Message,
+    prepared: PreparedClaudeConversation,
+): Promise<DecodedConversationResponse> {
+    if (response.stop_reason === null) {
+        throw new Error('Claude Messages response ended without a terminal stop reason');
+    }
+    const completedAt = prepared.runtime.completed_at ?? new Date().toISOString();
+    const runtime = { ...prepared.runtime, recorded_at: completedAt };
+    const records = await assistantMessageRecords({
+        message: { role: 'assistant', content: providerJsonValue(response.content) as unknown as ContentBlockParam[] },
+        message_index: 0,
+        scope: prepared.runtime.response_operation_id,
+        source: 'received',
+        runtime,
+        tool_definitions: prepared.tool_definitions,
+        provider: prepared.provider,
+    });
+    const received = records.turns[0];
+    if (received?.kind !== 'agent') throw new Error('Claude Messages response did not decode to an agent turn');
+    const status =
+        response.stop_reason === 'max_tokens' || response.stop_reason === 'model_context_window_exceeded'
+            ? 'interrupted'
+            : 'completed';
+    const turn: ConversationTurn = {
+        ...received,
+        id: prepared.response_turn_id,
+        status,
+        timestamps: {
+            recorded_at: completedAt,
+            ...(prepared.runtime.started_at === undefined ? {} : { started_at: prepared.runtime.started_at }),
+            completed_at: completedAt,
+        },
+        provenance: { type: 'generated' },
+        generation_id: prepared.generation_id,
+        blocks: received.blocks.map((block) =>
+            block.type !== 'native_replay'
+                ? block
+                : {
+                      ...block,
+                      dependencies: {
+                          ...block.dependencies,
+                          turn_ids: [prepared.response_turn_id],
+                          request_ids: [prepared.receipt.request_id],
+                      },
+                  },
+        ),
+    };
+    const generation: ExecutedGeneration = await createExecutedGeneration({
+        id: prepared.generation_id,
+        runtime: prepared.runtime,
+        receipt: prepared.receipt,
+        provider: prepared.provider,
+        protocol: CLAUDE_MESSAGES_PROTOCOL,
+        adapter_version: CLAUDE_MESSAGES_ADAPTER_VERSION,
+        requested_model: prepared.payload.model,
+        resolved_model: response.model,
+        provider_response_id: response.id,
+        finish_reason: response.stop_reason,
+        usage: claudeUsage(response.usage),
+    });
+    return {
+        turns: [turn],
+        generation,
+        assets: records.assets.map((asset) => ({
+            ...asset,
+            provenance: { type: 'generated', generation_id: generation.id, source_turn_id: turn.id },
+        })),
+        diagnostics: [],
+        payload_fingerprint: await fingerprintJson(providerJsonValue(response)),
+    };
+}
+
+export function appendClaudeCanonicalResponse(
+    prepared: PreparedClaudeConversation,
+    decoded: DecodedConversationResponse,
+): ConversationDocument {
+    return appendDecodedConversationResponse(prepared, decoded, {
+        operation_id: prepared.runtime.response_operation_id,
+        recorded_at: decoded.generation.timestamps.recorded_at,
+    }).document;
+}
+
+/** Read-only compatibility projection for versioned legacy API responses. */
+export function exportLegacyClaudeMessagesConversation(document: ConversationDocument): ClaudePrompt {
+    return compileClaudeMessagesConversation(parseConversationDocument(document)).conversation;
+}

--- a/drivers/src/shared/claude-messages.ts
+++ b/drivers/src/shared/claude-messages.ts
@@ -67,6 +67,15 @@ import {
     truncateLargeTextInConversation,
 } from '@llumiverse/core';
 import { asyncMap } from '@llumiverse/core/async';
+import { canonicalConversationTurnNumber } from '../conversation/canonical-runtime.js';
+import {
+    appendClaudeCanonicalResponse,
+    type CanonicalClaudeToolResultBlockParam,
+    decodeClaudeCanonicalResponse,
+    finalizeClaudePreparedRequest,
+    type PreparedClaudeConversation,
+    prepareClaudeCanonicalState,
+} from './claude-messages-conversation-adapter.js';
 import { claudeFinishReason, logClaudeTruncation } from './claude-stop-reason.js';
 import { resolveClaudeThinking } from './claude-thinking.js';
 import { truncateBinaryForDebug } from './debug-prompt.js';
@@ -411,7 +420,10 @@ export async function formatClaudePrompt(
                         type: 'tool_result',
                         tool_use_id: segment.tool_use_id,
                         content: contentBlocks,
-                    } satisfies ToolResultBlockParam,
+                        ...(segment.tool_result_status === undefined
+                            ? {}
+                            : { _llumiverse_tool_result_status: segment.tool_result_status }),
+                    } satisfies CanonicalClaudeToolResultBlockParam,
                 ],
             });
         } else {
@@ -707,8 +719,16 @@ export function convertClaudeToolBlocksToText(messages: MessageParam[]): Message
 // ============================================================================
 
 function stripClaudeCacheControlFromBlock<T extends ContentBlockParam>(block: T): T {
-    if (typeof block === 'object' && block !== null && 'cache_control' in block) {
-        const { cache_control: _cc, ...rest } = block as T & { cache_control: unknown };
+    if (
+        typeof block === 'object' &&
+        block !== null &&
+        ('cache_control' in block || '_llumiverse_tool_result_status' in block)
+    ) {
+        const {
+            cache_control: _cc,
+            _llumiverse_tool_result_status: _status,
+            ...rest
+        } = block as T & { cache_control?: unknown; _llumiverse_tool_result_status?: unknown };
         return rest as T;
     }
     return block;
@@ -987,19 +1007,14 @@ export function buildClaudeStreamingConversation(
     return processed as ClaudePrompt;
 }
 
-function finalizeClaudeConversation(
+function projectClaudeConversation(
     conversation: ClaudePrompt,
-    result: Message,
     options: ExecutionOptions,
+    currentTurn: number,
 ): ClaudePrompt {
-    let completedConversation = updateClaudeConversation(conversation, createPromptFromResponse(result));
-    completedConversation = incrementConversationTurn(completedConversation) as ClaudePrompt;
-    completedConversation = pruneClaudeThinking(completedConversation);
-    const currentTurn = getConversationMeta(completedConversation).turnNumber;
-    const activeTurnStart = findClaudeActiveTurnStart(completedConversation);
-    const protectedMessages = new Set(
-        activeTurnStart >= 0 ? completedConversation.messages.slice(activeTurnStart) : [],
-    );
+    const prunedConversation = pruneClaudeThinking(conversation);
+    const activeTurnStart = findClaudeActiveTurnStart(prunedConversation);
+    const protectedMessages = new Set(activeTurnStart >= 0 ? prunedConversation.messages.slice(activeTurnStart) : []);
     const preserveSubtree = (value: unknown): boolean => {
         if (!value || typeof value !== 'object') return false;
         if (protectedMessages.has(value as MessageParam)) return true;
@@ -1014,7 +1029,7 @@ function finalizeClaudeConversation(
         textMaxTokens: isClaudePromptCacheEnabled(options) ? undefined : options.stripTextMaxTokens,
         preserveSubtree,
     };
-    let processedConversation = stripBase64ImagesFromConversation(completedConversation, stripOpts);
+    let processedConversation = stripBase64ImagesFromConversation(prunedConversation, stripOpts);
     processedConversation = truncateLargeTextInConversation(processedConversation, stripOpts);
     processedConversation = stripHeartbeatsFromConversation(processedConversation, {
         keepForTurns: options.stripHeartbeatsAfterTurns ?? 1,
@@ -1078,6 +1093,80 @@ function findClaudeActiveTurnStart(conversation: ClaudePrompt): number {
 // Execution helpers (standalone, take a client parameter)
 // ============================================================================
 
+function prepareCanonicalClaudeProjection(
+    prepared: Omit<PreparedClaudeConversation, 'payload' | 'receipt' | 'diagnostics'>,
+    options: ExecutionOptions,
+): ClaudePrompt {
+    return projectClaudeConversation(
+        prepared.native_conversation,
+        options,
+        canonicalConversationTurnNumber(prepared.document),
+    );
+}
+
+function canonicalClaudeUsage(
+    prepared: Omit<PreparedClaudeConversation, 'payload' | 'receipt' | 'diagnostics'>,
+): ExecutionTokenUsage | undefined {
+    const usage = prepared.accepted_response?.generation.usage;
+    if (usage === undefined) return undefined;
+    return {
+        ...(usage.input_tokens === undefined ? {} : { prompt: usage.input_tokens }),
+        ...(usage.output_tokens === undefined ? {} : { result: usage.output_tokens }),
+        ...(usage.total_tokens === undefined ? {} : { total: usage.total_tokens }),
+        ...(usage.cache_read_tokens === undefined ? {} : { prompt_cached: usage.cache_read_tokens }),
+        ...(usage.cache_write_tokens === undefined ? {} : { prompt_cache_write: usage.cache_write_tokens }),
+        ...(usage.input_new_tokens === undefined ? {} : { prompt_new: usage.input_new_tokens }),
+    };
+}
+
+function recoverClaudeCompletion(
+    prepared: Omit<PreparedClaudeConversation, 'payload' | 'receipt' | 'diagnostics'>,
+    options: ExecutionOptions,
+    includeThoughts: boolean,
+): Completion {
+    const accepted = prepared.accepted_response;
+    if (accepted === undefined) throw new Error('No accepted Claude Messages response is available');
+    if (options.include_original_response) {
+        throw new Error('An idempotently recovered Claude Messages response cannot reconstruct original_response');
+    }
+    const result = accepted.turn.blocks.flatMap((block): CompletionResult[] => {
+        if (block.type === 'text') return [{ type: 'text', value: block.text }];
+        if (block.type === 'json') return [{ type: 'json', value: block.value }];
+        if (block.type === 'reasoning' && includeThoughts) return [{ type: 'thoughts', value: block.text }];
+        return [];
+    });
+    const toolUse = accepted.turn.blocks.flatMap((block): ToolUse[] =>
+        block.type === 'tool_call'
+            ? [
+                  {
+                      id: block.call_id,
+                      tool_name: block.tool_name,
+                      tool_input: block.arguments.type === 'json' ? (block.arguments.value as JSONObject) : {},
+                  },
+              ]
+            : [],
+    );
+    return {
+        result: result.length > 0 ? result : [{ type: 'text', value: '' }],
+        ...(toolUse.length === 0 ? {} : { tool_use: toolUse }),
+        token_usage: canonicalClaudeUsage(prepared),
+        finish_reason: toolUse.length > 0 ? 'tool_use' : claudeFinishReason(accepted.generation.finish_reason),
+        conversation: prepared.document,
+    };
+}
+
+function recoveredClaudeStream(completion: Completion): DriverCompletionStream {
+    const stream = (async function* (): AsyncIterable<CompletionChunkObject> {
+        yield {
+            result: completion.result,
+            tool_use: completion.tool_use,
+            token_usage: completion.token_usage,
+            finish_reason: completion.finish_reason,
+        };
+    })();
+    return Object.assign(stream, { finalizeConversation: () => completion.conversation });
+}
+
 /**
  * Execute a non-streaming Claude completion.
  * Works with the Anthropic, Vertex AI, and Bedrock Mantle SDK clients.
@@ -1091,10 +1180,22 @@ export async function executeClaudeCompletion(
     transportOptions?: Pick<RequestOptions, 'signal' | 'timeout'>,
 ): Promise<Completion> {
     const model_options = options.model_options as ClaudeBaseOptions | undefined;
-
-    const conversation = updateClaudeConversation(options.conversation as ClaudePrompt | undefined, prompt);
-
+    const canonicalState = await prepareClaudeCanonicalState({
+        conversation: options.conversation,
+        prompt,
+        options,
+        provider,
+    });
+    const includeThoughts = model_options?.include_thoughts ?? false;
+    if (canonicalState.accepted_response !== undefined) {
+        return recoverClaudeCompletion(canonicalState, options, includeThoughts);
+    }
+    const conversation = prepareCanonicalClaudeProjection(canonicalState, options);
     const { payload, requestOptions } = getClaudePayload(options, conversation, provider, 'execute');
+    const prepared = await finalizeClaudePreparedRequest(
+        { ...canonicalState, native_conversation: conversation },
+        payload,
+    );
 
     const responseStream = await streamClaudeMessages(
         client,
@@ -1104,11 +1205,10 @@ export async function executeClaudeCompletion(
     const result = await responseStream.finalMessage();
     logClaudeTruncation(logger, result.stop_reason, { provider, model: options.model });
 
-    const includeThoughts = model_options?.include_thoughts ?? false;
     const completionResults = collectClaudeResults(result.content, includeThoughts);
     const tool_use = collectClaudeTools(result.content);
-
-    const processedConversation = finalizeClaudeConversation(conversation, result, options);
+    const decoded = await decodeClaudeCanonicalResponse(result, prepared);
+    const processedConversation = appendClaudeCanonicalResponse(prepared, decoded);
 
     return {
         result: completionResults.length > 0 ? completionResults : [{ type: 'text', value: '' }],
@@ -1132,9 +1232,22 @@ export async function streamClaudeCompletion(
     transportOptions?: Pick<RequestOptions, 'signal' | 'timeout'>,
 ): Promise<DriverCompletionStream> {
     const model_options = options.model_options as ClaudeBaseOptions | undefined;
-    const conversation = updateClaudeConversation(options.conversation as ClaudePrompt | undefined, prompt);
-
+    const canonicalState = await prepareClaudeCanonicalState({
+        conversation: options.conversation,
+        prompt,
+        options,
+        provider,
+    });
+    const includeThoughts = model_options?.include_thoughts ?? false;
+    if (canonicalState.accepted_response !== undefined) {
+        return recoveredClaudeStream(recoverClaudeCompletion(canonicalState, options, includeThoughts));
+    }
+    const conversation = prepareCanonicalClaudeProjection(canonicalState, options);
     const { payload, requestOptions } = getClaudePayload(options, conversation, provider, 'stream');
+    const prepared = await finalizeClaudePreparedRequest(
+        { ...canonicalState, native_conversation: conversation },
+        payload,
+    );
     const streamingPayload: MessageStreamParams = { ...payload, stream: true };
 
     const response_stream = await streamClaudeMessages(
@@ -1205,7 +1318,7 @@ export async function streamClaudeCompletion(
                         }
                         break;
                     case 'thinking_delta':
-                        if (model_options?.include_thoughts) {
+                        if (includeThoughts) {
                             return {
                                 result: streamEvent.delta.thinking
                                     ? [{ type: 'thoughts', value: streamEvent.delta.thinking }]
@@ -1232,7 +1345,8 @@ export async function streamClaudeCompletion(
         [Symbol.asyncIterator]: () => stream[Symbol.asyncIterator](),
         finalizeConversation: async () => {
             const finalMessage = await response_stream.finalMessage();
-            return finalizeClaudeConversation(conversation, finalMessage, options);
+            const decoded = await decodeClaudeCanonicalResponse(finalMessage, prepared);
+            return appendClaudeCanonicalResponse(prepared, decoded);
         },
     };
 }

--- a/drivers/src/shared/claude-reasoning-replay.test.ts
+++ b/drivers/src/shared/claude-reasoning-replay.test.ts
@@ -1,11 +1,15 @@
 import type { Message, RawMessageStreamEvent } from '@anthropic-ai/sdk/resources/messages.js';
+import { type ConversationDocument, parseConversationDocument } from '@llumiverse/conversation';
+import { type ExecutionOptions, PromptRole } from '@llumiverse/core';
 import { describe, expect, it, vi } from 'vitest';
+import { AnthropicDriver } from '../anthropic/index.js';
 import {
     type ClaudePrompt,
     executeClaudeCompletion,
     pruneClaudeThinking,
     streamClaudeCompletion,
 } from './claude-messages.js';
+import { exportLegacyClaudeMessagesConversation } from './claude-messages-conversation-adapter.js';
 import { claudeFinishReason, logClaudeTruncation } from './claude-stop-reason.js';
 
 function sdkStream(events: RawMessageStreamEvent[], finalMessage: Message) {
@@ -40,6 +44,42 @@ function clientFor(message: Message, events: RawMessageStreamEvent[] = []) {
 }
 
 const prompt: ClaudePrompt = { messages: [{ role: 'user', content: 'question' }] };
+const expectedFinalToolContent = [
+    { type: 'thinking', thinking: 'plan', signature: 'signed-thinking' },
+    { type: 'redacted_thinking', data: 'encrypted-redaction' },
+    { type: 'text', text: 'checking' },
+    { type: 'tool_use', id: 'call-1', name: 'lookup', input: { city: 'Paris' } },
+];
+
+function legacyConversation(value: unknown): ClaudePrompt {
+    return exportLegacyClaudeMessagesConversation(value as ConversationDocument);
+}
+
+function latestGeneratedText(value: unknown): string | undefined {
+    const document = parseConversationDocument(value);
+    for (let index = document.turns.length - 1; index >= 0; index -= 1) {
+        const turn = document.turns[index];
+        if (turn.kind !== 'agent' || turn.provenance.type !== 'generated') continue;
+        return turn.blocks.find((block) => block.type === 'text')?.text;
+    }
+    return undefined;
+}
+
+function canonicalOptions(attempt: string, recordedAt: string, conversation?: unknown): ExecutionOptions {
+    return {
+        model: 'claude-sonnet-4-6',
+        ...(conversation === undefined ? {} : { conversation }),
+        conversation_runtime: {
+            conversation_id: 'conversation:claude-structured',
+            request_id: 'request:claude-structured',
+            attempt_id: attempt,
+            input_operation_id: 'input:claude-structured',
+            response_operation_id: 'response:claude-structured',
+            recorded_at: recordedAt,
+            started_at: recordedAt,
+        },
+    };
+}
 
 describe('Claude native reasoning replay', () => {
     it('normalizes both Claude truncation stop reasons to length', () => {
@@ -85,8 +125,8 @@ describe('Claude native reasoning replay', () => {
         });
 
         expect(completion.result).toEqual([{ type: 'text', value: 'checking' }]);
-        expect(completion.conversation).toMatchObject({
-            messages: expect.arrayContaining([{ role: 'assistant', content: finalToolMessage.content }]),
+        expect(legacyConversation(completion.conversation)).toMatchObject({
+            messages: expect.arrayContaining([{ role: 'assistant', content: expectedFinalToolContent }]),
         });
     });
 
@@ -104,8 +144,16 @@ describe('Claude native reasoning replay', () => {
         });
 
         expect(completion.result).toEqual([{ type: 'text', value: 'final answer' }]);
-        expect(completion.conversation).toMatchObject({
-            messages: expect.arrayContaining([{ role: 'assistant', content: finalMessage.content }]),
+        expect(legacyConversation(completion.conversation)).toMatchObject({
+            messages: expect.arrayContaining([
+                {
+                    role: 'assistant',
+                    content: [
+                        { type: 'thinking', thinking: 'final plan', signature: 'final-signature' },
+                        { type: 'text', text: 'final answer' },
+                    ],
+                },
+            ]),
         });
     });
 
@@ -122,8 +170,8 @@ describe('Claude native reasoning replay', () => {
         const conversation = await stream.finalizeConversation?.();
 
         expect(results).toEqual([{ type: 'text', value: 'checking' }]);
-        expect(conversation).toMatchObject({
-            messages: expect.arrayContaining([{ role: 'assistant', content: finalToolMessage.content }]),
+        expect(legacyConversation(conversation)).toMatchObject({
+            messages: expect.arrayContaining([{ role: 'assistant', content: expectedFinalToolContent }]),
         });
 
         const nextMessage = {
@@ -149,10 +197,92 @@ describe('Claude native reasoning replay', () => {
 
         expect(nextStream).toHaveBeenCalledWith(
             expect.objectContaining({
-                messages: expect.arrayContaining([{ role: 'assistant', content: finalToolMessage.content }]),
+                messages: expect.arrayContaining([{ role: 'assistant', content: expectedFinalToolContent }]),
             }),
             undefined,
         );
+    });
+
+    it('validates structured output through the full Claude driver and retries without another provider call', async () => {
+        const rawText = '{ "answer" : "Tokyo" }';
+        const finalMessage = {
+            id: 'msg-structured',
+            type: 'message',
+            role: 'assistant',
+            model: 'claude-sonnet-4-6',
+            content: [{ type: 'text', text: rawText }],
+            stop_reason: 'end_turn',
+            stop_sequence: null,
+            usage: { input_tokens: 2, output_tokens: 3 },
+        } as unknown as Message;
+        const providerCall = vi.fn(() => sdkStream([], finalMessage));
+        const driver = new AnthropicDriver({ apiKey: 'test' });
+        driver.client = { messages: { stream: providerCall } } as never;
+        const resultSchema: NonNullable<ExecutionOptions['result_schema']> = {
+            type: 'object',
+            properties: { answer: { type: 'string' } },
+            required: ['answer'],
+            additionalProperties: false,
+        };
+        const segments = [{ role: PromptRole.user, content: 'Return the city.' }];
+
+        const first = await driver.execute(segments, {
+            ...canonicalOptions('attempt:first', '2026-09-11T00:00:00.000Z'),
+            result_schema: resultSchema,
+        });
+        expect(first.result).toEqual([{ type: 'json', value: { answer: 'Tokyo' } }]);
+        expect(latestGeneratedText(first.conversation)).toBe(rawText);
+
+        const retried = await driver.execute(segments, {
+            ...canonicalOptions('attempt:retry', '2026-09-11T00:01:00.000Z', first.conversation),
+            result_schema: resultSchema,
+        });
+        expect(retried.result).toEqual(first.result);
+        expect(retried.conversation).toEqual(first.conversation);
+        expect(providerCall).toHaveBeenCalledOnce();
+    });
+
+    it('validates streamed structured output through the full Claude driver while retaining source text', async () => {
+        const rawText = '{"answer":"Tokyo"}';
+        const finalMessage = {
+            id: 'msg-stream-structured',
+            type: 'message',
+            role: 'assistant',
+            model: 'claude-sonnet-4-6',
+            content: [{ type: 'text', text: rawText }],
+            stop_reason: 'end_turn',
+            stop_sequence: null,
+            usage: { input_tokens: 2, output_tokens: 3 },
+        } as unknown as Message;
+        const events = [
+            {
+                type: 'message_start',
+                message: { ...finalMessage, content: [], stop_reason: null },
+            },
+            { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: rawText } },
+            {
+                type: 'message_delta',
+                delta: { stop_reason: 'end_turn', stop_sequence: null },
+                usage: { output_tokens: 3 },
+            },
+        ] as RawMessageStreamEvent[];
+        const driver = new AnthropicDriver({ apiKey: 'test' });
+        driver.client = { messages: { stream: () => sdkStream(events, finalMessage) } } as never;
+        const stream = await driver.stream([{ role: PromptRole.user, content: 'Return the city.' }], {
+            ...canonicalOptions('attempt:stream', '2026-09-11T00:00:00.000Z'),
+            result_schema: {
+                type: 'object',
+                properties: { answer: { type: 'string' } },
+                required: ['answer'],
+                additionalProperties: false,
+            },
+        });
+
+        for await (const _chunk of stream) {
+            // Consume the public stream so core finalization and schema validation run.
+        }
+        expect(stream.completion?.result).toEqual([{ type: 'json', value: { answer: 'Tokyo' } }]);
+        expect(latestGeneratedText(stream.completion?.conversation)).toBe(rawText);
     });
 
     it('prunes only completed historical reasoning and keeps an active tool chain intact', () => {

--- a/drivers/src/vertexai/index.ts
+++ b/drivers/src/vertexai/index.ts
@@ -111,6 +111,10 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
     static readonly PROVIDER = Providers.vertexai;
     provider = VertexAIDriver.PROVIDER;
 
+    protected supportsCanonicalConversation(options: ExecutionOptions): boolean {
+        return getModelDefinition(options.model).canonical_conversation_supported === true;
+    }
+
     aiplatform: v1beta1.ModelServiceClient | undefined;
     anthropicClient: AnthropicVertex | undefined;
     fetchClient: FetchClient | undefined;

--- a/drivers/src/vertexai/models.ts
+++ b/drivers/src/vertexai/models.ts
@@ -21,6 +21,7 @@ export function trimModelName(model: string): string {
 
 export interface ModelDefinition<PromptT = VertexAIPrompt> {
     model: AIModel;
+    canonical_conversation_supported?: boolean;
     versions?: string[]; // the versions of the model that are available. ex: ['001', '002']
     createPrompt(driver: VertexAIDriver, segments: PromptSegment[], options: ExecutionOptions): Promise<PromptT>;
     requestTextCompletion(

--- a/drivers/src/vertexai/models/claude.ts
+++ b/drivers/src/vertexai/models/claude.ts
@@ -49,6 +49,7 @@ function resolveVertexAIModelPath(options: ExecutionOptions): {
 
 export class ClaudeModelDefinition implements ModelDefinition<ClaudePrompt> {
     model: AIModel;
+    readonly canonical_conversation_supported = true;
 
     constructor(modelId: string) {
         this.model = {

--- a/drivers/src/vertexai/models/openai_chat_completions.ts
+++ b/drivers/src/vertexai/models/openai_chat_completions.ts
@@ -37,6 +37,7 @@ export class OpenAIChatCompletionsModelDefinition
     implements ModelDefinition<OpenAIChatCompletionsPrompt>
 {
     model: AIModel;
+    readonly canonical_conversation_supported = true;
     private readonly vertexOptions: VertexOpenAIChatCompletionsOptions;
 
     constructor(options: VertexOpenAIChatCompletionsOptions) {

--- a/drivers/tsconfig.json
+++ b/drivers/tsconfig.json
@@ -28,6 +28,7 @@
     "exclude": ["node_modules", "**/*.test.ts", "lib", "test"],
     "references": [
         { "path": "../common" },
+        { "path": "../conversation" },
         { "path": "../core" }
     ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
 
   common:
     dependencies:
+      '@llumiverse/conversation':
+        specifier: workspace:*
+        version: link:../conversation
       zod:
         specifier: ^4.5.4
         version: 4.5.4
@@ -187,6 +190,9 @@ importers:
       '@llumiverse/common':
         specifier: workspace:*
         version: link:../common
+      '@llumiverse/conversation':
+        specifier: workspace:*
+        version: link:../conversation
       '@types/node':
         specifier: ^24.13.3
         version: 24.13.3
@@ -278,6 +284,9 @@ importers:
       '@llumiverse/common':
         specifier: workspace:*
         version: link:../common
+      '@llumiverse/conversation':
+        specifier: workspace:*
+        version: link:../conversation
       '@llumiverse/core':
         specifier: workspace:*
         version: link:../core

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,6 +157,31 @@ importers:
         specifier: ^4.1.11
         version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.0.16(@types/node@24.13.3))
 
+  conversation:
+    dependencies:
+      zod:
+        specifier: ^4.5.4
+        version: 4.5.4
+    devDependencies:
+      '@types/node':
+        specifier: ^24.13.3
+        version: 24.13.3
+      ajv:
+        specifier: ^8.20.0
+        version: 8.20.0
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.20.0)
+      rimraf:
+        specifier: ^6.1.3
+        version: 6.1.3
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      vitest:
+        specifier: ^4.1.11
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.0.16(@types/node@24.13.3))
+
   core:
     dependencies:
       '@llumiverse/common':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   # pnpm 12 workspace discovery requires patterns without a leading "./".
   - common
+  - conversation
   - core
   - drivers
   - examples


### PR DESCRIPTION
Introduce the experimental `@llumiverse/conversation` package and adopt it in OpenAI Chat Completions, OpenAI Responses, and Claude Messages execution. The canonical document owns turns, assets, tool calls/results, generations, usage, context selection, and ingestion receipts through strict Zod schemas and inferred TypeScript types.

The adapters import native history, project canonical context into native requests, ingest sync/stream responses, and recover accepted retries without another provider call. Preserve exact tool arguments, reasoning/replay payloads, image bytes/details, execution status, usage accounting, and imported retention age. Unsupported canonical routes, visible media, and incompatible protected replay fail explicitly. Read-only legacy projections remain available at compatibility boundaries.

The package is private and unpublished at schema version 0, exact revision `2026-09-11.ingestion.1`. This is an adoption increment, not full migration: remaining adapters, runtime type retirement, segmented storage, editing/compaction execution, delivery contracts, and publication are still pending.

Validation (commands run in each named package):

| Package | Commands | Unit results |
| --- | --- | --- |
| conversation | `pnpm lint`, `pnpm build`, `pnpm typecheck:test`, `pnpm test`, `pnpm verify:exports` | 69 passed |
| common | `pnpm lint`, `pnpm build`, `pnpm typecheck:test`, `pnpm test` | 246 passed |
| core | `pnpm lint`, `pnpm build`, `pnpm typecheck:test`, `pnpm test` | 190 passed |
| drivers | `pnpm lint`, `pnpm build`, `pnpm typecheck:test`, `pnpm test` | 726 passed, 19 existing skips |

`pnpm format:check`, `git diff --check`, export verification, and local package-content inspection passed. Coverage includes strict JSON/schema parity, persistence, conflicting retries, fresh retry timestamps, structured-output validation through full drivers, stream truncation, request-only trimming, cross-protocol media, and protected replay rejection. No npm publication was performed.

The recursive JSON schema registers its own named instance so emitted JSON Schema references stay stable and never introduce an anonymous definition. The package remains private; no npm publication was performed.

The Responses adapter also covers sync/stream ingestion, persisted tool continuation, incomplete response continuation, native reasoning/media preservation, and accepted retry parity for usage and service tier. Foundry and Mantle admit canonical histories through their parent routes. Private tool-result evidence survives protocol conversion without being sent to providers. Independent conformance tests reject stale replay after semantic changes or incompatible provider/model routing.

The latest Responses increment passed driver lint, test typecheck, all 726 driver tests (19 existing skips), and dependent workspace builds. Exact-head CI passed on `7cde7d587e331e941886abd520a6fb2ddb2c02c2`: [build and test run 34677370760](https://github.com/vertesia/llumiverse/actions/runs/34677370760), lint, and security checks are green.
